### PR TITLE
fix: npm publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    environment: production
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow configuration. The change sets the deployment environment to "production" in the `publish-mcp.yml` workflow.