### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -177,11 +177,12 @@ async function startHTTPServer(factoryWithSSE: (sseClients: Set<Response>, broad
   // Upload encrypted blob
   app.post('/share', shareLimiter, express.raw({ type: 'application/octet-stream', limit: '10mb' }), (req: Request, res: Response) => {
     const id = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
-    const body = req.body as Buffer | undefined;
-    if (!body || body.length === 0) {
+    const rawBody = req.body as unknown;
+    if (!Buffer.isBuffer(rawBody) || rawBody.length === 0) {
       res.status(400).json({ error: 'Empty body. Send as application/octet-stream.' });
       return;
     }
+    const body = rawBody as Buffer;
     if (body.length > MAX_SHARE_SIZE) {
       res.status(413).json({ error: 'Payload too large' });
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/davidszakacs/excalimate/security/code-scanning/4](https://github.com/davidszakacs/excalimate/security/code-scanning/4)

General approach: When dealing with user-controlled data that you expect to be a `Buffer`, add an explicit runtime type check before using it, instead of relying solely on middleware and TypeScript casts. Reject the request if the body is missing or not of the expected type.

Best concrete fix here: In the `/share` POST handler, replace the unsafe cast `const body = req.body as Buffer | undefined;` with a variable of type `unknown` and then verify that it is a `Buffer` using `Buffer.isBuffer`. If it is not a `Buffer`, respond with HTTP 400 and do not proceed. Once the check passes, you can safely treat `body` as a `Buffer`. This avoids type confusion on `body.length` and later uses, and satisfies CodeQL by introducing a runtime type check on the untrusted request data.

Specific changes in `mcp-server/src/index.ts`:

- In the `/share` route handler (around lines 178–196), change:
  - `const body = req.body as Buffer | undefined;`
  - To a pattern like:
    - `const rawBody = req.body as unknown;`
    - Check `if (!Buffer.isBuffer(rawBody) || rawBody.length === 0) { ... }`
    - Then assign `const body = rawBody;` typed as `Buffer` (TypeScript will infer inside the `else` branch).
- Keep the existing size checks and storage logic unchanged, but operate on the now-validated `body`.

No new methods or imports are needed: `Buffer` is a global in Node.js, and `Buffer.isBuffer` is standard.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
