### PR TITLE
Potential fix for code scanning alert no. 3: Permissive CORS configuration

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -19,6 +19,42 @@ import type { Request, Response } from 'express';
 import { FileCheckpointStore } from './checkpoint-store.js';
 import { createServer, getSharedState } from './server.js';
 
+function getCorsOrigin(): Parameters<typeof cors>[0]['origin'] {
+  const raw = process.env.CORS_ORIGIN;
+
+  if (!raw || !raw.trim()) {
+    // No CORS origin configured: disable CORS by default
+    return false;
+  }
+
+  const origins = raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+
+  if (origins.length === 0) {
+    return false;
+  }
+
+  if (origins.length === 1) {
+    return origins[0];
+  }
+
+  // Multiple allowed origins: validate incoming origin against the list
+  return (origin, callback) => {
+    // Allow requests without an Origin header (e.g., same-origin or non-browser clients)
+    if (!origin) {
+      return callback(null, true);
+    }
+
+    if (origins.includes(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(new Error('Not allowed by CORS'), false);
+  };
+}
+
 async function startStdioServer(factory: () => McpServer): Promise<void> {
   await factory().connect(new StdioServerTransport());
 }
@@ -28,7 +64,7 @@ async function startHTTPServer(factoryWithSSE: (sseClients: Set<Response>, broad
   const app = express();
   app.use(helmet({ contentSecurityPolicy: false })); // Security headers
   app.use(cors({
-    origin: process.env.CORS_ORIGIN ?? '*',
+    origin: getCorsOrigin(),
   }));
 
   // Rate limiting


### PR DESCRIPTION
Potential fix for [https://github.com/davidszakacs/excalimate/security/code-scanning/3](https://github.com/davidszakacs/excalimate/security/code-scanning/3)

In general, to fix permissive CORS issues you must avoid `origin: true` or `origin: '*'` and avoid blindly trusting user- or externally-controlled values. Instead, configure CORS with a restrictive list of allowed origins (or `false` to disable CORS) and validate any dynamic origin against this whitelist. For environment-variable-based configuration, you should parse and validate the value rather than directly passing it through.

In this file, the single best fix without changing existing functionality too much is:
- Remove the `'*'` fallback so that CORS is not automatically open to the world.
- Parse `process.env.CORS_ORIGIN` as either:
  - A single allowed origin string, or
  - A comma-separated list of allowed origins, and validate request origins against that list.
- If no valid origin configuration is provided, default to `false` (CORS disabled) instead of `"*"`.

Concretely, in `startHTTPServer` in `mcp-server/src/index.ts`, we will:
1. Introduce a small helper function `getCorsOrigin()` above `startHTTPServer` that:
   - Reads `process.env.CORS_ORIGIN`.
   - If empty/whitespace, returns `false`.
   - Splits on commas, trims entries, and filters out empties.
   - If the resulting list is empty, returns `false`.
   - If it has one entry, returns that string (acceptable for `cors`).
   - If it has multiple entries, returns a function `(origin, callback)` that:
     - Allows requests with no `Origin` header (non-browser / same-origin).
     - Allows only if `origin` is in the allowed list; otherwise calls back with an error.
2. Replace the existing `app.use(cors({ origin: process.env.CORS_ORIGIN ?? '*' }))` with `app.use(cors({ origin: getCorsOrigin() }))`.

This preserves compatibility for deployments that currently use a single allowed origin via `CORS_ORIGIN`, while avoiding the insecure `'*'` default and adding support for multiple origins with validation. No new external dependencies are required; we reuse the existing `cors` import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
