### PR TITLE
feat: mcp install guide, image export and dark mode export

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -10,6 +10,7 @@ import { SequenceRevealPanel } from '../SequenceReveal/SequenceRevealPanel';
 import { WelcomeOverlay } from '../Onboarding/WelcomeOverlay';
 import { ToolbarHints } from '../Onboarding/ToolbarHints';
 import { ErrorBoundary } from '../common/ErrorBoundary';
+import { McpSetupGuide } from '../Pages/McpSetupGuide';
 import { useAnimationStore } from '../../stores/animationStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -56,6 +57,9 @@ export function App() {
   }, [theme]);
 
   const mantineColorScheme = theme === 'dark' ? 'dark' : 'light';
+
+  // Page navigation — render a full-screen page instead of the main app
+  const activePage = useUIStore((s) => s.activePage);
 
   // Use selectors to avoid over-subscription
   const mode = useUIStore((s) => s.mode);
@@ -114,6 +118,9 @@ export function App() {
       <ModalsProvider>
         <Notifications position="bottom-right" />
         <NavigationProgress />
+        {activePage === 'mcp-guide' ? (
+          <McpSetupGuide />
+        ) : (
         <div className="flex flex-col h-screen w-screen bg-surface text-text">
           {/* Top toolbar */}
           <Toolbar />
@@ -237,6 +244,7 @@ export function App() {
         </ErrorBoundary>
       </div>
     </div>
+        )}
         </ModalsProvider>
       </MantineProvider>
   );

--- a/src/components/Onboarding/ToolbarHints.tsx
+++ b/src/components/Onboarding/ToolbarHints.tsx
@@ -45,7 +45,7 @@ interface HintPos {
 export function ToolbarHints() {
   const mode = useUIStore((s) => s.mode);
   const drawToolActive = useUIStore((s) => s.drawToolActive);
-  const selectedElementIds = useUIStore((s) => s.selectedElementIds);
+  const hasSelection = useUIStore((s) => s.selectedElementIds.length > 0);
   const targets = useProjectStore((s) => s.targets);
   const tracks = useAnimationStore((s) => s.timeline.tracks);
   const [hints, setHints] = useState<HintPos[]>([]);
@@ -53,7 +53,6 @@ export function ToolbarHints() {
 
   const hasElements = targets.length > 1;
   const hasTracks = tracks.length > 0;
-  const hasSelection = selectedElementIds.length > 0;
   // Edit: hide when elements exist or drawing tool active
   // Animate: hide when tracks exist OR user selects an element (they're interacting)
   const visible = mode === 'edit'

--- a/src/components/Onboarding/WelcomeOverlay.tsx
+++ b/src/components/Onboarding/WelcomeOverlay.tsx
@@ -3,6 +3,7 @@ import {
   IconFolderOpen,
   IconFileImport,
   IconBroadcast,
+  IconServer,
 } from '@tabler/icons-react';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -82,6 +83,11 @@ export function WelcomeOverlay() {
               onClick={() => {
                 document.querySelector<HTMLButtonElement>('[data-hint="live"] button')?.click();
               }}
+            />
+            <ActionLink
+              icon={<IconServer size={16} />}
+              label="MCP Setup Guide"
+              onClick={() => useUIStore.getState().setActivePage('mcp-guide')}
             />
           </Stack>
         )}

--- a/src/components/Onboarding/WelcomeOverlay.tsx
+++ b/src/components/Onboarding/WelcomeOverlay.tsx
@@ -1,4 +1,4 @@
-import { Kbd, Stack, Text } from '@mantine/core';
+import { Stack, Text } from '@mantine/core';
 import {
   IconFolderOpen,
   IconFileImport,
@@ -17,14 +17,13 @@ import { useAnimationStore } from '../../stores/animationStore';
 export function WelcomeOverlay() {
   const mode = useUIStore((s) => s.mode);
   const drawToolActive = useUIStore((s) => s.drawToolActive);
-  const selectedElementIds = useUIStore((s) => s.selectedElementIds);
+  const hasSelection = useUIStore((s) => s.selectedElementIds.length > 0);
   const theme = useUIStore((s) => s.theme);
   const targets = useProjectStore((s) => s.targets);
   const tracks = useAnimationStore((s) => s.timeline.tracks);
 
   const hasElements = targets.length > 1;
   const hasTracks = tracks.length > 0;
-  const hasSelection = selectedElementIds.length > 0;
 
   // Hide when the user has content or is actively interacting
   if (mode === 'edit' && (hasElements || drawToolActive)) return null;
@@ -99,12 +98,10 @@ export function WelcomeOverlay() {
 function ActionLink({
   icon,
   label,
-  shortcut,
   onClick,
 }: {
   icon: React.ReactNode;
   label: string;
-  shortcut?: string;
   onClick: () => void;
 }) {
   return (
@@ -125,9 +122,6 @@ function ActionLink({
       >
         {label}
       </span>
-      {shortcut && (
-        <Kbd size="xs" style={{ opacity: 0.5 }}>{shortcut}</Kbd>
-      )}
     </button>
   );
 }

--- a/src/components/Pages/McpSetupGuide.tsx
+++ b/src/components/Pages/McpSetupGuide.tsx
@@ -1,0 +1,265 @@
+import { ActionIcon, CopyButton, Tooltip, Code, Text, Stack, Group } from '@mantine/core';
+import {
+  IconArrowLeft,
+  IconCopy,
+  IconCheck,
+  IconTerminal2,
+  IconBrandVscode,
+  IconMessageChatbot,
+  IconCursorText,
+  IconBroadcast,
+} from '@tabler/icons-react';
+import { useUIStore } from '../../stores/uiStore';
+
+const HANDWRITTEN = '"Virgil", "Segoe Print", "Comic Sans MS", cursive';
+
+function CodeBlock({ code, label }: { code: string; label?: string }) {
+  return (
+    <div
+      className="relative rounded-lg overflow-hidden"
+      style={{ border: '1px solid var(--color-border)' }}
+    >
+      {label && (
+        <div
+          className="px-3 py-1.5 text-[11px] uppercase tracking-wider font-semibold"
+          style={{ background: 'var(--color-surface-alt)', color: 'var(--color-text-muted)' }}
+        >
+          {label}
+        </div>
+      )}
+      <div className="relative">
+        <Code
+          block
+          className="text-sm"
+          style={{ background: 'var(--color-surface)', borderRadius: 0 }}
+        >
+          {code}
+        </Code>
+        <div className="absolute top-2 right-2">
+        <CopyButton value={code}>
+          {({ copied, copy }) => (
+            <Tooltip label={copied ? 'Copied' : 'Copy'}>
+              <ActionIcon
+                variant="subtle"
+                color={copied ? 'green' : 'gray'}
+                size="sm"
+                onClick={copy}
+              >
+                {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </CopyButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-3">
+      <Group gap="sm">
+        <span style={{ color: 'var(--color-text-muted)', opacity: 0.6 }}>{icon}</span>
+        <Text
+          size="lg"
+          fw={600}
+          style={{ fontFamily: HANDWRITTEN, color: 'var(--color-text-muted)', opacity: 0.7 }}
+        >
+          {title}
+        </Text>
+      </Group>
+      <div className="space-y-2 pl-1">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Paragraph({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      size="sm"
+      style={{ color: 'var(--color-text-muted)', opacity: 0.65, lineHeight: 1.7 }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+export function McpSetupGuide() {
+  const theme = useUIStore((s) => s.theme);
+
+  return (
+    <div className="h-screen w-screen overflow-y-auto" style={{ background: 'var(--color-surface)' }}>
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        {/* Back button */}
+        <button
+          type="button"
+          onClick={() => useUIStore.getState().setActivePage(null)}
+          className="flex items-center gap-2 mb-8 text-text-muted hover:text-text transition-colors cursor-pointer"
+          style={{ fontFamily: HANDWRITTEN, fontSize: '15px', opacity: 0.6 }}
+        >
+          <IconArrowLeft size={18} />
+          Back to Excalimate
+        </button>
+
+        {/* Header */}
+        <Stack gap="xs" align="center" mb="xl">
+          <img
+            src={theme === 'dark' ? '/excalimate_logo_dark.svg' : '/excalimate_logo.svg'}
+            alt="Excalimate"
+            className="h-10 opacity-80"
+          />
+          <Text
+            size="xl"
+            fw={600}
+            ta="center"
+            style={{ fontFamily: HANDWRITTEN, color: 'var(--color-text-muted)', opacity: 0.65 }}
+          >
+            MCP Server Setup Guide
+          </Text>
+          <Text
+            size="sm"
+            ta="center"
+            style={{ color: 'var(--color-text-muted)', opacity: 0.5, fontFamily: HANDWRITTEN }}
+          >
+            Connect your AI coding assistant to Excalimate
+          </Text>
+        </Stack>
+
+        <Stack gap="xl">
+          {/* Step 1: Start the server */}
+          <Section icon={<IconTerminal2 size={20} />} title="1. Start the MCP server">
+            <Paragraph>
+              Run the server with a single command. It starts in HTTP mode with live preview enabled by default.
+            </Paragraph>
+            <CodeBlock code="npx @excalimate/mcp-server" label="Terminal" />
+            <Paragraph>
+              The server will listen on <Code>http://localhost:3001/mcp</Code>. To use a custom port:
+            </Paragraph>
+            <CodeBlock code="npx @excalimate/mcp-server --port 4000" />
+          </Section>
+
+          {/* Step 2: Connect in Excalimate */}
+          <Section icon={<IconBroadcast size={20} />} title="2. Connect in Excalimate">
+            <Paragraph>
+              Click the broadcast icon in the toolbar (top-right) to connect to the running server.
+              Once connected, you'll see a live preview of everything the AI creates in real-time.
+            </Paragraph>
+            <Paragraph>
+              You can configure the server URL in <strong>File → Preferences</strong>.
+            </Paragraph>
+          </Section>
+
+          {/* Step 3: Configure your AI tool */}
+          <Section icon={<IconMessageChatbot size={20} />} title="3. Configure your AI tool">
+            <Paragraph>
+              Add the MCP server to your AI coding assistant. Pick your tool below:
+            </Paragraph>
+
+            {/* VS Code */}
+            <Group gap="xs" mt="sm">
+              <IconBrandVscode size={16} style={{ color: 'var(--color-text-muted)', opacity: 0.6 }} />
+              <Text size="sm" fw={600} style={{ color: 'var(--color-text-muted)', opacity: 0.7 }}>
+                VS Code (GitHub Copilot)
+              </Text>
+            </Group>
+            <Paragraph>
+              Create <Code>.vscode/mcp.json</Code> in your project:
+            </Paragraph>
+            <CodeBlock
+              label=".vscode/mcp.json"
+              code={`{
+  "servers": {
+    "excalimate": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}`}
+            />
+
+            {/* Cursor */}
+            <Group gap="xs" mt="sm">
+              <IconCursorText size={16} style={{ color: 'var(--color-text-muted)', opacity: 0.6 }} />
+              <Text size="sm" fw={600} style={{ color: 'var(--color-text-muted)', opacity: 0.7 }}>
+                Cursor
+              </Text>
+            </Group>
+            <Paragraph>
+              Go to <strong>Settings → MCP Servers</strong>, then add:
+            </Paragraph>
+            <CodeBlock
+              code={`Name: excalimate
+Type: http
+URL:  http://localhost:3001/mcp`}
+            />
+
+            {/* Claude Desktop */}
+            <Group gap="xs" mt="sm">
+              <IconMessageChatbot size={16} style={{ color: 'var(--color-text-muted)', opacity: 0.6 }} />
+              <Text size="sm" fw={600} style={{ color: 'var(--color-text-muted)', opacity: 0.7 }}>
+                Claude Desktop
+              </Text>
+            </Group>
+            <Paragraph>
+              Claude Desktop uses stdio mode (no live preview). Add to your <Code>claude_desktop_config.json</Code>:
+            </Paragraph>
+            <CodeBlock
+              label="claude_desktop_config.json"
+              code={`{
+  "mcpServers": {
+    "excalimate": {
+      "command": "npx",
+      "args": ["@excalimate/mcp-server", "--stdio"]
+    }
+  }
+}`}
+            />
+
+            {/* Claude Code */}
+            <Group gap="xs" mt="sm">
+              <IconTerminal2 size={16} style={{ color: 'var(--color-text-muted)', opacity: 0.6 }} />
+              <Text size="sm" fw={600} style={{ color: 'var(--color-text-muted)', opacity: 0.7 }}>
+                Claude Code (CLI)
+              </Text>
+            </Group>
+            <CodeBlock
+              code={`npx @excalimate/mcp-server &
+claude mcp add excalimate http://localhost:3001/mcp`}
+            />
+
+            {/* Windsurf */}
+            <Group gap="xs" mt="sm">
+              <IconTerminal2 size={16} style={{ color: 'var(--color-text-muted)', opacity: 0.6 }} />
+              <Text size="sm" fw={600} style={{ color: 'var(--color-text-muted)', opacity: 0.7 }}>
+                Windsurf
+              </Text>
+            </Group>
+            <CodeBlock
+              label="mcp_config.json"
+              code={`{
+  "mcpServers": {
+    "excalimate": {
+      "serverUrl": "http://localhost:3001/mcp"
+    }
+  }
+}`}
+            />
+          </Section>
+
+          {/* Done */}
+          <div className="text-center pt-4 pb-8">
+            <Text
+              size="md"
+              style={{ fontFamily: HANDWRITTEN, color: 'var(--color-text-muted)', opacity: 0.5 }}
+            >
+              That's it! Ask your AI to create diagrams and animations.
+            </Text>
+          </div>
+        </Stack>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar/ExportControls.tsx
+++ b/src/components/Toolbar/ExportControls.tsx
@@ -1,11 +1,18 @@
 import { useState, type ReactNode } from 'react';
-import { Button, Modal, Progress, Text, Group, Stack, Alert } from '@mantine/core';
+import { Button, Modal, Progress, Text, Group, Stack, Alert, Tabs, SegmentedControl } from '@mantine/core';
 import { nprogress } from '@mantine/nprogress';
 import { notifications } from '@mantine/notifications';
-import { IconMovie, IconVideo, IconPhoto, IconSvg, IconDownload, IconCheck, IconX } from '@tabler/icons-react';
+import {
+  IconMovie, IconVideo, IconPhoto, IconSvg, IconDownload, IconCheck, IconX,
+  IconCamera,
+} from '@tabler/icons-react';
 import { exportAnimation } from '../../services/ExportService';
 import type { ExportFormat, ExportQuality } from '../../services/ExportService';
 import { useAnimationStore } from '../../stores/animationStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+
+// ── Video export ─────────────────────────────────────────────────
 
 const FORMAT_INFO: Record<ExportFormat, { label: string; desc: string; icon: ReactNode }> = {
   mp4: { label: 'MP4', desc: 'H.264 — best quality, universal playback', icon: <IconMovie size={16} /> },
@@ -21,18 +28,198 @@ const QUALITY_INFO: Record<ExportQuality, { label: string; desc: string }> = {
   'very-high': { label: 'Very High', desc: '40 Mbps / 1280px' },
 };
 
+// ── Image export ─────────────────────────────────────────────────
+
+type ImageFormat = 'png' | 'jpg' | 'svg';
+type ImageSource = 'raw' | 'animated' | 'camera';
+type ImageScale = 1 | 2 | 3 | 4;
+
+const IMAGE_FORMATS: { value: ImageFormat; label: string }[] = [
+  { value: 'png', label: 'PNG' },
+  { value: 'jpg', label: 'JPG' },
+  { value: 'svg', label: 'SVG' },
+];
+
+const IMAGE_SCALES: { value: string; label: string }[] = [
+  { value: '1', label: '1x' },
+  { value: '2', label: '2x' },
+  { value: '3', label: '3x' },
+  { value: '4', label: '4x' },
+];
+
+// ── General settings ─────────────────────────────────────────────
+
+type ExportTheme = 'light' | 'dark';
+
+async function exportImage(
+  source: ImageSource,
+  imageFormat: ImageFormat,
+  scale: ImageScale,
+  exportTheme: ExportTheme,
+): Promise<void> {
+  const { getNonDeletedElements, exportToSvg } = await import('@excalidraw/excalidraw');
+  const { applyAnimationToElements } = await import('../../core/engine/renderUtils');
+  const { getCameraRect } = await import('../../services/export/cameraMath');
+
+  const project = useProjectStore.getState().project;
+  if (!project?.scene) throw new Error('No scene to export');
+
+  const rawElements = getNonDeletedElements(project.scene.elements);
+  const targets = useProjectStore.getState().targets;
+  const frameState = (await import('../../stores/playbackStore')).usePlaybackStore.getState().frameState;
+  const files = project.scene.files ?? {};
+
+  // Choose elements based on source
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let elements: any[] = [...rawElements];
+  if (source === 'animated' || source === 'camera') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    elements = applyAnimationToElements([...rawElements] as any, frameState, targets);
+  }
+
+  const isDark = exportTheme === 'dark';
+
+  // exportWithDarkMode applies a CSS invert filter to the ENTIRE SVG (including
+  // background). So we pass the LIGHT-mode colors and let the filter invert them:
+  // white background → dark, black strokes → white, etc.
+  const svg = await exportToSvg({
+    elements,
+    files,
+    appState: {
+      exportBackground: true,
+      exportWithDarkMode: isDark,
+      viewBackgroundColor: '#ffffff',
+    },
+    exportPadding: 20,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+  // Crop to camera frame if needed
+  if (source === 'camera') {
+    const cfg = useProjectStore.getState().cameraFrame;
+    const cameraRect = getCameraRect(cfg, frameState);
+    const vb = svg.viewBox?.baseVal;
+
+    // Compute scene bounds to map camera coords to SVG coords
+    let sMinX = Infinity, sMinY = Infinity, sMaxX = -Infinity, sMaxY = -Infinity;
+    for (const el of elements) {
+      const x1 = Math.min(el.x, el.x + el.width);
+      const y1 = Math.min(el.y, el.y + el.height);
+      const x2 = Math.max(el.x, el.x + el.width);
+      const y2 = Math.max(el.y, el.y + el.height);
+      if (x1 < sMinX) sMinX = x1;
+      if (y1 < sMinY) sMinY = y1;
+      if (x2 > sMaxX) sMaxX = x2;
+      if (y2 > sMaxY) sMaxY = y2;
+    }
+
+    const sceneW = (sMaxX - sMinX) || 1;
+    const sceneH = (sMaxY - sMinY) || 1;
+    const svgScaleX = (vb?.width ?? sceneW) / sceneW;
+    const svgScaleY = (vb?.height ?? sceneH) / sceneH;
+
+    const camSvgX = (cameraRect.x - cameraRect.width / 2 - sMinX) * svgScaleX + (vb?.x ?? 0);
+    const camSvgY = (cameraRect.y - cameraRect.height / 2 - sMinY) * svgScaleY + (vb?.y ?? 0);
+    const camSvgW = cameraRect.width * svgScaleX;
+    const camSvgH = cameraRect.height * svgScaleY;
+
+    svg.setAttribute('viewBox', `${camSvgX} ${camSvgY} ${camSvgW} ${camSvgH}`);
+  }
+
+  if (imageFormat === 'svg') {
+    // Direct SVG download
+    const svgStr = new XMLSerializer().serializeToString(svg);
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    downloadBlob(blob, `excalimate-export.svg`);
+    return;
+  }
+
+  // Rasterize SVG to canvas
+  const vb = svg.viewBox?.baseVal;
+  const baseW = vb?.width ?? 800;
+  const baseH = vb?.height ?? 600;
+  const outW = Math.round(baseW * scale);
+  const outH = Math.round(baseH * scale);
+
+  svg.setAttribute('width', String(outW));
+  svg.setAttribute('height', String(outH));
+
+  const svgStr = new XMLSerializer().serializeToString(svg);
+  const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = outW;
+  canvas.height = outH;
+  const ctx = canvas.getContext('2d')!;
+
+  const img = new Image(outW, outH);
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => {
+      ctx.fillStyle = isDark ? '#121212' : '#ffffff';
+      ctx.fillRect(0, 0, outW, outH);
+      ctx.drawImage(img, 0, 0, outW, outH);
+      URL.revokeObjectURL(url);
+      resolve();
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to rasterize SVG'));
+    };
+    img.src = url;
+  });
+
+  const mimeType = imageFormat === 'jpg' ? 'image/jpeg' : 'image/png';
+  const quality = imageFormat === 'jpg' ? 0.92 : undefined;
+  canvas.toBlob(
+    (b) => {
+      if (b) downloadBlob(b, `excalimate-export.${imageFormat}`);
+    },
+    mimeType,
+    quality,
+  );
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Component ────────────────────────────────────────────────────
+
 export function ExportControls() {
+  const mode = useUIStore((s) => s.mode);
   const [showDialog, setShowDialog] = useState(false);
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+
+  // Video state
   const [format, setFormat] = useState<ExportFormat>('mp4');
   const [quality, setQuality] = useState<ExportQuality>('high');
   const [exporting, setExporting] = useState(false);
   const [progress, setProgress] = useState(0);
 
+  // Image state
+  const [imageFormat, setImageFormat] = useState<ImageFormat>('png');
+  const [imageSource, setImageSource] = useState<ImageSource>('raw');
+  const [imageScale, setImageScale] = useState<ImageScale>(2);
+
+  // General
+  const [exportTheme, setExportTheme] = useState<ExportTheme>('light');
+
   const clipStart = useAnimationStore((s) => s.clipStart);
   const clipEnd = useAnimationStore((s) => s.clipEnd);
   const clipDuration = ((clipEnd - clipStart) / 1000).toFixed(1);
 
-  const handleExport = async () => {
+  const handleOpen = () => {
+    setActiveTab(mode === 'animate' ? 'video' : 'image');
+    setShowDialog(true);
+  };
+
+  const handleVideoExport = async () => {
     try {
       setExporting(true);
       setProgress(0);
@@ -40,6 +227,7 @@ export function ExportControls() {
       await exportAnimation({
         format,
         quality,
+        theme: exportTheme,
         onProgress: (p) => {
           setProgress(p);
           nprogress.set(p * 100);
@@ -55,110 +243,217 @@ export function ExportControls() {
     } catch (error) {
       nprogress.complete();
       const message = error instanceof Error ? error.message : 'Export failed';
-      notifications.show({
-        title: 'Export failed',
-        message,
-        icon: <IconX size={16} />,
-        color: 'red',
-      });
+      notifications.show({ title: 'Export failed', message, icon: <IconX size={16} />, color: 'red' });
     } finally {
       setExporting(false);
       setProgress(0);
     }
   };
 
+  const handleImageExport = async () => {
+    try {
+      setExporting(true);
+      nprogress.start();
+      await exportImage(imageSource, imageFormat, imageScale, exportTheme);
+      nprogress.complete();
+      notifications.show({
+        title: 'Image exported',
+        message: `${imageFormat.toUpperCase()} image at ${imageScale}x scale.`,
+        icon: <IconCheck size={16} />,
+        color: 'green',
+      });
+    } catch (error) {
+      nprogress.complete();
+      const message = error instanceof Error ? error.message : 'Export failed';
+      notifications.show({ title: 'Export failed', message, icon: <IconX size={16} />, color: 'red' });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const isAnimateMode = mode === 'animate';
+
   return (
     <>
-      <Button variant="subtle" color="gray" size="compact-sm" leftSection={<IconDownload size={14} />} onClick={() => setShowDialog(true)}>
+      <Button variant="subtle" color="gray" size="compact-sm" leftSection={<IconDownload size={14} />} onClick={handleOpen}>
         Export
       </Button>
 
       <Modal
         opened={showDialog}
         onClose={() => setShowDialog(false)}
-        title="Export Animation"
+        title="Export"
         size="md"
       >
-        <Stack gap="md">
-          {/* Clip info */}
-          <Text size="xs" c="dimmed">
-            Clip: {(clipStart / 1000).toFixed(1)}s – {(clipEnd / 1000).toFixed(1)}s ({clipDuration}s)
-          </Text>
+        <Tabs value={activeTab} onChange={setActiveTab}>
+          <Tabs.List grow>
+            <Tabs.Tab value="video" leftSection={<IconMovie size={14} />}>Video</Tabs.Tab>
+            <Tabs.Tab value="image" leftSection={<IconPhoto size={14} />}>Image</Tabs.Tab>
+          </Tabs.List>
 
-          {/* Export progress */}
-          {exporting ? (
-            <Stack gap="xs">
-              <Group gap="xs">
-                {FORMAT_INFO[format].icon}
-                <Text size="sm" fw={500}>Exporting {FORMAT_INFO[format].label}…</Text>
-              </Group>
-              <Progress value={progress * 100} animated size="lg" radius="sm" />
-              <Text size="xs" c="dimmed" ta="center">{Math.round(progress * 100)}%</Text>
-              <Alert variant="light" color="blue" radius="sm">
-                <Text size="xs">You can close this dialog — the export will continue in the background.</Text>
-              </Alert>
+          {/* ── Video Tab ─────────────────────────── */}
+          <Tabs.Panel value="video" pt="md">
+            <Stack gap="md">
+              <Text size="xs" c="dimmed">
+                Clip: {(clipStart / 1000).toFixed(1)}s – {(clipEnd / 1000).toFixed(1)}s ({clipDuration}s)
+              </Text>
+
+              {exporting && activeTab === 'video' ? (
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    {FORMAT_INFO[format].icon}
+                    <Text size="sm" fw={500}>Exporting {FORMAT_INFO[format].label}…</Text>
+                  </Group>
+                  <Progress value={progress * 100} animated size="lg" radius="sm" />
+                  <Text size="xs" c="dimmed" ta="center">{Math.round(progress * 100)}%</Text>
+                  <Alert variant="light" color="blue" radius="sm">
+                    <Text size="xs">You can close this dialog — the export will continue in the background.</Text>
+                  </Alert>
+                </Stack>
+              ) : (
+                <>
+                  <div>
+                    <Text size="xs" fw={500} mb={8}>Format</Text>
+                    <div className="grid grid-cols-2 gap-1.5">
+                      {(Object.keys(FORMAT_INFO) as ExportFormat[]).map((f) => {
+                        const info = FORMAT_INFO[f];
+                        return (
+                          <button
+                            key={f}
+                            type="button"
+                            className={`px-3 py-2 rounded border text-left text-xs transition-colors cursor-pointer ${
+                              format === f
+                                ? 'border-accent bg-accent-muted text-accent'
+                                : 'border-border text-text-muted hover:border-accent/50'
+                            }`}
+                            onClick={() => setFormat(f)}
+                          >
+                            <div className="font-medium flex items-center gap-1">{info.icon} {info.label}</div>
+                            <div className="text-[10px] opacity-70 mt-0.5">{info.desc}</div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {format !== 'svg' && (
+                    <div>
+                      <Text size="xs" fw={500} mb={8}>Quality</Text>
+                      <div className="grid grid-cols-4 gap-1">
+                        {(Object.keys(QUALITY_INFO) as ExportQuality[]).map((q) => {
+                          const info = QUALITY_INFO[q];
+                          return (
+                            <button
+                              key={q}
+                              type="button"
+                              className={`px-2 py-1.5 rounded border text-center text-[10px] transition-colors cursor-pointer ${
+                                quality === q
+                                  ? 'border-accent bg-accent-muted text-accent'
+                                  : 'border-border text-text-muted hover:border-accent/50'
+                              }`}
+                              onClick={() => setQuality(q)}
+                            >
+                              <div className="font-medium">{info.label}</div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <Text size="xs" c="dimmed" mt={4}>{QUALITY_INFO[quality].desc}</Text>
+                    </div>
+                  )}
+
+                  <Button fullWidth leftSection={<IconDownload size={16} />} onClick={handleVideoExport}>
+                    Export {FORMAT_INFO[format].label}
+                  </Button>
+                </>
+              )}
             </Stack>
-          ) : (
-            <>
-              {/* Format selection */}
-              <div>
-                <Text size="xs" fw={500} mb={8}>Format</Text>
-                <div className="grid grid-cols-2 gap-1.5">
-                  {(Object.keys(FORMAT_INFO) as ExportFormat[]).map((f) => {
-                    const info = FORMAT_INFO[f];
-                    return (
+          </Tabs.Panel>
+
+          {/* ── Image Tab ─────────────────────────── */}
+          <Tabs.Panel value="image" pt="md">
+            <Stack gap="md">
+              {/* Source (animate mode only) */}
+              {isAnimateMode && (
+                <div>
+                  <Text size="xs" fw={500} mb={8}>Source</Text>
+                  <div className="grid grid-cols-1 gap-1.5">
+                    {([
+                      { value: 'raw' as ImageSource, label: 'Complete drawing', desc: 'Original scene without animation', icon: <IconPhoto size={14} /> },
+                      { value: 'animated' as ImageSource, label: 'Current animation state', desc: 'Drawing with animation applied at current time', icon: <IconMovie size={14} /> },
+                      { value: 'camera' as ImageSource, label: 'Camera frame', desc: 'Cropped to camera frame at current time', icon: <IconCamera size={14} /> },
+                    ]).map((s) => (
                       <button
-                        key={f}
-                        className={`px-3 py-2 rounded border text-left text-xs transition-colors ${
-                          format === f
+                        key={s.value}
+                        type="button"
+                        className={`px-3 py-2 rounded border text-left text-xs transition-colors cursor-pointer ${
+                          imageSource === s.value
                             ? 'border-accent bg-accent-muted text-accent'
                             : 'border-border text-text-muted hover:border-accent/50'
                         }`}
-                        onClick={() => setFormat(f)}
+                        onClick={() => setImageSource(s.value)}
                       >
-                        <div className="font-medium flex items-center gap-1">{info.icon} {info.label}</div>
-                        <div className="text-[10px] opacity-70 mt-0.5">{info.desc}</div>
+                        <div className="font-medium flex items-center gap-1">{s.icon} {s.label}</div>
+                        <div className="text-[10px] opacity-70 mt-0.5">{s.desc}</div>
                       </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Quality selection (not for SVG) */}
-              {format !== 'svg' && (
-                <div>
-                  <Text size="xs" fw={500} mb={8}>Quality</Text>
-                  <div className="grid grid-cols-4 gap-1">
-                    {(Object.keys(QUALITY_INFO) as ExportQuality[]).map((q) => {
-                      const info = QUALITY_INFO[q];
-                      return (
-                        <button
-                          key={q}
-                          className={`px-2 py-1.5 rounded border text-center text-[10px] transition-colors ${
-                            quality === q
-                              ? 'border-accent bg-accent-muted text-accent'
-                              : 'border-border text-text-muted hover:border-accent/50'
-                          }`}
-                          onClick={() => setQuality(q)}
-                        >
-                          <div className="font-medium">{info.label}</div>
-                        </button>
-                      );
-                    })}
+                    ))}
                   </div>
-                  <Text size="xs" c="dimmed" mt={4}>
-                    {QUALITY_INFO[quality].desc}
-                  </Text>
                 </div>
               )}
 
-              {/* Export button */}
-              <Button fullWidth leftSection={<IconDownload size={16} />} onClick={handleExport}>
-                Export {FORMAT_INFO[format].label}
+              {/* Format */}
+              <div>
+                <Text size="xs" fw={500} mb={8}>Format</Text>
+                <SegmentedControl
+                  fullWidth
+                  size="xs"
+                  value={imageFormat}
+                  onChange={(v) => setImageFormat(v as ImageFormat)}
+                  data={IMAGE_FORMATS}
+                />
+              </div>
+
+              {/* Scale (not for SVG) */}
+              {imageFormat !== 'svg' && (
+                <div>
+                  <Text size="xs" fw={500} mb={8}>Scale</Text>
+                  <SegmentedControl
+                    fullWidth
+                    size="xs"
+                    value={String(imageScale)}
+                    onChange={(v) => setImageScale(Number(v) as ImageScale)}
+                    data={IMAGE_SCALES}
+                  />
+                </div>
+              )}
+
+              <Button
+                fullWidth
+                leftSection={<IconDownload size={16} />}
+                onClick={handleImageExport}
+                loading={exporting}
+              >
+                Export {imageFormat.toUpperCase()}
               </Button>
-            </>
-          )}
-        </Stack>
+            </Stack>
+          </Tabs.Panel>
+        </Tabs>
+
+        {/* ── Shared settings (visible for both tabs) ── */}
+        <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--color-border)' }}>
+          <Group gap="sm" align="center">
+            <Text size="xs" fw={500}>Export Theme</Text>
+            <SegmentedControl
+              size="xs"
+              value={exportTheme}
+              onChange={(v) => setExportTheme(v as ExportTheme)}
+              data={[
+                { value: 'light', label: 'Light' },
+                { value: 'dark', label: 'Dark' },
+              ]}
+            />
+          </Group>
+        </div>
       </Modal>
     </>
   );

--- a/src/components/Toolbar/InfoLinks.tsx
+++ b/src/components/Toolbar/InfoLinks.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { ActionIcon, Popover, Stack, Text, Group, Tooltip } from '@mantine/core';
+import {
+  IconBrandGithub,
+  IconBrandX,
+  IconBrandBluesky,
+  IconHeart,
+} from '@tabler/icons-react';
+
+const REPO = 'excalimate/excalimate';
+const GITHUB_URL = `https://github.com/${REPO}`;
+const STARS_KEY = 'excalimate-gh-stars';
+
+function getCachedStars(): number | null {
+  try {
+    const raw = localStorage.getItem(STARS_KEY);
+    if (!raw) return null;
+    const { count, ts } = JSON.parse(raw);
+    // Cache for 1 hour
+    if (Date.now() - ts < 3600000) return count;
+  } catch { /* ignore */ }
+  return null;
+}
+
+function cacheStars(count: number): void {
+  try {
+    localStorage.setItem(STARS_KEY, JSON.stringify({ count, ts: Date.now() }));
+  } catch { /* ignore */ }
+}
+
+export function InfoLinks() {
+  const [stars, setStars] = useState<number | null>(getCachedStars);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  useEffect(() => {
+    if (stars !== null) return;
+    fetch(`https://api.github.com/repos/${REPO}`, { signal: AbortSignal.timeout(5000) })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data?.stargazers_count != null) {
+          setStars(data.stargazers_count);
+          cacheStars(data.stargazers_count);
+        }
+      })
+      .catch(() => { /* best effort */ });
+  }, [stars]);
+
+  return (
+    <>
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* GitHub link with star count */}
+      <Tooltip label="GitHub repository">
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-text-muted hover:text-text transition-colors"
+        >
+          <IconBrandGithub size={16} />
+          {stars !== null && (
+            <span className="text-[11px]">
+              {stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : stars}
+            </span>
+          )}
+        </a>
+      </Tooltip>
+
+      {/* Credits popover */}
+      <Popover
+        opened={popoverOpen}
+        onChange={setPopoverOpen}
+        position="bottom-end"
+        shadow="md"
+        width={220}
+      >
+        <Popover.Target>
+          <Tooltip label="About">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={() => setPopoverOpen((o) => !o)}
+            >
+              <IconHeart size={15} />
+            </ActionIcon>
+          </Tooltip>
+        </Popover.Target>
+        <Popover.Dropdown>
+          <Stack gap="sm">
+            <Text size="xs" ta="center" c="dimmed">
+              Made with ❤️ by David Szakacs
+            </Text>
+            <Group justify="center" gap="xs">
+              <Tooltip label="X / Twitter">
+                <ActionIcon
+                  component="a"
+                  href="https://x.com/thedavidszakacs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                >
+                  <IconBrandX size={16} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Bluesky">
+                <ActionIcon
+                  component="a"
+                  href="https://bsky.app/profile/davidszakacs.bsky.social"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                >
+                  <IconBrandBluesky size={16} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="GitHub">
+                <ActionIcon
+                  component="a"
+                  href="https://github.com/davidszakacs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                >
+                  <IconBrandGithub size={16} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          </Stack>
+        </Popover.Dropdown>
+      </Popover>
+    </>
+  );
+}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -15,6 +15,7 @@ import { FileControls } from './FileControls';
 import { ModeSwitcher } from './ModeSwitcher';
 import { ThemeToggle } from './ThemeToggle';
 import { ExportControls } from './ExportControls';
+import { InfoLinks } from './InfoLinks';
 import { useUIStore } from '../../stores/uiStore';
 import { useMcpLive, getMcpUrl } from '../../hooks/useMcpLive';
 
@@ -161,6 +162,7 @@ export function Toolbar() {
         <ExportControls />
         <div className="w-px h-5 bg-border mx-1" />
         <ThemeToggle />
+        <InfoLinks />
       </div>
       <Modal
         opened={showConnectionError}

--- a/src/services/export/exportGIF.ts
+++ b/src/services/export/exportGIF.ts
@@ -51,7 +51,7 @@ export async function exportGIF(options: ExportOptions): Promise<void> {
     const time = clipStart + (i / totalFrames) * clipDuration;
     const frameState = engine.computeFrame(timeline, time, hierarchy);
 
-    await renderFrame(elements, project.scene.files, frameState, targets, gifW, gifH, canvas);
+    await renderFrame(elements, project.scene.files, frameState, targets, gifW, gifH, canvas, options.theme ?? 'light');
     gif.addFrame(canvas, { delay: Math.round(1000 / fps), copy: true });
     onProgress?.((i + 1) / (totalFrames + 1) * 0.8);
   }

--- a/src/services/export/exportMP4.ts
+++ b/src/services/export/exportMP4.ts
@@ -68,7 +68,7 @@ export async function exportMP4(options: ExportOptions): Promise<void> {
   for (let i = 0; i <= totalFrames; i++) {
     const time = clipStart + (i / totalFrames) * clipDuration;
     const frameState = engine.computeFrame(timeline, time, hierarchy);
-    await renderFrame(elements, project.scene.files, frameState, targets, res.width, res.height, canvas);
+    await renderFrame(elements, project.scene.files, frameState, targets, res.width, res.height, canvas, options.theme ?? 'light');
     const frame = new VideoFrame(canvas, { timestamp: i * frameDurationUs, duration: frameDurationUs });
     encoder.encode(frame, { keyFrame: i % (fps * 2) === 0 });
     frame.close();

--- a/src/services/export/exportSVG.ts
+++ b/src/services/export/exportSVG.ts
@@ -28,10 +28,15 @@ export async function exportAnimatedSVG(options: ExportOptions): Promise<void> {
   const clipDuration = clipEnd - clipStart;
   const totalFrames = Math.ceil(clipDuration / 1000 * fps);
 
+  const isDark = options.theme === 'dark';
   const svg = await exportToSvg({
     elements,
     files: project.scene.files ?? {},
-    appState: { exportBackground: true },
+    appState: {
+      exportBackground: true,
+      exportWithDarkMode: isDark,
+      viewBackgroundColor: '#ffffff',
+    },
     exportPadding: 0,
   });
 

--- a/src/services/export/exportWebM.ts
+++ b/src/services/export/exportWebM.ts
@@ -60,7 +60,7 @@ export async function exportWebM(options: ExportOptions): Promise<void> {
   for (let i = 0; i <= totalFrames; i++) {
     const time = clipStart + (i / totalFrames) * clipDuration;
     const frameState = engine.computeFrame(timeline, time, hierarchy);
-    await renderFrame(elements, project.scene.files, frameState, targets, res.width, res.height, canvas);
+    await renderFrame(elements, project.scene.files, frameState, targets, res.width, res.height, canvas, options.theme ?? 'light');
     const frame = new VideoFrame(canvas, { timestamp: i * frameDurationUs, duration: frameDurationUs });
     encoder.encode(frame, { keyFrame: i % (fps * 2) === 0 });
     frame.close();

--- a/src/services/export/renderFrame.ts
+++ b/src/services/export/renderFrame.ts
@@ -14,17 +14,23 @@ export async function renderFrame(
   outW: number,
   outH: number,
   outputCanvas: HTMLCanvasElement,
+  theme: 'light' | 'dark' = 'light',
 ): Promise<void> {
   try {
     const animated = applyAnimationToElements(elements, frameState, targets);
 
     const cfg = useProjectStore.getState().cameraFrame;
+    const isDark = theme === 'dark';
 
     const { exportToSvg } = await import('@excalidraw/excalidraw');
     const svg = await exportToSvg({
       elements: animated,
       files: files ?? {},
-      appState: { exportBackground: true },
+      appState: {
+        exportBackground: true,
+        exportWithDarkMode: isDark,
+        viewBackgroundColor: '#ffffff',
+      },
       exportPadding: 0,
     });
 
@@ -82,7 +88,7 @@ export async function renderFrame(
     await new Promise<void>((resolve) => {
       img.onload = () => {
         const ctx = outputCanvas.getContext('2d')!;
-        ctx.fillStyle = '#ffffff';
+        ctx.fillStyle = isDark ? '#121212' : '#ffffff';
         ctx.fillRect(0, 0, outW, outH);
         ctx.drawImage(img, 0, 0, outW, outH);
         URL.revokeObjectURL(url);

--- a/src/services/export/types.ts
+++ b/src/services/export/types.ts
@@ -5,6 +5,7 @@ export interface ExportOptions {
   format: ExportFormat;
   quality?: ExportQuality;
   fps?: number;
+  theme?: 'light' | 'dark';
   onProgress?: (progress: number) => void;
 }
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -28,6 +28,8 @@ interface UIState {
   liveMode: boolean;
   /** True when a shape/draw tool is active in Excalidraw (not selection/hand). */
   drawToolActive: boolean;
+  /** The currently displayed page. null = main app. */
+  activePage: string | null;
 
   // Actions
   setMode: (mode: AppMode) => void;
@@ -46,6 +48,7 @@ interface UIState {
   toggleLayersPanel: () => void;
   setLiveMode: (live: boolean) => void;
   setDrawToolActive: (active: boolean) => void;
+  setActivePage: (page: string | null) => void;
 }
 
 export const useUIStore = create<UIState>()((set, get) => ({
@@ -57,6 +60,7 @@ export const useUIStore = create<UIState>()((set, get) => ({
   layersPanelOpen: true,
   liveMode: false,
   drawToolActive: false,
+  activePage: null,
   panelSizes: {
     leftPanel: 48,
     rightPanel: 280,
@@ -153,5 +157,9 @@ export const useUIStore = create<UIState>()((set, get) => ({
 
   setDrawToolActive: (active: boolean): void => {
     set({ drawToolActive: active });
+  },
+
+  setActivePage: (page: string | null): void => {
+    set({ activePage: page });
   },
 }));


### PR DESCRIPTION
This pull request introduces two major improvements: a new MCP Server Setup Guide page to assist users in connecting their AI coding assistants, and a significant expansion of the export functionality to support advanced image export options alongside video export. The changes enhance user onboarding and provide a more flexible, user-friendly export experience.

**New MCP Server Setup Guide:**

- Added a new `McpSetupGuide` page (`src/components/Pages/McpSetupGuide.tsx`) that provides step-by-step instructions for connecting Excalimate to various AI coding assistants, including code snippets, tool-specific guides, and a user-friendly layout.
- Integrated the guide into the application navigation: users can access it from the Welcome Overlay via a new action link, and the main `App` component now renders the guide as a full-screen page when selected. [[1]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R13) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R61-R63) [[3]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R121-R123) [[4]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R247) [[5]](diffhunk://#diff-d257d1804855c46e74e3fa586ee653fbfd7692fb20acf06a887272a94284f778R6) [[6]](diffhunk://#diff-d257d1804855c46e74e3fa586ee653fbfd7692fb20acf06a887272a94284f778R87-R91)

**Export Functionality Enhancements:**

- Refactored the `ExportControls` component to support both video and advanced image export via a tabbed modal interface. Users can now export images in PNG, JPG, or SVG formats, choose between raw, animated, or camera-cropped sources, and select export scale and theme. [[1]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL2-R15) [[2]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR31-R230) [[3]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR246-R301)
- Implemented a new `exportImage` function with camera cropping, scaling, and theme support, as well as robust error handling and user notifications for export success or failure. [[1]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR31-R230) [[2]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR246-R301)
- Improved the UI/UX of the export modal, including segmented controls, progress feedback, and a more intuitive workflow for both image and video exports. [[1]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR246-R301) [[2]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL103) [[3]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL112-R324)

These changes collectively improve the onboarding experience for new users and provide more powerful export tools for all users.

**References:** [[1]](diffhunk://#diff-f6a4421eaa6b9a6bda5ed79ec61056e341055996a041afa64acb9df6d20508a4R1-R265) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R13) [[3]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R61-R63) [[4]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R121-R123) [[5]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R247) [[6]](diffhunk://#diff-d257d1804855c46e74e3fa586ee653fbfd7692fb20acf06a887272a94284f778R6) [[7]](diffhunk://#diff-d257d1804855c46e74e3fa586ee653fbfd7692fb20acf06a887272a94284f778R87-R91) [[8]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL2-R15) [[9]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR31-R230) [[10]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fR246-R301) [[11]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL103) [[12]](diffhunk://#diff-5b7866f9d7cc84754a9bba93b125c52486f0ecb968a0efa65c00f43068b90f2fL112-R324)