### PR TITLE
Improve MCP server performance and add comprehensive tests

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,63 @@
+name: Auto-tag on Version Bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'mcp-server/package.json'
+
+jobs:
+  tag:
+    name: Create Tags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check web app version bump
+        id: app
+        run: |
+          # Compare package.json version between HEAD and HEAD~1
+          CURRENT=$(node -p "require('./package.json').version")
+          PREVIOUS=$(git show HEAD~1:package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null || echo "")
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "previous=$PREVIOUS" >> $GITHUB_OUTPUT
+          if [ "$CURRENT" != "$PREVIOUS" ] && [ -n "$PREVIOUS" ]; then
+            echo "bumped=true" >> $GITHUB_OUTPUT
+          else
+            echo "bumped=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check MCP server version bump
+        id: mcp
+        run: |
+          CURRENT=$(node -p "require('./mcp-server/package.json').version")
+          PREVIOUS=$(git show HEAD~1:mcp-server/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null || echo "")
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "previous=$PREVIOUS" >> $GITHUB_OUTPUT
+          if [ "$CURRENT" != "$PREVIOUS" ] && [ -n "$PREVIOUS" ]; then
+            echo "bumped=true" >> $GITHUB_OUTPUT
+          else
+            echo "bumped=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create web app tag
+        if: steps.app.outputs.bumped == 'true'
+        run: |
+          TAG="v${{ steps.app.outputs.current }}"
+          echo "Creating tag: $TAG"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create MCP server tag
+        if: steps.mcp.outputs.bumped == 'true'
+        run: |
+          TAG="mcp-server-v${{ steps.mcp.outputs.current }}"
+          echo "Creating tag: $TAG"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/mcp-bench.yml
+++ b/.github/workflows/mcp-bench.yml
@@ -1,0 +1,90 @@
+name: MCP Server Benchmarks
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp-server/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mcp-server/**'
+
+jobs:
+  benchmark:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        working-directory: mcp-server
+        run: npm ci
+
+      - name: Build
+        working-directory: mcp-server
+        run: npx tsc
+
+      - name: Run benchmarks
+        working-directory: mcp-server
+        run: npx tsx bench/run.ts --markdown --output bench-results.md
+
+      - name: Run benchmarks (JSON)
+        working-directory: mcp-server
+        run: npx tsx bench/run.ts --json --output bench-results.json
+
+      - name: Write job summary
+        working-directory: mcp-server
+        run: cat bench-results.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            mcp-server/bench-results.md
+            mcp-server/bench-results.json
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const md = fs.readFileSync('mcp-server/bench-results.md', 'utf8');
+
+            // Find existing bench comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '<!-- mcp-bench-results -->';
+            const existing = comments.find(c => c.body?.includes(marker));
+            const body = `${marker}\n${md}`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,4 +1,4 @@
-name: Publish MCP Server to npm
+name: Publish MCP Server
 
 on:
   push:
@@ -53,6 +53,11 @@ jobs:
         working-directory: mcp-server
         run: node -e "require('./dist/index.js'); console.log('Build verified'); process.exit(0)"
 
+      # Run benchmarks
+      - name: Run benchmarks
+        working-directory: mcp-server
+        run: npx tsx bench/run.ts --markdown --output bench-results.md
+
       # Publish
       - name: Publish to npm (dry run)
         if: ${{ github.event.inputs.dry-run == 'true' }}
@@ -66,17 +71,39 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
-      # Create GitHub Release
+      # Create GitHub Release with changelog
       - name: Extract version from tag
         if: startsWith(github.ref, 'refs/tags/')
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/mcp-server-v}" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for version
+        if: startsWith(github.ref, 'refs/tags/')
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [VERSION]" to the next "## [" or end of file
+          NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" mcp-server/CHANGELOG.md)
+          # If no version-specific section found, use [Unreleased]
+          if [ -z "$NOTES" ]; then
+            NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/d; p; }' mcp-server/CHANGELOG.md)
+          fi
+          # Write to file for the release step
+          echo "$NOTES" > release-notes.md
+          # Append benchmark results
+          if [ -f mcp-server/bench-results.md ]; then
+            echo "" >> release-notes.md
+            echo "---" >> release-notes.md
+            echo "" >> release-notes.md
+            cat mcp-server/bench-results.md >> release-notes.md
+          fi
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           name: 'MCP Server v${{ steps.version.outputs.version }}'
-          generate_release_notes: true
+          body_path: release-notes.md
           files: |
-            mcp-server/dist/**
+            mcp-server/bench-results.md

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,62 @@
+name: Release Web App
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!mcp-server-v*'
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/d; p; }' CHANGELOG.md)
+          fi
+          echo "$NOTES" > release-notes.md
+
+      - name: Create build archive
+        run: tar -czf excalimate-${{ steps.version.outputs.version }}.tar.gz -C dist .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: 'Excalimate v${{ steps.version.outputs.version }}'
+          body_path: release-notes.md
+          files: |
+            excalimate-${{ steps.version.outputs.version }}.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- N/A
+
+### Changed
+- N/A
+
+### Fixed
+- N/A
+
+## [0.3.0] - 2026-03-22
+
+### Added
 - New Project modal with name and aspect ratio selection
 - Onboarding overlay with hand-drawn Excalidraw-style arrows and hints
 - MCP Setup Guide page accessible from the welcome overlay
@@ -32,6 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Elements no longer disappear during MCP live preview in edit mode
 - Removed opacity clamping in animation preview
 
-## [0.2.0] - 2025-12-01
+## [0.2.0] - 2026-03-16
 
 - Initial public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the Excalimate web app will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- New Project modal with name and aspect ratio selection
+- Onboarding overlay with hand-drawn Excalidraw-style arrows and hints
+- MCP Setup Guide page accessible from the welcome overlay
+- Image export (PNG, JPG, SVG) with source selection and 1x–4x scale
+- Dark/light theme toggle for exports
+- GitHub stars link and credits popover in the toolbar
+- ESC clears keyframe selection via capture-phase handler
+- Property panel shows keyframe editors when keyframes are selected without an element
+
+### Changed
+- Default theme is now light mode (persists user preference)
+- Export modal redesigned with Video/Image tabs and shared theme control
+- Animate mode shows correct animation state on initial load (no scrub needed)
+- Live MCP preview stays in edit mode until keyframes are added
+- SSE delta messages merged incrementally (scene + timeline)
+- `extractTargets()` skipped when only element properties change (not IDs)
+
+### Fixed
+- Undo restoring deleted elements no longer creates false keyframes
+- Group deletion now properly restores animation tracks on undo
+- `toggleMode()` now triggers `computeFrameAtTime` when entering animate mode
+- Elements no longer disappear during MCP live preview in edit mode
+- Removed opacity clamping in animation preview
+
+## [0.2.0] - 2025-12-01
+
+- Initial public release

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to the MCP server will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `create_animated_scene` composite tool — create elements + keyframes + sequences + camera + clip in one call
+- Batched state mutations via `addKeyframesBatchToState` — eliminates per-keyframe overhead
+- SSE track-level delta broadcasting — only changed tracks/elements sent, not full state
+- Gzip compression for SSE payloads >512 bytes
+- Element property stripping in SSE deltas (removes non-visual metadata)
+- Lazy JSON serialization cache with version counter
+- Benchmark suite (`bench/`) with deterministic fixtures and visual reports
+
+### Changed
+- `add_keyframes_batch` now uses single-pass batch insertion (was per-keyframe loop)
+- `create_sequence` batches all keyframes before applying (was 3× state mutations per element)
+- `add_scale_animation` batches scale + translate compensation keyframes
+- `set_camera_frame` batches 4 initial camera keyframes in one call
+- `add_camera_keyframes_batch` uses batch insertion
+- Reference text slimmed from 11KB to 4.6KB, updated workflow to recommend `create_animated_scene`
+
+### Fixed
+- N/A
+
+## [0.3.5] - 2025-12-15
+
+- Initial public release

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- N/A
+
+### Changed
+- N/A
+
+### Fixed
+- N/A
+
+## [0.4.0] - 2026-03-22
+
+### Added
 - `create_animated_scene` composite tool — create elements + keyframes + sequences + camera + clip in one call
 - Batched state mutations via `addKeyframesBatchToState` — eliminates per-keyframe overhead
 - SSE track-level delta broadcasting — only changed tracks/elements sent, not full state
@@ -27,6 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-## [0.3.5] - 2025-12-15
+## [0.3.5] - 2026-03-16
 
 - Initial public release

--- a/mcp-server/bench/fixtures/generator.ts
+++ b/mcp-server/bench/fixtures/generator.ts
@@ -1,0 +1,210 @@
+/**
+ * Seeded PRNG (mulberry32) — deterministic random numbers for reproducible fixtures.
+ */
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const STROKE_COLORS = ['#1e1e1e', '#e03131', '#2f9e44', '#1971c2', '#f08c00', '#6741d9', '#0c8599', '#e8590c'];
+const BG_COLORS = ['transparent', '#ffc9c9', '#b2f2bb', '#a5d8ff', '#ffec99', '#d0bfff', '#99e9f2', '#ffd8a8'];
+const EASINGS = ['easeOut', 'easeInOutCubic', 'easeOutBack', 'easeInOut', 'easeOutCubic'] as const;
+const PROPERTIES = ['opacity', 'translateX', 'translateY', 'drawProgress', 'scaleX'] as const;
+
+function pick<T>(arr: readonly T[], rand: () => number): T {
+  return arr[Math.floor(rand() * arr.length)];
+}
+
+export interface FixtureElement {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  strokeColor: string;
+  backgroundColor: string;
+  fillStyle: string;
+  strokeWidth: number;
+  [key: string]: unknown;
+}
+
+export interface FixtureKeyframe {
+  targetId: string;
+  property: string;
+  time: number;
+  value: number;
+  easing?: string;
+}
+
+export interface FixtureScene {
+  elements: FixtureElement[];
+  keyframes: FixtureKeyframe[];
+  sequences: { elementIds: string[]; property: string; startTime: number; delay: number; duration: number }[];
+  clipEnd: number;
+  cameraFrame: { x: number; y: number; width: number; aspectRatio: '16:9' };
+}
+
+function generateElements(count: number, rand: () => number): FixtureElement[] {
+  const elements: FixtureElement[] = [];
+  const cols = Math.ceil(Math.sqrt(count));
+  const spacing = 250;
+
+  for (let i = 0; i < count; i++) {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const x = 100 + col * spacing;
+    const y = 100 + row * spacing;
+    const r = rand();
+
+    let el: FixtureElement;
+    if (r < 0.35) {
+      // Rectangle
+      el = {
+        id: `el-${i}`,
+        type: 'rectangle',
+        x, y,
+        width: 120 + Math.floor(rand() * 80),
+        height: 60 + Math.floor(rand() * 40),
+        strokeColor: pick(STROKE_COLORS, rand),
+        backgroundColor: pick(BG_COLORS, rand),
+        fillStyle: 'solid',
+        strokeWidth: 2,
+      };
+    } else if (r < 0.50) {
+      // Ellipse
+      el = {
+        id: `el-${i}`,
+        type: 'ellipse',
+        x, y,
+        width: 100 + Math.floor(rand() * 60),
+        height: 100 + Math.floor(rand() * 60),
+        strokeColor: pick(STROKE_COLORS, rand),
+        backgroundColor: pick(BG_COLORS, rand),
+        fillStyle: 'solid',
+        strokeWidth: 2,
+      };
+    } else if (r < 0.60) {
+      // Diamond
+      el = {
+        id: `el-${i}`,
+        type: 'diamond',
+        x, y,
+        width: 100 + Math.floor(rand() * 40),
+        height: 100 + Math.floor(rand() * 40),
+        strokeColor: pick(STROKE_COLORS, rand),
+        backgroundColor: pick(BG_COLORS, rand),
+        fillStyle: 'solid',
+        strokeWidth: 2,
+      };
+    } else if (r < 0.80) {
+      // Arrow
+      const dx = 150 + Math.floor(rand() * 100);
+      el = {
+        id: `el-${i}`,
+        type: 'arrow',
+        x, y: y + 30,
+        width: dx,
+        height: 0,
+        strokeColor: pick(STROKE_COLORS, rand),
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        points: [[0, 0], [dx, 0]],
+        endArrowhead: 'arrow',
+      };
+    } else {
+      // Text
+      const texts = ['Server', 'Client', 'Database', 'API', 'Cache', 'Queue', 'Auth', 'Gateway'];
+      el = {
+        id: `el-${i}`,
+        type: 'text',
+        x, y,
+        width: 100,
+        height: 30,
+        strokeColor: pick(STROKE_COLORS, rand),
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 1,
+        text: pick(texts, rand),
+        fontSize: 20,
+        fontFamily: 5,
+        textAlign: 'center',
+      };
+    }
+
+    elements.push(el);
+  }
+
+  return elements;
+}
+
+function generateKeyframes(elements: FixtureElement[], count: number, rand: () => number): FixtureKeyframe[] {
+  const keyframes: FixtureKeyframe[] = [];
+  const targetIds = elements.map(el => el.id);
+
+  for (let i = 0; i < count; i++) {
+    const targetId = targetIds[i % targetIds.length];
+    const el = elements[i % elements.length];
+    const prop = pick(PROPERTIES, rand);
+    const stagger = Math.floor(i / targetIds.length) * 500;
+    const baseTime = (i % targetIds.length) * 300 + stagger;
+
+    // Property-appropriate values
+    if (prop === 'opacity') {
+      keyframes.push({ targetId, property: 'opacity', time: baseTime, value: 0 });
+      keyframes.push({ targetId, property: 'opacity', time: baseTime + 500, value: 1, easing: pick(EASINGS, rand) });
+    } else if (prop === 'translateX' || prop === 'translateY') {
+      const offset = -200 + Math.floor(rand() * 400);
+      keyframes.push({ targetId, property: prop, time: baseTime, value: offset });
+      keyframes.push({ targetId, property: prop, time: baseTime + 800, value: 0, easing: pick(EASINGS, rand) });
+    } else if (prop === 'drawProgress' && (el.type === 'arrow' || el.type === 'line')) {
+      keyframes.push({ targetId, property: 'drawProgress', time: baseTime, value: 0 });
+      keyframes.push({ targetId, property: 'drawProgress', time: baseTime + 1000, value: 1, easing: 'easeInOut' });
+    } else if (prop === 'scaleX') {
+      keyframes.push({ targetId, property: 'scaleX', time: baseTime, value: 0.3 });
+      keyframes.push({ targetId, property: 'scaleX', time: baseTime + 600, value: 1, easing: 'easeOutBack' });
+      keyframes.push({ targetId, property: 'scaleY', time: baseTime, value: 0.3 });
+      keyframes.push({ targetId, property: 'scaleY', time: baseTime + 600, value: 1, easing: 'easeOutBack' });
+    } else {
+      // Fallback to opacity
+      keyframes.push({ targetId, property: 'opacity', time: baseTime, value: 0 });
+      keyframes.push({ targetId, property: 'opacity', time: baseTime + 500, value: 1, easing: pick(EASINGS, rand) });
+    }
+  }
+
+  return keyframes;
+}
+
+export function generateScene(elementCount: number, keyframeCount: number, seed: number): FixtureScene {
+  const rand = mulberry32(seed);
+  const elements = generateElements(elementCount, rand);
+  const keyframes = generateKeyframes(elements, keyframeCount, rand);
+
+  // Compute scene bounds for camera
+  let maxX = 0, maxY = 0;
+  for (const el of elements) {
+    maxX = Math.max(maxX, el.x + el.width);
+    maxY = Math.max(maxY, el.y + el.height);
+  }
+
+  const maxTime = keyframes.reduce((m, kf) => Math.max(m, kf.time), 0);
+
+  return {
+    elements,
+    keyframes,
+    sequences: [],
+    clipEnd: maxTime + 500,
+    cameraFrame: {
+      x: Math.round(maxX / 2),
+      y: Math.round(maxY / 2),
+      width: Math.round(maxX + 200),
+      aspectRatio: '16:9',
+    },
+  };
+}

--- a/mcp-server/bench/fixtures/scenes.ts
+++ b/mcp-server/bench/fixtures/scenes.ts
@@ -1,0 +1,18 @@
+import { generateScene, type FixtureScene } from './generator.js';
+
+// Fixed seed for all presets — produces identical output every run
+const SEED = 42;
+
+export const SMALL: FixtureScene = generateScene(10, 10, SEED);
+export const MEDIUM: FixtureScene = generateScene(35, 50, SEED + 1);
+export const LARGE: FixtureScene = generateScene(85, 150, SEED + 2);
+export const VERY_LARGE: FixtureScene = generateScene(280, 500, SEED + 3);
+
+export const ALL_SCENES = {
+  small: SMALL,
+  medium: MEDIUM,
+  large: LARGE,
+  'very-large': VERY_LARGE,
+} as const;
+
+export type SceneSize = keyof typeof ALL_SCENES;

--- a/mcp-server/bench/harness/McpTestClient.ts
+++ b/mcp-server/bench/harness/McpTestClient.ts
@@ -1,0 +1,80 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createServer } from '../../src/server.js';
+import type { CheckpointStore } from '../../src/checkpoint-store.js';
+import type { StateDelta } from '../../src/server/stateContext.js';
+
+export interface ToolCallResult {
+  name: string;
+  text: string;
+  durationMs: number;
+}
+
+/**
+ * In-process MCP client that calls tools on a real McpServer instance
+ * via the SDK's InMemoryTransport. No HTTP, no network — pure function call timing.
+ */
+export class McpTestClient {
+  private client: Client;
+  private server: McpServer;
+  private clientTransport: InMemoryTransport;
+  private serverTransport: InMemoryTransport;
+
+  private constructor(
+    client: Client,
+    server: McpServer,
+    clientTransport: InMemoryTransport,
+    serverTransport: InMemoryTransport,
+  ) {
+    this.client = client;
+    this.server = server;
+    this.clientTransport = clientTransport;
+    this.serverTransport = serverTransport;
+  }
+
+  static async create(
+    store: CheckpointStore,
+    onStateChange?: (delta: StateDelta) => void,
+  ): Promise<McpTestClient> {
+    const server = createServer(store, onStateChange);
+    const client = new Client({ name: 'bench-client', version: '1.0.0' });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    return new McpTestClient(client, server, clientTransport, serverTransport);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    const start = performance.now();
+    const result = await this.client.callTool({ name, arguments: args });
+    const durationMs = performance.now() - start;
+
+    const text = result.content
+      ?.filter((c: { type: string }) => c.type === 'text')
+      .map((c: { text?: string }) => c.text ?? '')
+      .join('\n') ?? '';
+
+    return { name, text, durationMs };
+  }
+
+  async callToolSequence(
+    calls: { name: string; args: Record<string, unknown> }[],
+  ): Promise<{ totalDurationMs: number; results: ToolCallResult[] }> {
+    const results: ToolCallResult[] = [];
+    const start = performance.now();
+
+    for (const call of calls) {
+      results.push(await this.callTool(call.name, call.args));
+    }
+
+    return { totalDurationMs: performance.now() - start, results };
+  }
+
+  async close(): Promise<void> {
+    await this.clientTransport.close();
+    await this.serverTransport.close();
+  }
+}

--- a/mcp-server/bench/harness/MemoryCheckpointStore.ts
+++ b/mcp-server/bench/harness/MemoryCheckpointStore.ts
@@ -1,0 +1,21 @@
+import type { CheckpointStore } from '../../src/checkpoint-store.js';
+import type { ServerState } from '../../src/types.js';
+
+/**
+ * In-memory checkpoint store — no filesystem I/O during benchmarks.
+ */
+export class MemoryCheckpointStore implements CheckpointStore {
+  private store = new Map<string, ServerState>();
+
+  async save(id: string, data: ServerState): Promise<void> {
+    this.store.set(id, data);
+  }
+
+  async load(id: string): Promise<ServerState | null> {
+    return this.store.get(id) ?? null;
+  }
+
+  async list(): Promise<string[]> {
+    return [...this.store.keys()];
+  }
+}

--- a/mcp-server/bench/harness/SseTrafficMonitor.ts
+++ b/mcp-server/bench/harness/SseTrafficMonitor.ts
@@ -1,0 +1,65 @@
+import { gzipSync } from 'node:zlib';
+import type { StateDelta } from '../../src/server/stateContext.js';
+
+export interface SseMessage {
+  areas: string;
+  rawBytes: number;
+  compressedBytes: number;
+}
+
+export interface TrafficReport {
+  messageCount: number;
+  totalRawBytes: number;
+  totalCompressedBytes: number;
+  compressionRatio: number;
+  messages: SseMessage[];
+}
+
+/**
+ * Intercepts SSE deltas to measure bandwidth.
+ * Pass createListener() as the onStateChange callback to createServer().
+ */
+export class SseTrafficMonitor {
+  messages: SseMessage[] = [];
+  totalRawBytes = 0;
+  totalCompressedBytes = 0;
+
+  createListener(): (delta: StateDelta) => void {
+    return (delta: StateDelta) => {
+      const raw = JSON.stringify({ type: 'state', state: delta });
+      const rawBytes = Buffer.byteLength(raw, 'utf8');
+      let compressedBytes = rawBytes;
+
+      if (rawBytes > 512) {
+        const compressed = gzipSync(raw).toString('base64');
+        compressedBytes = Buffer.byteLength(
+          JSON.stringify({ type: 'gz', data: compressed }),
+          'utf8',
+        );
+      }
+
+      const areas = Object.keys(delta).join('+');
+      this.messages.push({ areas, rawBytes, compressedBytes });
+      this.totalRawBytes += rawBytes;
+      this.totalCompressedBytes += compressedBytes;
+    };
+  }
+
+  report(): TrafficReport {
+    return {
+      messageCount: this.messages.length,
+      totalRawBytes: this.totalRawBytes,
+      totalCompressedBytes: this.totalCompressedBytes,
+      compressionRatio: this.totalRawBytes > 0
+        ? 1 - this.totalCompressedBytes / this.totalRawBytes
+        : 0,
+      messages: this.messages,
+    };
+  }
+
+  reset(): void {
+    this.messages = [];
+    this.totalRawBytes = 0;
+    this.totalCompressedBytes = 0;
+  }
+}

--- a/mcp-server/bench/harness/metrics.ts
+++ b/mcp-server/bench/harness/metrics.ts
@@ -1,0 +1,206 @@
+import type { ToolCallResult } from './McpTestClient.js';
+import type { TrafficReport } from './SseTrafficMonitor.js';
+import { getSharedStateJSON } from '../../src/server/stateContext.js';
+
+export interface BenchmarkResult {
+  scenario: string;
+  sceneSize: string;
+  toolCalls: number;
+  totalTimeMs: number;
+  perToolTimeMs: number[];
+  sseMessageCount: number;
+  sseRawBytes: number;
+  sseGzipBytes: number;
+  compressionRatio: number;
+  stateJsonBytes: number;
+  elementCount: number;
+  trackCount: number;
+  keyframeCount: number;
+  peakMemoryMB: number;
+}
+
+export function collectMetrics(
+  scenario: string,
+  sceneSize: string,
+  toolResults: ToolCallResult[],
+  totalTimeMs: number,
+  traffic: TrafficReport,
+  state: { elementCount: number; trackCount: number; keyframeCount: number },
+): BenchmarkResult {
+  const stateJson = getSharedStateJSON();
+  const memUsage = process.memoryUsage();
+
+  return {
+    scenario,
+    sceneSize,
+    toolCalls: toolResults.length,
+    totalTimeMs: Math.round(totalTimeMs * 100) / 100,
+    perToolTimeMs: toolResults.map(r => Math.round(r.durationMs * 100) / 100),
+    sseMessageCount: traffic.messageCount,
+    sseRawBytes: traffic.totalRawBytes,
+    sseGzipBytes: traffic.totalCompressedBytes,
+    compressionRatio: Math.round(traffic.compressionRatio * 1000) / 1000,
+    stateJsonBytes: Buffer.byteLength(stateJson, 'utf8'),
+    elementCount: state.elementCount,
+    trackCount: state.trackCount,
+    keyframeCount: state.keyframeCount,
+    peakMemoryMB: Math.round(memUsage.rss / 1024 / 1024 * 10) / 10,
+  };
+}
+
+export function formatTable(results: BenchmarkResult[]): string {
+  const cols = [
+    { key: 'scenario', label: 'Scenario', width: 18 },
+    { key: 'sceneSize', label: 'Size', width: 12 },
+    { key: 'toolCalls', label: 'Calls', width: 6 },
+    { key: 'totalTimeMs', label: 'Time(ms)', width: 10 },
+    { key: 'sseMessageCount', label: 'SSE Msgs', width: 9 },
+    { key: 'sseRawBytes', label: 'Raw(B)', width: 10 },
+    { key: 'sseGzipBytes', label: 'Gzip(B)', width: 10 },
+    { key: 'stateJsonBytes', label: 'State(B)', width: 10 },
+    { key: 'peakMemoryMB', label: 'Mem(MB)', width: 8 },
+  ];
+
+  const sep = '+' + cols.map(c => '-'.repeat(c.width + 2)).join('+') + '+';
+  const header = '|' + cols.map(c => ` ${c.label.padEnd(c.width)} `).join('|') + '|';
+  const lines = [sep, header, sep];
+
+  for (const r of results) {
+    const row = '|' + cols.map(c => {
+      const val = String((r as Record<string, unknown>)[c.key] ?? '');
+      return ` ${val.padEnd(c.width)} `;
+    }).join('|') + '|';
+    lines.push(row);
+  }
+  lines.push(sep);
+
+  return lines.join('\n');
+}
+
+export function formatComparison(
+  label1: string,
+  results1: BenchmarkResult[],
+  label2: string,
+  results2: BenchmarkResult[],
+): string {
+  const lines: string[] = [];
+  for (let i = 0; i < Math.min(results1.length, results2.length); i++) {
+    const a = results1[i];
+    const b = results2[i];
+    lines.push(`\n=== ${a.sceneSize} ===`);
+    lines.push(`${'Metric'.padEnd(20)} ${label1.padEnd(12)} ${label2.padEnd(12)} Change`);
+    lines.push('-'.repeat(60));
+
+    const metrics: [string, keyof BenchmarkResult][] = [
+      ['Tool calls', 'toolCalls'],
+      ['Total time (ms)', 'totalTimeMs'],
+      ['SSE messages', 'sseMessageCount'],
+      ['SSE raw bytes', 'sseRawBytes'],
+      ['SSE gzip bytes', 'sseGzipBytes'],
+      ['State bytes', 'stateJsonBytes'],
+      ['Peak memory (MB)', 'peakMemoryMB'],
+    ];
+
+    for (const [label, key] of metrics) {
+      const va = a[key] as number;
+      const vb = b[key] as number;
+      const change = va !== 0 ? Math.round((vb - va) / va * 100) : 0;
+      const sign = change > 0 ? '+' : '';
+      lines.push(
+        `${label.padEnd(20)} ${String(va).padEnd(12)} ${String(vb).padEnd(12)} ${sign}${change}%`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Markdown report with visual bar charts ────────────────────
+
+function bar(value: number, max: number, width = 20): string {
+  const filled = max > 0 ? Math.round((value / max) * width) : 0;
+  return '█'.repeat(Math.min(filled, width)) + '░'.repeat(width - Math.min(filled, width));
+}
+
+function fmtBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Generate a visual Markdown report suitable for GitHub Actions summary or PR comment.
+ */
+export function formatMarkdownReport(results: BenchmarkResult[]): string {
+  const lines: string[] = [];
+  lines.push('# 📊 MCP Server Benchmark Results\n');
+
+  // Group by scene size
+  const sizes = [...new Set(results.map(r => r.sceneSize))];
+  const scenarios = [...new Set(results.map(r => r.scenario))];
+
+  // ── Summary table ──
+  lines.push('## Summary\n');
+  lines.push('| Size | Scenario | Calls | Time | SSE Msgs | Gzip Traffic | State Size |');
+  lines.push('|------|----------|------:|-----:|---------:|-------------:|-----------:|');
+  for (const r of results) {
+    lines.push(
+      `| ${r.sceneSize} | ${r.scenario} | ${r.toolCalls} | ${r.totalTimeMs.toFixed(1)}ms | ${r.sseMessageCount} | ${fmtBytes(r.sseGzipBytes)} | ${fmtBytes(r.stateJsonBytes)} |`,
+    );
+  }
+
+  // ── Visual comparisons per size ──
+  for (const size of sizes) {
+    const sizeResults = results.filter(r => r.sceneSize === size);
+    if (sizeResults.length < 2) continue;
+
+    lines.push(`\n## ${size.charAt(0).toUpperCase() + size.slice(1)} Scene\n`);
+
+    // Tool calls chart
+    const maxCalls = Math.max(...sizeResults.map(r => r.toolCalls));
+    lines.push('### Tool Calls\n');
+    lines.push('```');
+    for (const r of sizeResults) {
+      lines.push(`${r.scenario.padEnd(12)} ${bar(r.toolCalls, maxCalls)} ${r.toolCalls}`);
+    }
+    lines.push('```\n');
+
+    // Time chart
+    const maxTime = Math.max(...sizeResults.map(r => r.totalTimeMs));
+    lines.push('### Execution Time\n');
+    lines.push('```');
+    for (const r of sizeResults) {
+      lines.push(`${r.scenario.padEnd(12)} ${bar(r.totalTimeMs, maxTime)} ${r.totalTimeMs.toFixed(1)}ms`);
+    }
+    lines.push('```\n');
+
+    // Bandwidth chart
+    const maxBw = Math.max(...sizeResults.map(r => r.sseGzipBytes));
+    lines.push('### SSE Bandwidth (gzip)\n');
+    lines.push('```');
+    for (const r of sizeResults) {
+      lines.push(`${r.scenario.padEnd(12)} ${bar(r.sseGzipBytes, maxBw)} ${fmtBytes(r.sseGzipBytes)}`);
+    }
+    lines.push('```\n');
+  }
+
+  // ── Key improvements ──
+  if (scenarios.includes('individual') && scenarios.includes('composite')) {
+    lines.push('## 🚀 Key Improvements\n');
+    for (const size of sizes) {
+      const ind = results.find(r => r.sceneSize === size && r.scenario === 'individual');
+      const comp = results.find(r => r.sceneSize === size && r.scenario === 'composite');
+      if (!ind || !comp) continue;
+
+      const callReduction = ind.toolCalls > 0 ? Math.round((1 - comp.toolCalls / ind.toolCalls) * 100) : 0;
+      const timeReduction = ind.totalTimeMs > 0 ? Math.round((1 - comp.totalTimeMs / ind.totalTimeMs) * 100) : 0;
+
+      lines.push(
+        `- **${size}**: ${callReduction}% fewer tool calls, ${timeReduction}% faster execution`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/mcp-server/bench/regression/compare.bench.ts
+++ b/mcp-server/bench/regression/compare.bench.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression Comparison: Published vs Dev
+ *
+ * Installs the published @excalimate/mcp-server package and runs identical
+ * fixture scenarios against both versions.
+ *
+ * Usage: npx tsx bench/regression/compare.bench.ts
+ *
+ * Note: The published version may not have create_animated_scene,
+ * so we compare using batch tools (Scenario B) which both versions support.
+ */
+import { ALL_SCENES, type SceneSize } from '../fixtures/scenes.js';
+import { runBatchTools } from '../scenarios/batch-tools.bench.js';
+import { runCompositeTool } from '../scenarios/composite-tool.bench.js';
+import { formatComparison, type BenchmarkResult } from '../harness/metrics.js';
+
+async function main() {
+  const sizes = Object.keys(ALL_SCENES) as SceneSize[];
+
+  console.log('=== Dev Build: Batch Tools (Scenario B) ===');
+  const devBatch: BenchmarkResult[] = [];
+  for (const size of sizes) {
+    process.stdout.write(`  ${size}...`);
+    const r = await runBatchTools(ALL_SCENES[size], size);
+    devBatch.push(r);
+    process.stdout.write(` ${r.totalTimeMs.toFixed(1)}ms\n`);
+  }
+
+  console.log('\n=== Dev Build: Composite Tool (Scenario C) ===');
+  const devComposite: BenchmarkResult[] = [];
+  for (const size of sizes) {
+    process.stdout.write(`  ${size}...`);
+    const r = await runCompositeTool(ALL_SCENES[size], size);
+    devComposite.push(r);
+    process.stdout.write(` ${r.totalTimeMs.toFixed(1)}ms\n`);
+  }
+
+  console.log('\n=== Batch vs Composite (Dev Build) ===');
+  console.log(formatComparison('Batch', devBatch, 'Composite', devComposite));
+
+  // To compare against published version, uncomment below after:
+  //   npm install @excalimate/mcp-server@latest --save-dev
+  //
+  // Then dynamically import and run:
+  //
+  // const pub = await import('@excalimate/mcp-server');
+  // const pubResults = await runWithServer(pub.createServer, ...);
+  // console.log(formatComparison('Published', pubResults, 'Dev', devBatch));
+}
+
+main().catch((err) => {
+  console.error('Regression benchmark failed:', err);
+  process.exit(1);
+});

--- a/mcp-server/bench/run.ts
+++ b/mcp-server/bench/run.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env tsx
+/**
+ * MCP Server Benchmark Runner
+ *
+ * Usage:
+ *   npx tsx bench/run.ts                          # Run all scenarios, all sizes
+ *   npx tsx bench/run.ts --scenario composite      # Specific scenario
+ *   npx tsx bench/run.ts --size medium             # Specific size
+ *   npx tsx bench/run.ts --json                    # JSON output
+ *   npx tsx bench/run.ts --iterations 5            # Multiple iterations
+ */
+import { ALL_SCENES, type SceneSize } from './fixtures/scenes.js';
+import { runIndividualTools } from './scenarios/individual-tools.bench.js';
+import { runBatchTools } from './scenarios/batch-tools.bench.js';
+import { runCompositeTool } from './scenarios/composite-tool.bench.js';
+import { runBandwidthComparison, formatBandwidthReport } from './scenarios/sse-bandwidth.bench.js';
+import { formatTable, formatMarkdownReport, type BenchmarkResult } from './harness/metrics.js';
+
+const args = process.argv.slice(2);
+const flagValue = (flag: string): string | undefined => {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
+};
+const hasFlag = (flag: string) => args.includes(flag);
+
+const jsonOutput = hasFlag('--json');
+const markdownOutput = hasFlag('--markdown');
+const outputFile = flagValue('--output');
+const scenarioFilter = flagValue('--scenario');
+const sizeFilter = flagValue('--size') as SceneSize | undefined;
+const iterations = parseInt(flagValue('--iterations') ?? '1', 10);
+const bandwidthMode = hasFlag('--bandwidth');
+
+const scenarios: Record<string, (scene: typeof ALL_SCENES[SceneSize], size: string) => Promise<BenchmarkResult>> = {
+  individual: runIndividualTools,
+  batch: runBatchTools,
+  composite: runCompositeTool,
+};
+
+async function main() {
+  const sizes = sizeFilter ? [sizeFilter] : (Object.keys(ALL_SCENES) as SceneSize[]);
+  const scenarioNames = scenarioFilter ? [scenarioFilter] : Object.keys(scenarios);
+  const allResults: BenchmarkResult[] = [];
+
+  if (bandwidthMode) {
+    const comparisons = [];
+    for (const size of sizes) {
+      if (!jsonOutput) process.stdout.write(`Bandwidth: ${size}...`);
+      const c = await runBandwidthComparison(ALL_SCENES[size], size);
+      comparisons.push(c);
+      if (!jsonOutput) process.stdout.write(' done\n');
+    }
+    if (jsonOutput) {
+      console.log(JSON.stringify(comparisons, null, 2));
+    } else {
+      console.log(formatBandwidthReport(comparisons));
+    }
+    return;
+  }
+
+  for (const name of scenarioNames) {
+    const runner = scenarios[name];
+    if (!runner) {
+      console.error(`Unknown scenario: ${name}`);
+      continue;
+    }
+
+    for (const size of sizes) {
+      for (let iter = 0; iter < iterations; iter++) {
+        if (!jsonOutput) {
+          const iterLabel = iterations > 1 ? ` [${iter + 1}/${iterations}]` : '';
+          process.stdout.write(`${name} / ${size}${iterLabel}...`);
+        }
+
+        const result = await runner(ALL_SCENES[size], size);
+        allResults.push(result);
+
+        if (!jsonOutput && !markdownOutput) {
+          process.stdout.write(` ${result.totalTimeMs.toFixed(1)}ms, ${result.sseMessageCount} SSE msgs, ${(result.sseGzipBytes / 1024).toFixed(1)}KB\n`);
+        }
+      }
+    }
+  }
+
+  // Generate output
+  let output: string;
+  if (jsonOutput) {
+    output = JSON.stringify(allResults, null, 2);
+  } else if (markdownOutput) {
+    output = formatMarkdownReport(allResults);
+  } else {
+    output = '\n' + formatTable(allResults);
+  }
+
+  // Write to file or stdout
+  if (outputFile) {
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(outputFile, output, 'utf8');
+    if (!jsonOutput && !markdownOutput) console.log(output);
+    console.log(`\nResults written to ${outputFile}`);
+  } else {
+    console.log(output);
+  }
+
+  // Also write to $GITHUB_STEP_SUMMARY if running in GitHub Actions
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import('node:fs');
+    const md = markdownOutput ? output : formatMarkdownReport(allResults);
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, md, 'utf8');
+  }
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/mcp-server/bench/scenarios/batch-tools.bench.ts
+++ b/mcp-server/bench/scenarios/batch-tools.bench.ts
@@ -1,0 +1,41 @@
+/**
+ * Scenario B: Batch Tools
+ * create_scene + add_keyframes_batch + set_clip_range + set_camera_frame
+ */
+import type { FixtureScene } from '../fixtures/generator.js';
+import { McpTestClient } from '../harness/McpTestClient.js';
+import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
+import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
+import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
+import { getSharedState } from '../../src/server/stateContext.js';
+
+export async function runBatchTools(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
+  const store = new MemoryCheckpointStore();
+  const monitor = new SseTrafficMonitor();
+  const client = await McpTestClient.create(store, monitor.createListener());
+
+  const calls: { name: string; args: Record<string, unknown> }[] = [
+    { name: 'create_scene', args: { elements: JSON.stringify(scene.elements) } },
+    { name: 'add_keyframes_batch', args: { keyframes: JSON.stringify(scene.keyframes) } },
+    { name: 'set_clip_range', args: { start: 0, end: scene.clipEnd } },
+    { name: 'set_camera_frame', args: scene.cameraFrame },
+  ];
+
+  const { totalDurationMs, results } = await client.callToolSequence(calls);
+  await new Promise(r => setTimeout(r, 100));
+
+  const state = getSharedState();
+  const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
+
+  const metrics = collectMetrics(
+    'batch',
+    sceneSize,
+    results,
+    totalDurationMs,
+    monitor.report(),
+    { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+  );
+
+  await client.close();
+  return metrics;
+}

--- a/mcp-server/bench/scenarios/composite-tool.bench.ts
+++ b/mcp-server/bench/scenarios/composite-tool.bench.ts
@@ -1,0 +1,47 @@
+/**
+ * Scenario C: Composite Tool
+ * Single create_animated_scene call with all data.
+ */
+import type { FixtureScene } from '../fixtures/generator.js';
+import { McpTestClient } from '../harness/McpTestClient.js';
+import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
+import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
+import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
+import { getSharedState } from '../../src/server/stateContext.js';
+
+export async function runCompositeTool(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
+  const store = new MemoryCheckpointStore();
+  const monitor = new SseTrafficMonitor();
+  const client = await McpTestClient.create(store, monitor.createListener());
+
+  const args: Record<string, unknown> = {
+    elements: JSON.stringify(scene.elements),
+    keyframes: JSON.stringify(scene.keyframes),
+    clipEnd: scene.clipEnd,
+    cameraFrame: scene.cameraFrame,
+  };
+  if (scene.sequences.length > 0) {
+    args.sequences = JSON.stringify(scene.sequences);
+  }
+
+  const start = performance.now();
+  const result = await client.callTool('create_animated_scene', args);
+  const totalDurationMs = performance.now() - start;
+
+  await new Promise(r => setTimeout(r, 100));
+
+  const state = getSharedState();
+  const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
+
+  const metrics = collectMetrics(
+    'composite',
+    sceneSize,
+    [result],
+    totalDurationMs,
+    monitor.report(),
+    { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+  );
+
+  await client.close();
+  return metrics;
+}

--- a/mcp-server/bench/scenarios/individual-tools.bench.ts
+++ b/mcp-server/bench/scenarios/individual-tools.bench.ts
@@ -1,0 +1,60 @@
+/**
+ * Scenario A: Individual Tools (baseline)
+ * Old workflow — create_scene + N × add_keyframe + set_clip_range + set_camera_frame
+ */
+import type { FixtureScene } from '../fixtures/generator.js';
+import { McpTestClient } from '../harness/McpTestClient.js';
+import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
+import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
+import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
+import { getSharedState } from '../../src/server/stateContext.js';
+
+export async function runIndividualTools(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
+  const store = new MemoryCheckpointStore();
+  const monitor = new SseTrafficMonitor();
+  const client = await McpTestClient.create(store, monitor.createListener());
+
+  const calls: { name: string; args: Record<string, unknown> }[] = [];
+
+  // 1. create_scene
+  calls.push({ name: 'create_scene', args: { elements: JSON.stringify(scene.elements) } });
+
+  // 2. Individual keyframes
+  for (const kf of scene.keyframes) {
+    calls.push({
+      name: 'add_keyframe',
+      args: {
+        targetId: kf.targetId,
+        property: kf.property,
+        time: kf.time,
+        value: kf.value,
+        ...(kf.easing ? { easing: kf.easing } : {}),
+      },
+    });
+  }
+
+  // 3. set_clip_range
+  calls.push({ name: 'set_clip_range', args: { start: 0, end: scene.clipEnd } });
+
+  // 4. set_camera_frame
+  calls.push({ name: 'set_camera_frame', args: scene.cameraFrame });
+
+  // Wait for SSE debounce to flush
+  const { totalDurationMs, results } = await client.callToolSequence(calls);
+  await new Promise(r => setTimeout(r, 100));
+
+  const state = getSharedState();
+  const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
+
+  const metrics = collectMetrics(
+    'individual',
+    sceneSize,
+    results,
+    totalDurationMs,
+    monitor.report(),
+    { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+  );
+
+  await client.close();
+  return metrics;
+}

--- a/mcp-server/bench/scenarios/sse-bandwidth.bench.ts
+++ b/mcp-server/bench/scenarios/sse-bandwidth.bench.ts
@@ -1,0 +1,49 @@
+/**
+ * Scenario D: SSE Bandwidth Measurement
+ * Runs all three scenarios for a given scene size and compares SSE traffic.
+ */
+import type { FixtureScene } from '../fixtures/generator.js';
+import { runIndividualTools } from './individual-tools.bench.js';
+import { runBatchTools } from './batch-tools.bench.js';
+import { runCompositeTool } from './composite-tool.bench.js';
+import type { BenchmarkResult } from '../harness/metrics.js';
+
+export interface BandwidthComparison {
+  sceneSize: string;
+  individual: BenchmarkResult;
+  batch: BenchmarkResult;
+  composite: BenchmarkResult;
+}
+
+export async function runBandwidthComparison(
+  scene: FixtureScene,
+  sceneSize: string,
+): Promise<BandwidthComparison> {
+  const individual = await runIndividualTools(scene, sceneSize);
+  const batch = await runBatchTools(scene, sceneSize);
+  const composite = await runCompositeTool(scene, sceneSize);
+  return { sceneSize, individual, batch, composite };
+}
+
+export function formatBandwidthReport(comparisons: BandwidthComparison[]): string {
+  const lines: string[] = ['', '=== SSE Bandwidth Comparison ===', ''];
+
+  for (const c of comparisons) {
+    lines.push(`--- ${c.sceneSize} ---`);
+    lines.push(
+      `${''.padEnd(14)} ${'Calls'.padStart(6)} ${'SSE Msgs'.padStart(9)} ${'Raw(KB)'.padStart(10)} ${'Gzip(KB)'.padStart(10)} ${'Time(ms)'.padStart(10)}`,
+    );
+    for (const [label, r] of [
+      ['Individual', c.individual],
+      ['Batch', c.batch],
+      ['Composite', c.composite],
+    ] as const) {
+      lines.push(
+        `${label.padEnd(14)} ${String(r.toolCalls).padStart(6)} ${String(r.sseMessageCount).padStart(9)} ${(r.sseRawBytes / 1024).toFixed(1).padStart(10)} ${(r.sseGzipBytes / 1024).toFixed(1).padStart(10)} ${r.totalTimeMs.toFixed(1).padStart(10)}`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -30,7 +30,9 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "bench": "tsx bench/run.ts",
+    "bench:json": "tsx bench/run.ts --json"
   },
   "publishConfig": {
     "access": "public",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalimate/mcp-server",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Excalimate MCP server for creating Excalidraw designs and animating them with keyframes",
   "keywords": [

--- a/mcp-server/src/httpServer.ts
+++ b/mcp-server/src/httpServer.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import type { Request, Response } from 'express';
-import { getSharedState } from './server.js';
+import { getSharedStateJSON } from './server.js';
 
 function getCorsOrigin() {
   const raw = process.env.CORS_ORIGIN;
@@ -170,9 +170,10 @@ export async function startHTTPServer(
     req.on('close', () => sseClients.delete(res));
   });
 
-  // Current state endpoint
+  // Current state endpoint — serves cached JSON to avoid re-serialization
   app.get('/state', (_req: Request, res: Response) => {
-    res.json(getSharedState());
+    res.setHeader('Content-Type', 'application/json');
+    res.send(getSharedStateJSON());
   });
 
   const httpServer = app.listen(port, () => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,6 +3,10 @@ import { FileCheckpointStore } from './checkpoint-store.js';
 import { createServer } from './server.js';
 import { startStdioServer } from './stdioServer.js';
 import { startHTTPServer } from './httpServer.js';
+import { gzip } from 'node:zlib';
+import { promisify } from 'node:util';
+
+const gzipAsync = promisify(gzip);
 
 /** Parse --port=NNNN or --port NNNN from argv */
 function parsePort(): number | undefined {
@@ -37,11 +41,16 @@ async function main() {
   } else {
     await startHTTPServer((_sseClients, broadcastSSE) => {
       return createServer(store, (delta) => {
-        try {
-          const data = JSON.stringify({ type: 'state', state: delta });
-          broadcastSSE(data);
-        } catch (err) {
-          console.error('Failed to broadcast state:', err);
+        const json = JSON.stringify({ type: 'state', state: delta });
+        // Compress payloads >512 bytes with gzip+base64 to reduce SSE bandwidth.
+        // Small payloads aren't worth the overhead.
+        if (json.length > 512) {
+          gzipAsync(json).then(
+            (buf) => broadcastSSE(JSON.stringify({ type: 'gz', data: buf.toString('base64') })),
+            (err) => console.error('Failed to compress broadcast:', err),
+          );
+        } else {
+          broadcastSSE(json);
         }
       });
     }, cliPort);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -10,14 +10,15 @@ import { getElementBounds } from './server/geometry.js';
 import * as geometry from './server/geometry.js';
 import { registerAnimationTools } from './server/animationTools.js';
 import { registerCheckpointTools } from './server/checkpointTools.js';
+import { registerCompositeTools } from './server/compositeTools.js';
 import { registerQueryTools } from './server/queryTools.js';
 import { registerShareTools } from './server/shareTools.js';
 import { REFERENCE_TEXT, EXAMPLES_TEXT } from './server/referenceText.js';
 import { registerSceneTools } from './server/sceneTools.js';
-import { createStateContext, getSharedState } from './server/stateContext.js';
+import { createStateContext, getSharedState, getSharedStateJSON, getSceneElementsJSON, getTimelineJSON } from './server/stateContext.js';
 import type { StateChangeListener } from './server/stateContext.js';
 
-export { getSharedState };
+export { getSharedState, getSharedStateJSON, getSceneElementsJSON, getTimelineJSON };
 export type { StateChangeListener } from './server/stateContext.js';
 
 export function createServer(
@@ -43,6 +44,7 @@ export function createServer(
 
   registerSceneTools(server, ctx, normalizeElements);
   registerAnimationTools(server, ctx, getElementBounds);
+  registerCompositeTools(server, ctx, normalizeElements, getElementBounds);
   registerQueryTools(server, ctx, geometry);
   registerCheckpointTools(server, ctx, store);
   registerShareTools(server, ctx);

--- a/mcp-server/src/server/animationTools.ts
+++ b/mcp-server/src/server/animationTools.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { addKeyframeToState } from '../state.js';
+import { addKeyframeToState, addKeyframesBatchToState } from '../state.js';
 import type { AnimatableProperty, EasingType } from '../types.js';
 import { ANIMATABLE_PROPERTIES, EASING_TYPES } from '../types.js';
 import { ORIGIN_MAP } from './geometry.js';
 import type { StateContext } from './stateContext.js';
+import { getTimelineJSON } from './stateContext.js';
 
 export function registerAnimationTools(
   server: McpServer,
@@ -40,6 +41,11 @@ export function registerAnimationTools(
         const parsed = JSON.parse(keyframes);
         if (!Array.isArray(parsed)) return { content: [{ type: 'text', text: 'Error: must be array' }] };
 
+        const validProperties = new Set<string>(ANIMATABLE_PROPERTIES);
+        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
+        let skipped = 0;
+
+        // Collect scale origin compensation data
         const scaleCompensation = new Map<string, { targetId: string; time: number; sx: number; sy: number; origin: string; easing: string }>();
         for (const kf of parsed) {
           if ((kf.property === 'scaleX' || kf.property === 'scaleY') && kf.scaleOrigin && kf.scaleOrigin !== 'top-left') {
@@ -52,32 +58,31 @@ export function registerAnimationTools(
           }
         }
 
-        const validProperties = new Set(ANIMATABLE_PROPERTIES);
-        let count = 0;
-        let skipped = 0;
+        // Collect valid keyframes
         for (const kf of parsed) {
           if (!validProperties.has(kf.property)) { skipped++; continue; }
-          const state = ctx.getState();
-          ctx.updateState(addKeyframeToState(state, kf.targetId, kf.property, kf.time, kf.value, kf.easing ?? 'linear'));
-          count++;
+          batch.push({ targetId: kf.targetId, property: kf.property, time: kf.time, value: kf.value, easing: kf.easing ?? 'linear' });
         }
 
+        // Compute scale origin compensation keyframes
+        const state = ctx.getState();
         for (const skf of scaleCompensation.values()) {
           const [ox, oy] = ORIGIN_MAP[skf.origin] ?? [0.5, 0.5];
-          const state = ctx.getState();
           const el = state.scene.elements.find((e: any) => e.id === skf.targetId);
           if (!el) continue;
           const bounds = getElementBounds(el);
           const w = bounds.maxX - bounds.minX;
           const h = bounds.maxY - bounds.minY;
-          const tx = -w * (skf.sx - 1) * ox;
-          const ty = -h * (skf.sy - 1) * oy;
-          ctx.updateState(addKeyframeToState(state, skf.targetId, 'translateX', skf.time, tx, skf.easing as EasingType));
-          const updated = ctx.getState();
-          ctx.updateState(addKeyframeToState(updated, skf.targetId, 'translateY', skf.time, ty, skf.easing as EasingType));
-          count += 2;
+          batch.push(
+            { targetId: skf.targetId, property: 'translateX', time: skf.time, value: -w * (skf.sx - 1) * ox, easing: skf.easing as EasingType },
+            { targetId: skf.targetId, property: 'translateY', time: skf.time, value: -h * (skf.sy - 1) * oy, easing: skf.easing as EasingType },
+          );
         }
 
+        // Apply all keyframes in one pass
+        ctx.updateState(addKeyframesBatchToState(state, batch));
+
+        const count = batch.length;
         return { content: [{ type: 'text', text: `Added ${count} keyframes.${skipped ? ` Skipped ${skipped} with invalid properties.` : ''}` }] };
       } catch (e) {
         return { content: [{ type: 'text', text: `Error: ${e}` }] };
@@ -113,22 +118,22 @@ export function registerAnimationTools(
       duration: z.number().min(50).default(500).describe('Duration of each reveal (ms)'),
     },
     async ({ elementIds, property, startTime, delay, duration }) => {
+      const prop = property as AnimatableProperty;
+      const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
+
       for (let i = 0; i < elementIds.length; i++) {
         const revealStart = startTime + i * delay;
         const revealEnd = revealStart + duration;
         const targetId = elementIds[i];
 
-        if (revealStart > 0) {
-          const state = ctx.getState();
-          ctx.updateState(addKeyframeToState(state, targetId, property as AnimatableProperty, 0, 0));
-        }
-        if (revealStart > 10) {
-          const state = ctx.getState();
-          ctx.updateState(addKeyframeToState(state, targetId, property as AnimatableProperty, revealStart, 0));
-        }
-        const state = ctx.getState();
-        ctx.updateState(addKeyframeToState(state, targetId, property as AnimatableProperty, revealEnd, 1, 'easeOut'));
+        if (revealStart > 0) batch.push({ targetId, property: prop, time: 0, value: 0 });
+        if (revealStart > 10) batch.push({ targetId, property: prop, time: revealStart, value: 0 });
+        batch.push({ targetId, property: prop, time: revealEnd, value: 1, easing: 'easeOut' });
       }
+
+      const state = ctx.getState();
+      ctx.updateState(addKeyframesBatchToState(state, batch));
+
       const totalDuration = startTime + (elementIds.length - 1) * delay + duration;
       return { content: [{ type: 'text', text: `Sequence created: ${elementIds.length} elements, total ${totalDuration}ms.` }] };
     },
@@ -153,20 +158,9 @@ export function registerAnimationTools(
     'get_timeline',
     'Return the current animation timeline as JSON.',
     {},
-    async () => {
-      const state = ctx.getState();
-      return {
-        content: [{
-          type: 'text' as const,
-          text: JSON.stringify({
-            timeline: state.timeline,
-            clipStart: state.clipStart,
-            clipEnd: state.clipEnd,
-            cameraFrame: state.cameraFrame,
-          }, null, 2),
-        }],
-      };
-    },
+    async () => ({
+      content: [{ type: 'text' as const, text: getTimelineJSON() }],
+    }),
   );
 
   ctx.mutatingTool(
@@ -202,31 +196,29 @@ export function registerAnimationTools(
         const h = bounds.maxY - bounds.minY;
         const [ox, oy] = ORIGIN_MAP[origin] ?? [0.5, 0.5];
 
-        let count = 0;
+        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
         for (const kf of parsed) {
           const sx = kf.scaleX ?? 1;
           const sy = kf.scaleY ?? 1;
-          const easing = kf.easing ?? 'linear';
+          const easing = (kf.easing ?? 'linear') as EasingType;
 
-          let currentState = ctx.getState();
-          ctx.updateState(addKeyframeToState(currentState, targetId, 'scaleX', kf.time, sx, easing as EasingType));
-          currentState = ctx.getState();
-          ctx.updateState(addKeyframeToState(currentState, targetId, 'scaleY', kf.time, sy, easing as EasingType));
+          batch.push(
+            { targetId, property: 'scaleX', time: kf.time, value: sx, easing },
+            { targetId, property: 'scaleY', time: kf.time, value: sy, easing },
+          );
 
           const tx = -w * (sx - 1) * ox;
           const ty = -h * (sy - 1) * oy;
-
           if (Math.abs(tx) > 0.1 || Math.abs(ty) > 0.1 || ox !== 0 || oy !== 0) {
-            currentState = ctx.getState();
-            ctx.updateState(addKeyframeToState(currentState, targetId, 'translateX', kf.time, tx, easing as EasingType));
-            currentState = ctx.getState();
-            ctx.updateState(addKeyframeToState(currentState, targetId, 'translateY', kf.time, ty, easing as EasingType));
+            batch.push(
+              { targetId, property: 'translateX', time: kf.time, value: tx, easing },
+              { targetId, property: 'translateY', time: kf.time, value: ty, easing },
+            );
           }
-
-          count++;
         }
 
-        return { content: [{ type: 'text', text: `Added ${count} scale keyframes with origin "${origin}" for "${targetId}".` }] };
+        ctx.updateState(addKeyframesBatchToState(state, batch));
+        return { content: [{ type: 'text', text: `Added ${parsed.length} scale keyframes with origin "${origin}" for "${targetId}".` }] };
       } catch (e) {
         return { content: [{ type: 'text', text: `Error: ${e}` }] };
       }
@@ -250,14 +242,12 @@ export function registerAnimationTools(
       if (aspectRatio !== undefined) state.cameraFrame.aspectRatio = aspectRatio;
 
       const CAMERA_ID = '__camera_frame__';
-      let currentState = ctx.getState();
-      ctx.updateState(addKeyframeToState(currentState, CAMERA_ID, 'translateX', 0, 0));
-      currentState = ctx.getState();
-      ctx.updateState(addKeyframeToState(currentState, CAMERA_ID, 'translateY', 0, 0));
-      currentState = ctx.getState();
-      ctx.updateState(addKeyframeToState(currentState, CAMERA_ID, 'scaleX', 0, 1));
-      currentState = ctx.getState();
-      ctx.updateState(addKeyframeToState(currentState, CAMERA_ID, 'scaleY', 0, 1));
+      ctx.updateState(addKeyframesBatchToState(state, [
+        { targetId: CAMERA_ID, property: 'translateX', time: 0, value: 0 },
+        { targetId: CAMERA_ID, property: 'translateY', time: 0, value: 0 },
+        { targetId: CAMERA_ID, property: 'scaleX', time: 0, value: 1 },
+        { targetId: CAMERA_ID, property: 'scaleY', time: 0, value: 1 },
+      ]));
 
       const updated = ctx.getState();
       return { content: [{ type: 'text', text: `Camera: ${updated.cameraFrame.aspectRatio} at (${updated.cameraFrame.x}, ${updated.cameraFrame.y}), width ${updated.cameraFrame.width}. Initial keyframes created at t=0.` }] };
@@ -301,17 +291,20 @@ export function registerAnimationTools(
           zoom: 'scaleX',
           scale: 'scaleX',
         };
-        let count = 0;
+
+        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
         let skipped = 0;
         for (const kf of parsed) {
           let prop = kf.property;
           if (propMap[prop]) prop = propMap[prop];
           if (!validCameraProps.has(prop)) { skipped++; continue; }
-          const state = ctx.getState();
-          ctx.updateState(addKeyframeToState(state, CAMERA_ID, prop as AnimatableProperty, kf.time, kf.value, (kf.easing as EasingType) ?? 'linear'));
-          count++;
+          batch.push({ targetId: CAMERA_ID, property: prop as AnimatableProperty, time: kf.time, value: kf.value, easing: (kf.easing as EasingType) ?? 'linear' });
         }
-        return { content: [{ type: 'text', text: `Added ${count} camera keyframes.${skipped ? ` Skipped ${skipped} with invalid properties (use translateX, translateY, scaleX, scaleY).` : ''}` }] };
+
+        const state = ctx.getState();
+        ctx.updateState(addKeyframesBatchToState(state, batch));
+
+        return { content: [{ type: 'text', text: `Added ${batch.length} camera keyframes.${skipped ? ` Skipped ${skipped} with invalid properties (use translateX, translateY, scaleX, scaleY).` : ''}` }] };
       } catch (e) {
         return { content: [{ type: 'text', text: `Error: ${e}` }] };
       }

--- a/mcp-server/src/server/compositeTools.ts
+++ b/mcp-server/src/server/compositeTools.ts
@@ -1,0 +1,239 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { addKeyframesBatchToState } from '../state.js';
+import type { AnimatableProperty, EasingType } from '../types.js';
+import { ANIMATABLE_PROPERTIES, EASING_TYPES } from '../types.js';
+import { ORIGIN_MAP } from './geometry.js';
+import type { StateContext } from './stateContext.js';
+
+/**
+ * Registers the `create_animated_scene` composite tool.
+ *
+ * This is a high-level tool that replaces the typical multi-call pattern:
+ *   create_scene → add_keyframes_batch → create_sequence → set_clip_range → set_camera_frame
+ *
+ * All operations happen in a single tool call with one SSE broadcast at the end,
+ * reducing AI round-trips from 5-18 to 1 and minimizing network traffic.
+ */
+export function registerCompositeTools(
+  server: McpServer,
+  ctx: StateContext,
+  normalizeElements: (elements: any[]) => any[],
+  getElementBounds: (el: any) => { minX: number; minY: number; maxX: number; maxY: number },
+): void {
+  ctx.mutatingTool(
+    'create_animated_scene',
+    'Create a complete animated scene in one call: elements + keyframes + sequences + camera + clip range. ' +
+    'Preferred over calling create_scene, add_keyframes_batch, create_sequence separately. ' +
+    'Only elements is required — all other fields are optional.',
+    {
+      elements: z.string().describe(
+        'JSON string of Excalidraw elements array',
+      ),
+      keyframes: z.string().optional().describe(
+        'JSON array of {targetId, property, time, value, easing?, scaleOrigin?}. ' +
+        'Properties: opacity, translateX, translateY, scaleX, scaleY, rotation, drawProgress.',
+      ),
+      sequences: z.string().optional().describe(
+        'JSON array of {elementIds: string[], property?: "opacity"|"drawProgress", ' +
+        'startTime?: number, delay?: number, duration?: number}. Creates reveal sequences.',
+      ),
+      duration: z.number().optional().describe('Timeline duration in ms (default: 30000)'),
+      clipStart: z.number().optional().describe('Clip start time in ms (default: 0)'),
+      clipEnd: z.number().optional().describe('Clip end time in ms'),
+      cameraFrame: z.object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+        width: z.number().optional(),
+        aspectRatio: z.enum(['16:9', '4:3', '1:1', '3:2']).optional(),
+      }).optional().describe('Camera frame position and size'),
+    },
+    async ({ elements, keyframes, sequences, duration, clipStart, clipEnd, cameraFrame }) => {
+      const errors: string[] = [];
+      const stats = { elements: 0, keyframes: 0, sequences: 0 };
+
+      // ── 1. Parse and create scene elements ───────────────
+      let parsedElements: any[];
+      try {
+        parsedElements = JSON.parse(elements);
+        if (!Array.isArray(parsedElements)) {
+          return { content: [{ type: 'text' as const, text: 'Error: elements must be a JSON array' }] };
+        }
+      } catch (e) {
+        return { content: [{ type: 'text' as const, text: `Error parsing elements: ${e}` }] };
+      }
+
+      const state = ctx.getState();
+      state.scene.elements = normalizeElements(parsedElements);
+      stats.elements = parsedElements.length;
+
+      // ── 2. Set timeline duration ─────────────────────────
+      if (duration !== undefined) {
+        state.timeline.duration = Math.max(1000, duration);
+      }
+
+      // ── 3. Camera frame ──────────────────────────────────
+      if (cameraFrame) {
+        if (cameraFrame.x !== undefined) state.cameraFrame.x = cameraFrame.x;
+        if (cameraFrame.y !== undefined) state.cameraFrame.y = cameraFrame.y;
+        if (cameraFrame.width !== undefined) state.cameraFrame.width = cameraFrame.width;
+        if (cameraFrame.aspectRatio !== undefined) state.cameraFrame.aspectRatio = cameraFrame.aspectRatio;
+      }
+
+      // ── 4. Collect all keyframes into a single batch ─────
+      const allKeyframes: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
+      const validProperties = new Set<string>(ANIMATABLE_PROPERTIES);
+      const validEasings = new Set<string>(EASING_TYPES);
+
+      // 4a. Camera initial keyframes (always create at t=0 so camera starts correctly)
+      if (cameraFrame) {
+        const CAMERA_ID = '__camera_frame__';
+        allKeyframes.push(
+          { targetId: CAMERA_ID, property: 'translateX', time: 0, value: 0 },
+          { targetId: CAMERA_ID, property: 'translateY', time: 0, value: 0 },
+          { targetId: CAMERA_ID, property: 'scaleX', time: 0, value: 1 },
+          { targetId: CAMERA_ID, property: 'scaleY', time: 0, value: 1 },
+        );
+      }
+
+      // 4b. User-supplied keyframes
+      if (keyframes) {
+        try {
+          const parsedKfs = JSON.parse(keyframes);
+          if (!Array.isArray(parsedKfs)) {
+            errors.push('keyframes must be a JSON array — skipped');
+          } else {
+            // Pre-process scale compensation (same logic as add_keyframes_batch)
+            const scaleCompensation = new Map<string, { targetId: string; time: number; sx: number; sy: number; origin: string; easing: string }>();
+
+            for (const kf of parsedKfs) {
+              if (!kf.targetId || !kf.property || kf.time === undefined || kf.value === undefined) continue;
+              if (!validProperties.has(kf.property)) continue;
+
+              // Collect scale origin compensation data
+              if ((kf.property === 'scaleX' || kf.property === 'scaleY') && kf.scaleOrigin && kf.scaleOrigin !== 'top-left') {
+                const key = `${kf.targetId}@${kf.time}`;
+                const existing = scaleCompensation.get(key) ?? {
+                  targetId: kf.targetId, time: kf.time, sx: 1, sy: 1,
+                  origin: kf.scaleOrigin, easing: kf.easing ?? 'linear',
+                };
+                if (kf.property === 'scaleX') existing.sx = kf.value;
+                if (kf.property === 'scaleY') existing.sy = kf.value;
+                existing.origin = kf.scaleOrigin;
+                scaleCompensation.set(key, existing);
+              }
+
+              const easing = (kf.easing && validEasings.has(kf.easing)) ? kf.easing : 'linear';
+              allKeyframes.push({
+                targetId: kf.targetId,
+                property: kf.property as AnimatableProperty,
+                time: kf.time,
+                value: kf.value,
+                easing: easing as EasingType,
+              });
+              stats.keyframes++;
+            }
+
+            // Compute scale origin translation compensation
+            for (const skf of scaleCompensation.values()) {
+              const [ox, oy] = ORIGIN_MAP[skf.origin] ?? [0.5, 0.5];
+              const el = state.scene.elements.find((e: any) => e.id === skf.targetId);
+              if (!el) continue;
+              const bounds = getElementBounds(el);
+              const w = bounds.maxX - bounds.minX;
+              const h = bounds.maxY - bounds.minY;
+              const tx = -w * (skf.sx - 1) * ox;
+              const ty = -h * (skf.sy - 1) * oy;
+              const easing = (validEasings.has(skf.easing) ? skf.easing : 'linear') as EasingType;
+              allKeyframes.push(
+                { targetId: skf.targetId, property: 'translateX', time: skf.time, value: tx, easing },
+                { targetId: skf.targetId, property: 'translateY', time: skf.time, value: ty, easing },
+              );
+              stats.keyframes += 2;
+            }
+          }
+        } catch (e) {
+          errors.push(`Error parsing keyframes: ${e}`);
+        }
+      }
+
+      // 4c. Sequence reveals → expand into keyframes
+      if (sequences) {
+        try {
+          const parsedSeqs = JSON.parse(sequences);
+          if (!Array.isArray(parsedSeqs)) {
+            errors.push('sequences must be a JSON array — skipped');
+          } else {
+            for (const seq of parsedSeqs) {
+              const ids = seq.elementIds;
+              if (!Array.isArray(ids) || ids.length === 0) continue;
+
+              const prop: AnimatableProperty = (seq.property === 'drawProgress') ? 'drawProgress' : 'opacity';
+              const startTime = seq.startTime ?? 0;
+              const delay = seq.delay ?? 300;
+              const dur = seq.duration ?? 500;
+
+              for (let i = 0; i < ids.length; i++) {
+                const revealStart = startTime + i * delay;
+                const revealEnd = revealStart + dur;
+                const targetId = ids[i];
+
+                if (revealStart > 0) {
+                  allKeyframes.push({ targetId, property: prop, time: 0, value: 0 });
+                }
+                if (revealStart > 10) {
+                  allKeyframes.push({ targetId, property: prop, time: revealStart, value: 0 });
+                }
+                allKeyframes.push({ targetId, property: prop, time: revealEnd, value: 1, easing: 'easeOut' });
+                stats.keyframes += (revealStart > 0 ? 1 : 0) + (revealStart > 10 ? 1 : 0) + 1;
+              }
+              stats.sequences++;
+            }
+          }
+        } catch (e) {
+          errors.push(`Error parsing sequences: ${e}`);
+        }
+      }
+
+      // ── 5. Apply all keyframes in one batched pass ───────
+      if (allKeyframes.length > 0) {
+        const newState = addKeyframesBatchToState(state, allKeyframes);
+        ctx.updateState(newState);
+      }
+
+      // ── 6. Clip range ────────────────────────────────────
+      const finalState = ctx.getState();
+      if (clipStart !== undefined) finalState.clipStart = clipStart;
+      if (clipEnd !== undefined) {
+        finalState.clipEnd = Math.max((clipStart ?? finalState.clipStart) + 100, clipEnd);
+      } else if (clipStart === undefined && stats.sequences > 0) {
+        // Auto-set clip end to match the last sequence keyframe
+        let maxTime = 0;
+        for (const kf of allKeyframes) {
+          if (kf.time > maxTime) maxTime = kf.time;
+        }
+        if (maxTime > 0) {
+          finalState.clipEnd = Math.max(finalState.clipEnd, maxTime + 500);
+        }
+      }
+
+      // ── 7. Build response ────────────────────────────────
+      const parts = [
+        `Scene: ${stats.elements} elements`,
+        stats.keyframes > 0 ? `${stats.keyframes} keyframes` : null,
+        stats.sequences > 0 ? `${stats.sequences} sequences` : null,
+        cameraFrame ? `camera: ${finalState.cameraFrame.aspectRatio} at (${finalState.cameraFrame.x}, ${finalState.cameraFrame.y})` : null,
+        `clip: ${finalState.clipStart}ms–${finalState.clipEnd}ms`,
+      ].filter(Boolean).join(', ');
+
+      const msg = errors.length > 0
+        ? `${parts}\nWarnings: ${errors.join('; ')}`
+        : parts;
+
+      return { content: [{ type: 'text' as const, text: msg }] };
+    },
+    // Mark all areas dirty — this tool touches everything
+    ['scene', 'timeline', 'clip', 'cameraFrame'],
+  );
+}

--- a/mcp-server/src/server/referenceText.ts
+++ b/mcp-server/src/server/referenceText.ts
@@ -1,269 +1,98 @@
-export const REFERENCE_TEXT = `# Excalimate MCP Reference
+export const REFERENCE_TEXT = `# Excalimate Reference
 
-## Excalidraw Element Format
+## Element Format (base properties)
+{ id, type, x, y, width, height, strokeColor, backgroundColor, fillStyle, strokeWidth, opacity, groupIds, angle }
 
-Every element has these base properties:
-\`\`\`json
-{
-  "id": "unique-id",
-  "type": "rectangle|ellipse|diamond|arrow|line|text|freedraw|image",
-  "x": 100, "y": 200,
-  "width": 300, "height": 150,
-  "angle": 0,
-  "strokeColor": "#1e1e1e",
-  "backgroundColor": "transparent",
-  "fillStyle": "solid",
-  "strokeWidth": 2,
-  "roughness": 1,
-  "opacity": 100,
-  "groupIds": [],
-  "isDeleted": false
-}
-\`\`\`
+Types: rectangle, ellipse, diamond, arrow, line, text, freedraw, image
 
-### Text Elements
-\`\`\`json
-{
-  "type": "text",
-  "text": "Hello World",
-  "fontSize": 20,
-  "fontFamily": 5,
-  "textAlign": "center",
-  "verticalAlign": "middle"
-}
-\`\`\`
+Text extra: { text, fontSize, fontFamily: 5, textAlign, verticalAlign }
+Arrow/Line extra: { points: [[0,0],[dx,dy]], endArrowhead: "arrow"|null }
+Bound text: text with containerId → shape with boundElements:[{id,type:"text"}]
 
-### Arrow/Line Elements
-\`\`\`json
-{
-  "type": "arrow",
-  "points": [[0, 0], [200, 100]],
-  "startArrowhead": null,
-  "endArrowhead": "arrow",
-  "startBinding": null,
-  "endBinding": null
-}
-\`\`\`
+## Colors
+Stroke: #1e1e1e #e03131 #2f9e44 #1971c2 #f08c00 #6741d9 #0c8599 #e8590c
+Fill: transparent #ffc9c9 #b2f2bb #a5d8ff #ffec99 #d0bfff #99e9f2 #ffd8a8
 
-### Bound Text (Label on Shape)
-Create a text element with \`containerId\` pointing to the shape:
-\`\`\`json
-{ "type": "text", "containerId": "shape-id", ... }
-\`\`\`
-And add to the shape: \`"boundElements": [{"id": "text-id", "type": "text"}]\`
+## Animation Properties
+opacity (0–1), translateX/Y (px), scaleX/Y (0.1+), rotation (deg), drawProgress (0–1, lines/arrows only)
 
-## Color Palettes
-
-**Stroke**: #1e1e1e, #e03131, #2f9e44, #1971c2, #f08c00, #6741d9, #0c8599, #e8590c
-**Background**: transparent, #ffc9c9, #b2f2bb, #a5d8ff, #ffec99, #d0bfff, #99e9f2, #ffd8a8
-
-## Animatable Properties
-
-| Property | Range | Description |
-|----------|-------|-------------|
-| opacity | 0–1 | Element visibility (0=hidden, 1=visible) |
-| translateX | px | Horizontal position offset |
-| translateY | px | Vertical position offset |
-| scaleX | 0.1+ | Horizontal scale (1=normal) |
-| scaleY | 0.1+ | Vertical scale (1=normal) |
-| rotation | degrees | Rotation angle |
-| drawProgress | 0–1 | Stroke draw-on progress (for lines/arrows) |
-
-## Easing Types
-
+## Easings
 linear, easeIn, easeOut, easeInOut, easeInQuad, easeOutQuad, easeInOutQuad,
 easeInCubic, easeOutCubic, easeInOutCubic, easeInBack, easeOutBack, easeInOutBack,
 easeInElastic, easeOutElastic, easeInBounce, easeOutBounce, step
 
-## Workflow
+## Preferred Workflow
+1. Use **create_animated_scene** — one call for elements + keyframes + sequences + camera + clip range
+2. Use add_keyframes_batch or create_sequence for incremental changes
+3. Use save_checkpoint to persist
+4. Verify with animations_of_item, items_visible_in_camera, is_camera_centered
 
-1. Call \`read_me\` (this tool) to get the reference
-2. Call \`create_scene\` with Excalidraw elements JSON (or \`clear_scene\` to start fresh)
-3. Call \`add_keyframe\` or \`add_keyframes_batch\` to animate elements
-4. Use \`create_sequence\` for reveal animations
-5. Call \`set_clip_range\` to set export bounds
-6. Call \`save_checkpoint\` to persist
-7. User opens the checkpoint in the Excalimate web app for preview/export
-
-Use \`clear_scene\` to reset everything (elements + animations) or \`clear_animation\` to keep elements but remove all keyframes.
-
-## Example: Fade-in Rectangle
-
-\`\`\`
-1. create_scene: [{"id":"rect1","type":"rectangle","x":100,"y":100,"width":200,"height":100,...}]
-2. add_keyframe: {targetId:"rect1", property:"opacity", time:0, value:0}
-3. add_keyframe: {targetId:"rect1", property:"opacity", time:1000, value:1, easing:"easeOut"}
-\`\`\`
+## Key Tips
+- Set opacity 0 at time 0 for elements that appear later
+- Bound text inherits container animation
+- drawProgress only works on arrows/lines
+- easeOutBack = nice bounce; easeInOutCubic = best general-purpose
+- Camera: scale > 1 = zoomed out, < 1 = zoomed in
+- Set clip range before saving
 `;
 
-export const EXAMPLES_TEXT = `# Excalimate — Few-Shot Examples
+// Use string concatenation for EXAMPLES_TEXT to avoid backtick escaping issues
+const CB = '```'; // code block delimiter
+export const EXAMPLES_TEXT = `# Excalimate Examples
 
-## Example 1: Single Rectangle
-\`\`\`
-create_scene({ elements: '[{"id":"box1","type":"rectangle","x":200,"y":150,"width":250,"height":120,"strokeColor":"#1971c2","backgroundColor":"#a5d8ff","fillStyle":"solid"}]' })
-\`\`\`
+## Complete Scene (preferred — one call)
+${CB}
+create_animated_scene({
+  elements: '[
+    {"id":"A","type":"rectangle","x":100,"y":200,"width":150,"height":80,"strokeColor":"#1e1e1e","backgroundColor":"#b2f2bb","fillStyle":"solid","boundElements":[{"id":"A-label","type":"text"}]},
+    {"id":"A-label","type":"text","x":120,"y":225,"width":110,"height":30,"text":"Service A","fontSize":20,"fontFamily":5,"textAlign":"center","verticalAlign":"middle","containerId":"A"},
+    {"id":"B","type":"rectangle","x":500,"y":200,"width":150,"height":80,"strokeColor":"#1e1e1e","backgroundColor":"#a5d8ff","fillStyle":"solid","boundElements":[{"id":"B-label","type":"text"}]},
+    {"id":"B-label","type":"text","x":520,"y":225,"width":110,"height":30,"text":"Service B","fontSize":20,"fontFamily":5,"textAlign":"center","verticalAlign":"middle","containerId":"B"},
+    {"id":"arrow1","type":"arrow","x":250,"y":240,"width":250,"height":0,"points":[[0,0],[250,0]],"endArrowhead":"arrow"}
+  ]',
+  keyframes: '[
+    {"targetId":"A","property":"opacity","time":0,"value":0},
+    {"targetId":"A","property":"opacity","time":600,"value":1,"easing":"easeOut"},
+    {"targetId":"arrow1","property":"opacity","time":0,"value":0},
+    {"targetId":"arrow1","property":"opacity","time":600,"value":0},
+    {"targetId":"arrow1","property":"opacity","time":700,"value":1},
+    {"targetId":"arrow1","property":"drawProgress","time":600,"value":0},
+    {"targetId":"arrow1","property":"drawProgress","time":1800,"value":1,"easing":"easeInOut"},
+    {"targetId":"B","property":"opacity","time":0,"value":0},
+    {"targetId":"B","property":"opacity","time":1800,"value":0},
+    {"targetId":"B","property":"opacity","time":2400,"value":1,"easing":"easeOut"}
+  ]',
+  clipEnd: 3000,
+  cameraFrame: { x: 375, y: 240, width: 800 }
+})
+${CB}
 
-## Example 2: Rectangle with Bound Text Label
-\`\`\`
-create_scene({ elements: '[{"id":"server","type":"rectangle","x":100,"y":100,"width":200,"height":80,"strokeColor":"#1e1e1e","backgroundColor":"#a5d8ff","fillStyle":"solid","boundElements":[{"id":"server-label","type":"text"}]},{"id":"server-label","type":"text","x":140,"y":125,"width":120,"height":30,"text":"API Server","fontSize":20,"fontFamily":5,"textAlign":"center","verticalAlign":"middle","containerId":"server"}]' })
-\`\`\`
+## Staggered Reveal (simpler alternative)
+${CB}
+create_animated_scene({
+  elements: '[...elements...]',
+  sequences: '[{"elementIds":["title","box1","arrow1","box2"],"delay":400,"duration":600}]',
+  clipEnd: 3500
+})
+${CB}
 
-## Example 3: Two Shapes Connected by Arrow
-\`\`\`
-create_scene({ elements: '[{"id":"A","type":"rectangle","x":100,"y":200,"width":150,"height":80,"strokeColor":"#1e1e1e","backgroundColor":"#b2f2bb","fillStyle":"solid"},{"id":"B","type":"rectangle","x":500,"y":200,"width":150,"height":80,"strokeColor":"#1e1e1e","backgroundColor":"#a5d8ff","fillStyle":"solid"},{"id":"arrow1","type":"arrow","x":250,"y":240,"width":250,"height":0,"points":[[0,0],[250,0]],"endArrowhead":"arrow","startBinding":{"elementId":"A","focus":0,"gap":1},"endBinding":{"elementId":"B","focus":0,"gap":1}}]' })
-\`\`\`
+## Scale Animation (pop-in from center)
+${CB}
+add_scale_animation({ targetId: "box1", origin: "center", keyframes: '[{"time":0,"scaleX":0.3,"scaleY":0.3},{"time":600,"scaleX":1,"scaleY":1,"easing":"easeOutBack"}]' })
+${CB}
+Origins: center, top-left, top-right, bottom-left, bottom-right, top, bottom, left, right
 
-## Example 4: Ellipse and Diamond
-\`\`\`
-add_elements({ elements: '[{"id":"circle1","type":"ellipse","x":300,"y":100,"width":120,"height":120,"strokeColor":"#e03131","backgroundColor":"#ffc9c9","fillStyle":"solid"},{"id":"diamond1","type":"diamond","x":500,"y":90,"width":140,"height":140,"strokeColor":"#6741d9","backgroundColor":"#d0bfff","fillStyle":"solid"}]' })
-\`\`\`
-
-## Example 5: Multi-Point Line
-\`\`\`
-add_elements({ elements: '[{"id":"line1","type":"line","x":100,"y":300,"width":400,"height":80,"points":[[0,0],[200,-80],[400,0]],"strokeColor":"#e03131","strokeWidth":3}]' })
-\`\`\`
-
-## Example 6: Standalone Text
-\`\`\`
-add_elements({ elements: '[{"id":"title","type":"text","x":200,"y":50,"width":300,"height":50,"text":"Architecture Overview","fontSize":36,"fontFamily":5,"textAlign":"center","strokeColor":"#1e1e1e"}]' })
-\`\`\`
-
----
-
-# Animation Examples
-
-## Example 7: Fade In
-\`\`\`
-add_keyframe({ targetId: "box1", property: "opacity", time: 0, value: 0 })
-add_keyframe({ targetId: "box1", property: "opacity", time: 800, value: 1, easing: "easeOut" })
-\`\`\`
-
-## Example 8: Slide In from Left
-\`\`\`
-add_keyframes_batch({ keyframes: '[{"targetId":"box1","property":"translateX","time":0,"value":-300},{"targetId":"box1","property":"translateX","time":1000,"value":0,"easing":"easeOutCubic"},{"targetId":"box1","property":"opacity","time":0,"value":0},{"targetId":"box1","property":"opacity","time":500,"value":1,"easing":"easeOut"}]' })
-\`\`\`
-
-## Example 9: Pop In from Center (Scale Up with Bounce)
-\`\`\`
-add_keyframes_batch({ keyframes: '[{"targetId":"box1","property":"scaleX","time":0,"value":0.3,"scaleOrigin":"center"},{"targetId":"box1","property":"scaleY","time":0,"value":0.3,"scaleOrigin":"center"},{"targetId":"box1","property":"scaleX","time":600,"value":1,"easing":"easeOutBack","scaleOrigin":"center"},{"targetId":"box1","property":"scaleY","time":600,"value":1,"easing":"easeOutBack","scaleOrigin":"center"},{"targetId":"box1","property":"opacity","time":0,"value":0},{"targetId":"box1","property":"opacity","time":300,"value":1}]' })
-\`\`\`
-
-## Example 9b: Scale from Bottom Edge
-\`\`\`
-add_scale_animation({ targetId: "box1", origin: "bottom", keyframes: '[{"time":0,"scaleX":1,"scaleY":0},{"time":800,"scaleX":1,"scaleY":1,"easing":"easeOutCubic"}]' })
-\`\`\`
-Scale origins: center, top-left, top-right, bottom-left, bottom-right, top, bottom, left, right.
-Add "scaleOrigin" per scaleX/scaleY keyframe in add_keyframes_batch, or use add_scale_animation for a single element.
-
-## Example 10: Draw In an Arrow (Stroke Animation)
-\`\`\`
-add_keyframe({ targetId: "arrow1", property: "drawProgress", time: 0, value: 0 })
-add_keyframe({ targetId: "arrow1", property: "drawProgress", time: 1200, value: 1, easing: "easeInOut" })
-\`\`\`
-
-## Example 11: Sequential Reveal — A → Arrow → B (Most Common Pattern)
-\`\`\`
-add_keyframes_batch({ keyframes: '[
-  {"targetId":"A","property":"opacity","time":0,"value":0},
-  {"targetId":"A","property":"opacity","time":600,"value":1,"easing":"easeOut"},
-  {"targetId":"arrow1","property":"opacity","time":0,"value":0},
-  {"targetId":"arrow1","property":"opacity","time":600,"value":0},
-  {"targetId":"arrow1","property":"opacity","time":700,"value":1},
-  {"targetId":"arrow1","property":"drawProgress","time":600,"value":0},
-  {"targetId":"arrow1","property":"drawProgress","time":1800,"value":1,"easing":"easeInOut"},
-  {"targetId":"B","property":"opacity","time":0,"value":0},
-  {"targetId":"B","property":"opacity","time":1800,"value":0},
-  {"targetId":"B","property":"opacity","time":2400,"value":1,"easing":"easeOut"}
+## Camera Pan + Zoom
+${CB}
+set_camera_frame({ x: 300, y: 200, width: 800 })
+add_camera_keyframes_batch({ keyframes: '[
+  {"property":"translateX","time":0,"value":-200},
+  {"property":"translateX","time":3000,"value":200,"easing":"easeInOut"},
+  {"property":"scaleX","time":0,"value":1.5},
+  {"property":"scaleY","time":0,"value":1.5},
+  {"property":"scaleX","time":3000,"value":1,"easing":"easeInOutCubic"},
+  {"property":"scaleY","time":3000,"value":1,"easing":"easeInOutCubic"}
 ]' })
-\`\`\`
-
-## Example 12: Bidirectional Flow — A ↔ B
-\`\`\`
-add_keyframes_batch({ keyframes: '[
-  {"targetId":"A","property":"opacity","time":0,"value":0},
-  {"targetId":"A","property":"opacity","time":500,"value":1,"easing":"easeOut"},
-  {"targetId":"arrowAB","property":"opacity","time":0,"value":0},
-  {"targetId":"arrowAB","property":"opacity","time":500,"value":1},
-  {"targetId":"arrowAB","property":"drawProgress","time":500,"value":0},
-  {"targetId":"arrowAB","property":"drawProgress","time":1500,"value":1,"easing":"easeInOut"},
-  {"targetId":"B","property":"opacity","time":0,"value":0},
-  {"targetId":"B","property":"opacity","time":1500,"value":0},
-  {"targetId":"B","property":"opacity","time":2000,"value":1,"easing":"easeOut"},
-  {"targetId":"arrowBA","property":"opacity","time":0,"value":0},
-  {"targetId":"arrowBA","property":"opacity","time":2000,"value":1},
-  {"targetId":"arrowBA","property":"drawProgress","time":2000,"value":0},
-  {"targetId":"arrowBA","property":"drawProgress","time":3000,"value":1,"easing":"easeInOut"}
-]' })
-\`\`\`
-
-## Example 13: Staggered Reveal via create_sequence
-\`\`\`
-create_sequence({ elementIds: ["title","box1","arrow1","box2","arrow2","box3"], property: "opacity", startTime: 0, delay: 400, duration: 600 })
-\`\`\`
-Result: title at 0ms, box1 at 400ms, arrow1 at 800ms, box2 at 1200ms, arrow2 at 1600ms, box3 at 2000ms.
-
-## Example 14: Camera Pan
-\`\`\`
-set_camera_frame({ x: 300, y: 200, width: 800, aspectRatio: "16:9" })
-add_camera_keyframe({ property: "translateX", time: 0, value: -200 })
-add_camera_keyframe({ property: "translateX", time: 3000, value: 200, easing: "easeInOut" })
-\`\`\`
-
-## Example 15: Camera Zoom In
-\`\`\`
-add_camera_keyframe({ property: "scaleX", time: 0, value: 2 })
-add_camera_keyframe({ property: "scaleY", time: 0, value: 2 })
-add_camera_keyframe({ property: "scaleX", time: 2000, value: 1, easing: "easeInOutCubic" })
-add_camera_keyframe({ property: "scaleY", time: 2000, value: 1, easing: "easeInOutCubic" })
-\`\`\`
-
-## Example 16: Clip Range + Save
-\`\`\`
-set_clip_range({ start: 0, end: 5000 })
-save_checkpoint({ id: "my-animation" })
-\`\`\`
-
----
-
-# Tips
-
-1. Always call create_scene first (or clear_scene to start fresh), then animate.
-2. Use add_keyframes_batch for efficiency — one call for many keyframes.
-3. Use create_sequence for simple staggered reveals.
-4. Bound text inherits container animation — animating arrow opacity also hides its label.
-5. drawProgress only works on arrows and lines.
-6. easeOutBack gives a nice bounce for pop-in effects.
-7. easeInOutCubic is the best general-purpose easing.
-8. Set elements to opacity 0 at time 0 if they should appear later.
-9. Set clip range before saving — it defines what gets exported.
-10. Camera scale > 1 = zoomed out, < 1 = zoomed in.
-11. Use delete_items to remove elements AND their animation tracks in one call.
-12. Verify your work with animations_of_item, items_visible_in_camera, are_items_in_line, is_camera_centered.
-
-## Example 17: Verify Animation
-\`\`\`
-animations_of_item({ targetId: "box1" })
-// Returns:
-//   opacity:
-//     0ms 0% ↑ 100% 600ms (easeOut)
-
-items_visible_in_camera({ time: 1000 })
-// Returns: 5/8 items visible (62%) at 1000ms
-
-are_items_in_line({ ids: ["box1","box2","box3"], axis: "horizontal" })
-// Returns: ✅ Aligned (max deviation: 3px)
-
-is_camera_centered({ axis: "both", time: 0 })
-// Returns: ✅ Centered (offsets: dx=5 dy=2)
-\`\`\`
-
-## Example 18: Delete and Rebuild
-\`\`\`
-delete_items({ ids: ["old_box", "old_arrow"] })
-// Removes elements + all their animation tracks
-
-clear_scene()
-// Nuclear option: removes everything
-\`\`\`
+${CB}
 `;
 

--- a/mcp-server/src/server/sceneTools.ts
+++ b/mcp-server/src/server/sceneTools.ts
@@ -2,6 +2,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { StateContext } from './stateContext.js';
+import { getSceneElementsJSON } from './stateContext.js';
 
 export function registerSceneTools(
   server: McpServer,
@@ -90,7 +91,7 @@ export function registerSceneTools(
     'Return the current scene elements as JSON.',
     {},
     async () => ({
-      content: [{ type: 'text' as const, text: JSON.stringify(ctx.getState().scene.elements, null, 2) }],
+      content: [{ type: 'text' as const, text: getSceneElementsJSON() }],
     }),
   );
 

--- a/mcp-server/src/server/stateContext.ts
+++ b/mcp-server/src/server/stateContext.ts
@@ -3,12 +3,80 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createDefaultState } from '../state.js';
 import type { ServerState } from '../types.js';
 
-export type StateChangeListener = (delta: Partial<ServerState>) => void;
+/**
+ * Delta message format sent over SSE.
+ * Instead of full state areas, we send fine-grained changes:
+ * - Scene: only added/updated/removed elements
+ * - Timeline: only upserted/removed tracks
+ * - Clip and cameraFrame: sent as-is (small payloads)
+ */
+export interface StateDelta {
+  scene?: {
+    /** Elements that were added or have changed properties */
+    upsert: any[];
+    /** Element IDs that were removed */
+    removed: string[];
+  };
+  timeline?: {
+    /** Tracks that were added or have changed keyframes */
+    upsertedTracks: any[];
+    /** Track IDs that were removed */
+    removedTrackIds: string[];
+    /** Timeline metadata (duration, fps) — only sent if changed */
+    meta?: { duration: number; fps: number };
+  };
+  clipStart?: number;
+  clipEnd?: number;
+  cameraFrame?: ServerState['cameraFrame'];
+}
+
+export type StateChangeListener = (delta: StateDelta) => void;
 
 let _activeState: ServerState = createDefaultState();
 let _activeServerId: string | null = null;
+let _stateVersion = 0;
 
 export function getSharedState(): ServerState { return _activeState; }
+
+/**
+ * Cached JSON serialization of state areas.
+ * Invalidated by version counter — avoids re-serializing unchanged state
+ * on repeated get_scene / get_timeline / /state calls.
+ */
+const _jsonCache = {
+  fullState: { version: -1, json: '' },
+  sceneElements: { version: -1, json: '' },
+  timeline: { version: -1, json: '' },
+};
+
+/** Get the full state as a JSON string, using cache when unchanged. */
+export function getSharedStateJSON(): string {
+  if (_jsonCache.fullState.version === _stateVersion) return _jsonCache.fullState.json;
+  const json = JSON.stringify(_activeState);
+  _jsonCache.fullState = { version: _stateVersion, json };
+  return json;
+}
+
+/** Get scene elements as a pretty JSON string, using cache when unchanged. */
+export function getSceneElementsJSON(): string {
+  if (_jsonCache.sceneElements.version === _stateVersion) return _jsonCache.sceneElements.json;
+  const json = JSON.stringify(_activeState.scene.elements, null, 2);
+  _jsonCache.sceneElements = { version: _stateVersion, json };
+  return json;
+}
+
+/** Get timeline + clip + camera as a pretty JSON string, using cache when unchanged. */
+export function getTimelineJSON(): string {
+  if (_jsonCache.timeline.version === _stateVersion) return _jsonCache.timeline.json;
+  const json = JSON.stringify({
+    timeline: _activeState.timeline,
+    clipStart: _activeState.clipStart,
+    clipEnd: _activeState.clipEnd,
+    cameraFrame: _activeState.cameraFrame,
+  }, null, 2);
+  _jsonCache.timeline = { version: _stateVersion, json };
+  return json;
+}
 
 export interface StateContext {
   getState: () => ServerState;
@@ -26,6 +94,105 @@ export interface StateContext {
   ) => void;
 }
 
+// ── Delta computation helpers ──────────────────────────────────
+
+/** Snapshot the minimal data needed to compute scene deltas. */
+function snapshotElementIds(state: ServerState): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const el of state.scene.elements) {
+    // Use version (or versionNonce) as a change indicator
+    map.set(el.id, el.version ?? 0);
+  }
+  return map;
+}
+
+/** Snapshot track IDs and their keyframe counts for change detection. */
+function snapshotTracks(state: ServerState): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const t of state.timeline.tracks) {
+    map.set(t.id, t.keyframes.length);
+  }
+  return map;
+}
+
+/**
+ * Properties stripped from elements in SSE deltas to reduce payload size.
+ * These are non-visual metadata that the client can re-fetch on reconnect
+ * via the /state endpoint (which sends full elements).
+ */
+const STRIP_ELEMENT_KEYS = new Set([
+  'seed', 'versionNonce', 'updated', 'link', 'locked',
+  'roundness', 'boundElements', 'lastCommittedPoint',
+  'startBinding', 'endBinding', 'originalText', 'autoResize', 'baseline',
+]);
+
+function stripElement(el: any): any {
+  const stripped: any = {};
+  for (const key of Object.keys(el)) {
+    if (!STRIP_ELEMENT_KEYS.has(key)) stripped[key] = el[key];
+  }
+  return stripped;
+}
+
+function computeSceneDelta(
+  prevElements: Map<string, number>,
+  current: ServerState,
+): StateDelta['scene'] | undefined {
+  const upsert: any[] = [];
+  const currentIds = new Set<string>();
+
+  for (const el of current.scene.elements) {
+    currentIds.add(el.id);
+    const prevVersion = prevElements.get(el.id);
+    if (prevVersion === undefined || prevVersion !== (el.version ?? 0)) {
+      upsert.push(stripElement(el));
+    }
+  }
+
+  const removed: string[] = [];
+  for (const id of prevElements.keys()) {
+    if (!currentIds.has(id)) removed.push(id);
+  }
+
+  if (upsert.length === 0 && removed.length === 0) return undefined;
+  return { upsert, removed };
+}
+
+function computeTimelineDelta(
+  prevTracks: Map<string, number>,
+  prevDuration: number,
+  prevFps: number,
+  current: ServerState,
+): StateDelta['timeline'] | undefined {
+  const upsertedTracks: any[] = [];
+  const currentTrackIds = new Set<string>();
+
+  for (const track of current.timeline.tracks) {
+    currentTrackIds.add(track.id);
+    const prevKfCount = prevTracks.get(track.id);
+    if (prevKfCount === undefined || prevKfCount !== track.keyframes.length) {
+      upsertedTracks.push(track);
+    }
+  }
+
+  const removedTrackIds: string[] = [];
+  for (const id of prevTracks.keys()) {
+    if (!currentTrackIds.has(id)) removedTrackIds.push(id);
+  }
+
+  const metaChanged = current.timeline.duration !== prevDuration || current.timeline.fps !== prevFps;
+
+  if (upsertedTracks.length === 0 && removedTrackIds.length === 0 && !metaChanged) return undefined;
+
+  const result: StateDelta['timeline'] = { upsertedTracks, removedTrackIds };
+  if (metaChanged) {
+    result.meta = { duration: current.timeline.duration, fps: current.timeline.fps };
+  }
+  return result;
+}
+
+// ── State context factory ──────────────────────────────────────
+
 export function createStateContext(
   serverId: string,
   server: McpServer,
@@ -40,14 +207,15 @@ export function createStateContext(
   _activeServerId = serverId;
 
   // ── Delta broadcasting with debounce ───────────────────────────
-  // Track which top-level state areas are dirty via flags set by tools.
-  // When the debounced emit fires, only serialize and broadcast the
-  // dirty fields. This avoids serializing the entire scene+timeline
-  // on every keyframe addition.
   let _emitTimer: ReturnType<typeof setTimeout> | null = null;
   const _dirty = { scene: false, timeline: false, clip: false, cameraFrame: false };
 
-  /** Mark a state area as dirty so it's included in the next broadcast. */
+  // Snapshots taken before each tool call for delta computation
+  let _prevElementSnapshot: Map<string, number> = snapshotElementIds(_activeState);
+  let _prevTrackSnapshot: Map<string, number> = snapshotTracks(_activeState);
+  let _prevDuration: number = _activeState.timeline.duration;
+  let _prevFps: number = _activeState.timeline.fps;
+
   function markDirty(area: 'scene' | 'timeline' | 'clip' | 'cameraFrame' | 'all') {
     if (area === 'all') {
       _dirty.scene = _dirty.timeline = _dirty.clip = _dirty.cameraFrame = true;
@@ -57,8 +225,6 @@ export function createStateContext(
   }
 
   const emitChange = () => {
-    // Default: mark everything dirty (tools that don't specify get full broadcast).
-    // Specific tools can call markDirty() before emitChange() for fine-grained deltas.
     if (!_dirty.scene && !_dirty.timeline && !_dirty.clip && !_dirty.cameraFrame) {
       markDirty('all');
     }
@@ -69,16 +235,35 @@ export function createStateContext(
       try {
         if (!onStateChange) return;
 
-        const delta: Partial<ServerState> = {};
-        if (_dirty.scene) delta.scene = _activeState.scene;
-        if (_dirty.timeline) delta.timeline = _activeState.timeline;
-        if (_dirty.clip) { delta.clipStart = _activeState.clipStart; delta.clipEnd = _activeState.clipEnd; }
-        if (_dirty.cameraFrame) delta.cameraFrame = _activeState.cameraFrame;
+        const delta: StateDelta = {};
+        let hasContent = false;
+
+        if (_dirty.scene) {
+          delta.scene = computeSceneDelta(_prevElementSnapshot, _activeState);
+          _prevElementSnapshot = snapshotElementIds(_activeState);
+          if (delta.scene) hasContent = true;
+        }
+        if (_dirty.timeline) {
+          delta.timeline = computeTimelineDelta(_prevTrackSnapshot, _prevDuration, _prevFps, _activeState);
+          _prevTrackSnapshot = snapshotTracks(_activeState);
+          _prevDuration = _activeState.timeline.duration;
+          _prevFps = _activeState.timeline.fps;
+          if (delta.timeline) hasContent = true;
+        }
+        if (_dirty.clip) {
+          delta.clipStart = _activeState.clipStart;
+          delta.clipEnd = _activeState.clipEnd;
+          hasContent = true;
+        }
+        if (_dirty.cameraFrame) {
+          delta.cameraFrame = _activeState.cameraFrame;
+          hasContent = true;
+        }
 
         // Reset dirty flags
         _dirty.scene = _dirty.timeline = _dirty.clip = _dirty.cameraFrame = false;
 
-        if (Object.keys(delta).length === 0) return;
+        if (!hasContent) return;
         onStateChange(delta);
       } catch (err) {
         console.error('emitChange failed:', err);
@@ -90,11 +275,24 @@ export function createStateContext(
 
   const updateState = (newState: ServerState) => {
     _activeState = newState;
+    _stateVersion++;
   };
 
   const mutatingTool: StateContext['mutatingTool'] = (name, description, schema, handler, dirtyAreas) => {
     server.tool(name, description, schema, async (args: any) => {
+      // Snapshot before the tool mutates state
+      if (!dirtyAreas || dirtyAreas.includes('scene')) {
+        _prevElementSnapshot = snapshotElementIds(_activeState);
+      }
+      if (!dirtyAreas || dirtyAreas.includes('timeline')) {
+        _prevTrackSnapshot = snapshotTracks(_activeState);
+        _prevDuration = _activeState.timeline.duration;
+        _prevFps = _activeState.timeline.fps;
+      }
+
       const result = await handler(args);
+      // Bump version after mutation — invalidates JSON cache
+      _stateVersion++;
       if (dirtyAreas) {
         for (const area of dirtyAreas) markDirty(area);
       }

--- a/mcp-server/src/state.ts
+++ b/mcp-server/src/state.ts
@@ -93,3 +93,71 @@ export function addKeyframeToState(
     },
   };
 }
+
+/**
+ * Batch-add many keyframes in a single pass, avoiding per-keyframe state cloning.
+ *
+ * Groups keyframes by (targetId, property), creates/finds tracks once per group,
+ * appends all keyframes at once, sorts each track once at the end.
+ * Returns the final state in one shot.
+ */
+export function addKeyframesBatchToState(
+  state: ServerState,
+  keyframes: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[],
+): ServerState {
+  if (keyframes.length === 0) return state;
+
+  // Build a mutable copy of tracks array (shallow — track objects reused until modified)
+  const tracks = [...state.timeline.tracks];
+  // Index for O(1) track lookup: "targetId|property" → index in tracks[]
+  const trackIndex = new Map<string, number>();
+  for (let i = 0; i < tracks.length; i++) {
+    trackIndex.set(`${tracks[i].targetId}|${tracks[i].property}`, i);
+  }
+
+  // Determine target type once per targetId
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const elementIdSet = new Set(state.scene.elements.map((e: any) => e.id as string));
+  const targetTypeCache = new Map<string, 'element' | 'group'>();
+  // Track which indices were cloned and need a final sort
+  const modifiedIndices = new Set<number>();
+
+  for (const kf of keyframes) {
+    const key = `${kf.targetId}|${kf.property}`;
+    let idx = trackIndex.get(key);
+
+    if (idx === undefined) {
+      let targetType = targetTypeCache.get(kf.targetId);
+      if (targetType === undefined) {
+        targetType = elementIdSet.has(kf.targetId) ? 'element' : 'group';
+        targetTypeCache.set(kf.targetId, targetType);
+      }
+      const newTrack = createTrack(kf.targetId, targetType, kf.property);
+      idx = tracks.length;
+      tracks.push(newTrack);
+      trackIndex.set(key, idx);
+    }
+
+    // Clone track on first modification (copy-on-write)
+    if (!modifiedIndices.has(idx)) {
+      tracks[idx] = { ...tracks[idx], keyframes: [...tracks[idx].keyframes] };
+      modifiedIndices.add(idx);
+    }
+
+    // Append keyframe (defer sorting until the end)
+    tracks[idx].keyframes.push(createKeyframe(kf.time, kf.value, kf.easing ?? 'linear'));
+  }
+
+  // Sort keyframes once per modified track
+  for (const idx of modifiedIndices) {
+    tracks[idx].keyframes.sort((a, b) => a.time - b.time);
+  }
+
+  return {
+    ...state,
+    timeline: {
+      ...state.timeline,
+      tracks,
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excalimate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Excalimate — Create keyframe animations from Excalidraw designs, with an MCP server for AI-driven animation",
   "type": "module",

--- a/src/components/Canvas/ExcalidrawEditor.tsx
+++ b/src/components/Canvas/ExcalidrawEditor.tsx
@@ -19,9 +19,14 @@ export function ExcalidrawEditor({
   initialData,
 }: ExcalidrawEditorProps) {
   const theme = useUIStore((s) => s.theme);
+  const liveMode = useUIStore((s) => s.liveMode);
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const onSceneChangeRef = useRef(onSceneChange);
   const onElementsSelectedRef = useRef(onElementsSelected);
+  // Track element IDs we've pushed to Excalidraw so we can detect external changes
+  const knownElementIdsRef = useRef<string>('');
+  // Suppress the next onChange from our own updateScene call
+  const suppressNextChangeRef = useRef(false);
 
   useEffect(() => {
     onSceneChangeRef.current = onSceneChange;
@@ -39,6 +44,12 @@ export function ExcalidrawEditor({
     (elements: readonly ExcalidrawElement[], appState: any, _files: any) => {
       if (!apiRef.current) return;
 
+      // Skip onChange triggered by our own updateScene (live mode sync)
+      if (suppressNextChangeRef.current) {
+        suppressNextChangeRef.current = false;
+        return;
+      }
+
       // Persist viewport for edit mode restoration
       if (appState?.scrollX != null) {
         setCanvasViewport('edit', {
@@ -53,6 +64,12 @@ export function ExcalidrawEditor({
       const isDrawTool = toolType !== 'selection' && toolType !== 'hand' && toolType !== 'eraser';
       if (isDrawTool !== useUIStore.getState().drawToolActive) {
         useUIStore.getState().setDrawToolActive(isDrawTool);
+      }
+
+      // Update known IDs from Excalidraw's own state (only needed for live mode sync)
+      if (useUIStore.getState().liveMode) {
+        const nonDeleted = elements.filter(el => !el.isDeleted);
+        knownElementIdsRef.current = nonDeleted.map(el => el.id).join(',');
       }
 
       if (onSceneChangeRef.current) {
@@ -93,6 +110,28 @@ export function ExcalidrawEditor({
       files: initialData.files,
     };
   }, [initialData]);
+
+  // In live mode, sync external scene changes (from MCP) into Excalidraw.
+  // Without this, MCP-created elements disappear because Excalidraw only reads
+  // initialData on mount, and its onChange overwrites the store with stale data.
+  useEffect(() => {
+    if (!liveMode || !initialData) return;
+    const api = apiRef.current;
+    if (!api) return;
+
+    const newIds = (initialData.elements as ExcalidrawElement[])
+      .filter(el => !el.isDeleted)
+      .map(el => el.id)
+      .join(',');
+
+    if (newIds !== knownElementIdsRef.current && newIds.length > 0) {
+      knownElementIdsRef.current = newIds;
+      suppressNextChangeRef.current = true;
+      api.updateScene({
+        elements: initialData.elements as ExcalidrawElement[],
+      });
+    }
+  }, [liveMode, initialData]);
 
   return (
     <div

--- a/src/hooks/useMcpLive.ts
+++ b/src/hooks/useMcpLive.ts
@@ -15,6 +15,36 @@ import { computeFrameAtTime } from '../core/engine/playbackSingleton';
 
 const STORAGE_KEY = 'excalimate-mcp-url';
 
+/** Decompress a gzip+base64 encoded string using the browser's DecompressionStream API. */
+async function decompressGzBase64(b64: string): Promise<string> {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+  const ds = new DecompressionStream('gzip');
+  const writer = ds.writable.getWriter();
+  writer.write(bytes);
+  writer.close();
+
+  const reader = ds.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+  const merged = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
 function getPersistedMcpUrl(): string {
   try {
     return localStorage.getItem(STORAGE_KEY) || import.meta.env.VITE_MCP_SERVER_URL || 'http://localhost:3001';
@@ -131,6 +161,21 @@ export function useMcpLive() {
           const data = JSON.parse(event.data);
           if (data.type === 'state' && data.state) {
             applyState(data.state);
+          } else if (data.type === 'gz' && data.data) {
+            // Decompress gzipped SSE payload
+            decompressGzBase64(data.data).then(
+              (json) => {
+                try {
+                  const parsed = JSON.parse(json);
+                  if (parsed.type === 'state' && parsed.state) {
+                    applyState(parsed.state);
+                  }
+                } catch (e) {
+                  console.error('[MCP Live] Parse error after decompress:', e);
+                }
+              },
+              (err) => console.error('[MCP Live] Decompress error:', err),
+            );
           }
         } catch (e) {
           console.error('[MCP Live] Parse error:', e);
@@ -198,63 +243,145 @@ export function useMcpLive() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function applyState(state: any) {
   // ── Batch all store mutations ──────────────────────────────────
-  // Each store is updated with a single set() call to minimize intermediate
-  // renders.  Frame recomputation runs after all stores are committed via
-  // queueMicrotask so subscribers see fully consistent state.
+  // Supports both full-state messages (from /state endpoint on reconnect)
+  // and delta messages (from SSE with upsert/removed fields).
 
-  // 1. Scene + targets + mode (project store + UI store)
-  if (state.scene?.elements) {
-    // Force element opacity to 100 — animation controls visibility via keyframes
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const elements = state.scene.elements.map((el: any) => ({ ...el, opacity: 100 }));
-
+  // 1. Scene
+  if (state.scene) {
     const projectStore = useProjectStore.getState();
     const currentProject = projectStore.project;
 
-    if (!currentProject) {
-      projectStore.createNewProject('MCP Live', {
-        elements,
-        appState: state.scene.appState ?? {},
-        files: state.scene.files ?? {},
-      });
-    } else {
-      // Preserve the current scene's appState (viewport scroll/zoom) so the
-      // user's view isn't reset on every MCP update.
-      const currentAppState = currentProject.scene?.appState ?? {};
-      const scene = {
-        elements,
-        appState: { ...currentAppState, ...(state.scene.appState ?? {}) },
-        files: { ...(currentProject.scene?.files ?? {}), ...(state.scene.files ?? {}) },
-      };
-      projectStore.updateScene(scene);
-    }
+    // Detect delta format (has upsert/removed) vs full format (has elements array)
+    if (Array.isArray(state.scene.upsert) || Array.isArray(state.scene.removed)) {
+      // ── Delta scene update ──
+      if (currentProject?.scene) {
+        const currentElements = [...(currentProject.scene.elements ?? [])];
 
-    const targets = extractTargets(elements);
-    projectStore.setTargets(targets);
+        // Remove deleted elements
+        const removedSet = new Set<string>(state.scene.removed ?? []);
+        let elements = removedSet.size > 0
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ? currentElements.filter((el: any) => !removedSet.has(el.id))
+          : currentElements;
+
+        // Upsert (add or replace) elements
+        if (state.scene.upsert?.length > 0) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const upsertMap = new Map(state.scene.upsert.map((el: any) => [el.id, el]));
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          elements = elements.map((el: any) => upsertMap.get(el.id) ?? el);
+          // Add truly new elements (not in existing array)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const existingIds = new Set(elements.map((el: any) => el.id));
+          for (const el of state.scene.upsert) {
+            if (!existingIds.has(el.id)) elements.push(el);
+          }
+        }
+
+        // Elements from the server normalizer already have opacity: 100.
+        // No additional mapping needed for the delta path.
+
+        const currentAppState = currentProject.scene.appState ?? {};
+        projectStore.updateScene({
+          elements,
+          appState: currentAppState,
+          files: currentProject.scene.files ?? {},
+        });
+
+        // Only re-extract targets if element IDs changed (add/remove), not just property updates
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const prevIdSet = new Set(currentElements.map((e: any) => e.id));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (removedSet.size > 0 || state.scene.upsert?.some((el: any) => !prevIdSet.has(el.id))) {
+          const targets = extractTargets(elements);
+          projectStore.setTargets(targets);
+        }
+      }
+    } else if (state.scene.elements) {
+      // ── Full scene replacement (reconnect / initial sync) ──
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const elements = state.scene.elements.map((el: any) => ({ ...el, opacity: 100 }));
+
+      if (!currentProject) {
+        projectStore.createNewProject('MCP Live', {
+          elements,
+          appState: state.scene.appState ?? {},
+          files: state.scene.files ?? {},
+        });
+      } else {
+        const currentAppState = currentProject.scene?.appState ?? {};
+        const scene = {
+          elements,
+          appState: { ...currentAppState, ...(state.scene.appState ?? {}) },
+          files: { ...(currentProject.scene?.files ?? {}), ...(state.scene.files ?? {}) },
+        };
+        projectStore.updateScene(scene);
+      }
+
+      const targets = extractTargets(elements);
+      projectStore.setTargets(targets);
+    }
   }
 
-  // 2. Animation store — batch timeline + clip range into one set()
-  if (state.timeline || (state.clipStart !== undefined && state.clipEnd !== undefined)) {
-    const updates: Record<string, unknown> = {};
-    if (state.timeline) {
-      updates.timeline = state.timeline;
+  // 2. Animation store
+  if (state.timeline) {
+    const animStore = useAnimationStore.getState();
 
-      // Switch to animate mode only once the MCP server adds keyframes.
-      // While only scene elements are being created, the user stays in edit mode
-      // so they can see elements appearing naturally on the canvas.
-      if (
-        state.timeline.tracks?.length > 0 &&
-        useUIStore.getState().mode !== 'animate'
-      ) {
+    // Detect delta format (has upsertedTracks/removedTrackIds) vs full format (has tracks array)
+    if (Array.isArray(state.timeline.upsertedTracks) || Array.isArray(state.timeline.removedTrackIds)) {
+      // ── Delta timeline update ──
+      const currentTimeline = animStore.timeline;
+      let tracks = [...currentTimeline.tracks];
+
+      // Remove deleted tracks
+      if (state.timeline.removedTrackIds?.length > 0) {
+        const removedSet = new Set<string>(state.timeline.removedTrackIds);
+        tracks = tracks.filter(t => !removedSet.has(t.id));
+      }
+
+      // Upsert tracks
+      if (state.timeline.upsertedTracks?.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const upsertMap = new Map<string, any>(state.timeline.upsertedTracks.map((t: any) => [t.id, t]));
+        tracks = tracks.map(t => upsertMap.get(t.id) ?? t) as typeof tracks;
+        const existingIds = new Set(tracks.map(t => t.id));
+        for (const t of state.timeline.upsertedTracks) {
+          if (!existingIds.has(t.id)) tracks.push(t);
+        }
+      }
+
+      // Update metadata if present
+      const duration = state.timeline.meta?.duration ?? currentTimeline.duration;
+      const fps = state.timeline.meta?.fps ?? currentTimeline.fps;
+
+      const updates: Record<string, unknown> = {
+        timeline: { ...currentTimeline, tracks, duration, fps },
+      };
+
+      // Switch to animate mode when tracks appear
+      if (tracks.length > 0 && useUIStore.getState().mode !== 'animate') {
         useUIStore.getState().setMode('animate');
       }
+
+      useAnimationStore.setState(updates);
+    } else if (state.timeline.tracks) {
+      // ── Full timeline replacement ──
+      const updates: Record<string, unknown> = { timeline: state.timeline };
+
+      if (state.timeline.tracks.length > 0 && useUIStore.getState().mode !== 'animate') {
+        useUIStore.getState().setMode('animate');
+      }
+
+      useAnimationStore.setState(updates);
     }
-    if (state.clipStart !== undefined && state.clipEnd !== undefined) {
-      updates.clipStart = Math.max(0, state.clipStart);
-      updates.clipEnd = Math.max(state.clipStart + 100, state.clipEnd);
-    }
-    // Apply all animation updates in a single set() call
-    useAnimationStore.setState(updates);
+  }
+
+  // Clip range (unchanged — always small payload)
+  if (state.clipStart !== undefined && state.clipEnd !== undefined) {
+    useAnimationStore.setState({
+      clipStart: Math.max(0, state.clipStart),
+      clipEnd: Math.max(state.clipStart + 100, state.clipEnd),
+    });
   }
 
   // 3. Camera frame
@@ -262,12 +389,12 @@ function applyState(state: any) {
     useProjectStore.getState().setCameraFrame(state.cameraFrame);
   }
 
-  // 4. Recompute animation frame AFTER all stores are updated.
-  // queueMicrotask ensures all synchronous Zustand subscriptions have
-  // fired and React has batched the pending re-renders, so the frame
-  // computation reads fully consistent state.
-  queueMicrotask(() => {
-    const currentTime = usePlaybackStore.getState().currentTime;
-    computeFrameAtTime(currentTime);
-  });
+  // 4. Recompute animation frame AFTER all stores are updated — but only
+  // when scene or timeline actually changed (not for clip-only or camera-only updates).
+  if (state.scene || state.timeline) {
+    queueMicrotask(() => {
+      const currentTime = usePlaybackStore.getState().currentTime;
+      computeFrameAtTime(currentTime);
+    });
+  }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive benchmarking harness for the `mcp-server` package, including deterministic scene generation, in-memory test infrastructure, bandwidth monitoring, and automated reporting via GitHub Actions. These changes enable reliable, reproducible, and automated performance measurement for the MCP server.

**Benchmarking Infrastructure:**

* Added a GitHub Actions workflow (`.github/workflows/mcp-bench.yml`) to automatically run benchmarks on pushes and pull requests affecting `mcp-server`, generate Markdown and JSON reports, and comment results on PRs.

**Benchmark Scene Generation:**

* Implemented deterministic, seeded scene and keyframe generation in `mcp-server/bench/fixtures/generator.ts` for reproducible benchmark scenarios.
* Defined multiple preset scenes of varying sizes in `mcp-server/bench/fixtures/scenes.ts` for scalable benchmarking.

**In-Memory Test Harness:**

* Added `McpTestClient` (`mcp-server/bench/harness/McpTestClient.ts`) to enable in-process tool calls without network overhead.
* Created an in-memory checkpoint store (`mcp-server/bench/harness/MemoryCheckpointStore.ts`) to avoid filesystem I/O during tests.

**Traffic and Metrics Collection:**

* Introduced `SseTrafficMonitor` (`mcp-server/bench/harness/SseTrafficMonitor.ts`) to measure SSE message count, raw and compressed bandwidth, and compression ratios.
* Added utilities in `mcp-server/bench/harness/metrics.ts` for collecting, formatting, and generating Markdown reports of benchmark results, including visual bar charts and key improvements.