### PR TITLE
Fix auto-tagging and release pipelines

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,4 +1,4 @@
-name: Auto-tag on Version Bump
+name: Auto-tag & Release
 
 on:
   push:
@@ -8,11 +8,14 @@ on:
       - 'mcp-server/package.json'
 
 jobs:
-  tag:
-    name: Create Tags
+  detect:
+    name: Detect Version Bumps
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      app-bumped: ${{ steps.app.outputs.bumped }}
+      app-version: ${{ steps.app.outputs.current }}
+      mcp-bumped: ${{ steps.mcp.outputs.bumped }}
+      mcp-version: ${{ steps.mcp.outputs.current }}
 
     steps:
       - uses: actions/checkout@v4
@@ -22,13 +25,13 @@ jobs:
       - name: Check web app version bump
         id: app
         run: |
-          # Compare package.json version between HEAD and HEAD~1
           CURRENT=$(node -p "require('./package.json').version")
           PREVIOUS=$(git show HEAD~1:package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null || echo "")
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
           echo "previous=$PREVIOUS" >> $GITHUB_OUTPUT
           if [ "$CURRENT" != "$PREVIOUS" ] && [ -n "$PREVIOUS" ]; then
             echo "bumped=true" >> $GITHUB_OUTPUT
+            echo "🏷️ Web app: $PREVIOUS → $CURRENT"
           else
             echo "bumped=false" >> $GITHUB_OUTPUT
           fi
@@ -42,22 +45,136 @@ jobs:
           echo "previous=$PREVIOUS" >> $GITHUB_OUTPUT
           if [ "$CURRENT" != "$PREVIOUS" ] && [ -n "$PREVIOUS" ]; then
             echo "bumped=true" >> $GITHUB_OUTPUT
+            echo "🏷️ MCP server: $PREVIOUS → $CURRENT"
           else
             echo "bumped=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create web app tag
-        if: steps.app.outputs.bumped == 'true'
-        run: |
-          TAG="v${{ steps.app.outputs.current }}"
-          echo "Creating tag: $TAG"
-          git tag "$TAG"
-          git push origin "$TAG"
+  release-app:
+    name: Release Web App
+    needs: detect
+    if: needs.detect.outputs.app-bumped == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
-      - name: Create MCP server tag
-        if: steps.mcp.outputs.bumped == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+      - name: Extract changelog
+        id: changelog
         run: |
-          TAG="mcp-server-v${{ steps.mcp.outputs.current }}"
-          echo "Creating tag: $TAG"
-          git tag "$TAG"
-          git push origin "$TAG"
+          VERSION="${{ needs.detect.outputs.app-version }}"
+          NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/d; p; }' CHANGELOG.md)
+          fi
+          echo "$NOTES" > release-notes.md
+
+      - name: Create build archive
+        run: tar -czf excalimate-${{ needs.detect.outputs.app-version }}.tar.gz -C dist .
+
+      - name: Create tag and release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.detect.outputs.app-version }}
+          name: 'Excalimate v${{ needs.detect.outputs.app-version }}'
+          body_path: release-notes.md
+          files: |
+            excalimate-${{ needs.detect.outputs.app-version }}.tar.gz
+
+  release-mcp:
+    name: Release MCP Server
+    needs: detect
+    if: needs.detect.outputs.mcp-bumped == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install web app dependencies
+        run: npm ci
+
+      - name: Test web app
+        run: npx vitest run
+
+      - name: Install MCP server dependencies
+        working-directory: mcp-server
+        run: npm ci
+
+      - name: Type check
+        working-directory: mcp-server
+        run: npx tsc --noEmit
+
+      - name: Build
+        working-directory: mcp-server
+        run: npx tsc
+
+      - name: Verify build
+        working-directory: mcp-server
+        run: node -e "require('./dist/index.js'); console.log('Build verified'); process.exit(0)"
+
+      - name: Run benchmarks
+        working-directory: mcp-server
+        run: npx tsx bench/run.ts --markdown --output bench-results.md
+
+      - name: Publish to npm
+        working-directory: mcp-server
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Extract changelog
+        id: changelog
+        run: |
+          VERSION="${{ needs.detect.outputs.mcp-version }}"
+          NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" mcp-server/CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/{ /^## \[Unreleased\]/d; /^## \[/d; p; }' mcp-server/CHANGELOG.md)
+          fi
+          echo "$NOTES" > release-notes.md
+          if [ -f mcp-server/bench-results.md ]; then
+            echo "" >> release-notes.md
+            echo "---" >> release-notes.md
+            echo "" >> release-notes.md
+            cat mcp-server/bench-results.md >> release-notes.md
+          fi
+
+      - name: Create tag and release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: mcp-server-v${{ needs.detect.outputs.mcp-version }}
+          name: 'MCP Server v${{ needs.detect.outputs.mcp-version }}'
+          body_path: release-notes.md
+          files: |
+            mcp-server/bench-results.md

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,4 +1,4 @@
-name: Publish MCP Server
+name: Publish MCP Server (manual)
 
 on:
   push:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,4 +1,4 @@
-name: Release Web App
+name: Release Web App (manual)
 
 on:
   push:


### PR DESCRIPTION
This pull request significantly refactors and improves the release automation for both the web app and MCP server by splitting and enhancing the GitHub Actions workflows. The new approach separates detection of version bumps from the actual release processes, automates changelog extraction, adds build verification and benchmarks for MCP server releases, and clarifies the role of manual workflows.

**Workflow automation and release process improvements:**

* Refactored `.github/workflows/auto-tag.yml` to detect version bumps in both `package.json` files, and trigger separate, automated release jobs for the web app and MCP server, including changelog extraction, build/test steps, and GitHub release creation. The MCP server release also publishes to npm, runs benchmarks, and appends benchmark results to the release notes. [[1]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494L1-R1) [[2]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494L11-R18) [[3]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494L25-R34) [[4]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494R48-R180)

**Manual workflow clarification:**

* Renamed `.github/workflows/publish-mcp.yml` to "Publish MCP Server (manual)" to clarify its use as a manual workflow.
* Renamed `.github/workflows/release-app.yml` to "Release Web App (manual)" for the same reason.