### PR TITLE
Fix CodeQL alerts and bump web app + MCP server patch versions

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,6 +7,9 @@ on:
       - 'package.json'
       - 'mcp-server/package.json'
 
+permissions:
+  contents: read
+
 jobs:
   detect:
     name: Detect Version Bumps

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@excalimate/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@excalimate/mcp-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalimate/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "description": "Excalimate MCP server for creating Excalidraw designs and animating them with keyframes",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "excalimate",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "excalimate",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@dotlottie/dotlottie-js": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excalimate",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "description": "Excalimate — Create keyframe animations from Excalidraw designs, with an MCP server for AI-driven animation",
   "type": "module",

--- a/share-worker/src/index.ts
+++ b/share-worker/src/index.ts
@@ -59,7 +59,7 @@ function generateId(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(6));
   let binary = '';
   for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, '-').replace(/_/g, '_').replace(/=+$/, '');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 export default {


### PR DESCRIPTION
Follow-up to #76 (already merged). Resolves the two CodeQL code-scanning alerts raised on main, plus a patch version bump for the web app and MCP server.

## CodeQL fixes
- **#11 (Medium) — Replacement of a substring with itself** (share-worker/src/index.ts:62): generateId() did base64url conversion but the middle step was a no-op (.replace(/_/g, '_')), so a literal `/` could leak into generated IDs. Fixed to .replace(/\//g, '_'), producing valid URL-safe IDs.
- **#10 (Medium) — Workflow does not contain permissions** (.github/workflows/auto-tag.yml): added a top-level `permissions: contents: read`. The release jobs keep their own elevated job-level permissions, so reusable-workflow calls are unaffected.

## Version bumps
- Web app (xcalimate): 0.4.0 -> 0.4.1
- MCP server (@excalimate/mcp-server): 0.4.1 -> 0.4.2

## Validation
- `tsc --noEmit` on share-worker: clean
- `auto-tag.yml` parses; top-level `contents: read` with release jobs retaining their own perms
- Version bumps applied via `npm version patch` (package.json + lockfiles in sync). MCP server reads its version from package.json at runtime, so no source strings needed updating.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
