### PR TITLE
Make bottom timeline card collapsible

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useEffect, useCallback } from 'react';
 import { MantineProvider, CloseButton, ActionIcon, Tooltip } from '@mantine/core';
-import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
+import { IconLayoutSidebarLeftExpand, IconChevronUp } from '@tabler/icons-react';
 import { Notifications } from '@mantine/notifications';
 import { ModalsProvider } from '@mantine/modals';
 import { NavigationProgress } from '@mantine/nprogress';
@@ -67,6 +67,7 @@ export function App() {
   const selectedElementIds = useUIStore((s) => s.selectedElementIds);
   const sequenceRevealOpen = useUIStore((s) => s.sequenceRevealOpen);
   const layersPanelOpen = useUIStore((s) => s.layersPanelOpen);
+  const timelinePanelOpen = useUIStore((s) => s.timelinePanelOpen);
   const targets = useProjectStore((s) => s.targets);
   const project = useProjectStore((s) => s.project);
   const cameraFrame = useProjectStore((s) => s.cameraFrame);
@@ -190,6 +191,21 @@ export function App() {
               </Tooltip>
             </div>
           )}
+          {/* Timeline toggle (floating, visible when the timeline is collapsed) */}
+          {!timelinePanelOpen && (
+            <div className="absolute bottom-2 right-2 z-20">
+              <Tooltip label="Show timeline" position="left">
+                <ActionIcon
+                  variant="filled"
+                  color="indigo"
+                  size="md"
+                  onClick={() => useUIStore.getState().toggleTimelinePanel()}
+                >
+                  <IconChevronUp size={18} />
+                </ActionIcon>
+              </Tooltip>
+            </div>
+          )}
         </main>
 
         {/* Right: Property panel (visible when elements or keyframes selected) */}
@@ -219,6 +235,7 @@ export function App() {
       </div>
 
       {/* Bottom: Timeline panel */}
+      {timelinePanelOpen && (
       <div data-hint="timeline" className="h-[250px] mx-2 mb-2 border border-border bg-surface-alt rounded-lg shadow-float overflow-hidden">
         <ErrorBoundary fallback={<div className="flex items-center justify-center h-full text-sm text-danger">Timeline error</div>}>
         <TimelinePanelWrapper
@@ -241,9 +258,11 @@ export function App() {
           targetOrder={targetOrder}
           targetParents={targetParents}
           selectedElementIds={selectedElementIds}
+          onCollapse={() => useUIStore.getState().toggleTimelinePanel()}
         />
         </ErrorBoundary>
       </div>
+      )}
     </div>
         )}
         <ConsentBanner />

--- a/src/components/Timeline/TimelinePanel.tsx
+++ b/src/components/Timeline/TimelinePanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState, type MouseEvent } from 'react';
-import { ActionIcon } from '@mantine/core';
+import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconKeyframeFilled, IconX, IconVolume, IconVolumeOff, IconChevronRight, IconChevronDown } from '@tabler/icons-react';
 import type { AnimationTrack, Keyframe } from '../../types/animation';
 import { KeyframeDiamond } from './KeyframeDiamond';
@@ -42,6 +42,8 @@ export interface TimelinePanelProps {
   targetOrder: Map<string, number>;
   targetParents: Map<string, string | undefined>;
   zoom?: number;
+  /** When provided, renders a collapse button in the header that hides the timeline. */
+  onCollapse?: () => void;
 }
 
 type RowData =
@@ -94,6 +96,7 @@ export function TimelinePanel({
   targetOrder,
   targetParents,
   zoom: initialZoom = 0.1,
+  onCollapse,
 }: TimelinePanelProps) {
   void _onDeleteKeyframe;
 
@@ -200,6 +203,15 @@ export function TimelinePanel({
         <div className="flex-1 overflow-hidden" ref={keyframeAreaRef} onMouseDown={handleScrubberMouseDown} aria-label="Timeline scrubber">
           <TimeRuler duration={duration} zoom={zoom} scrollX={scrollX} width={rulerWidth} />
         </div>
+        {onCollapse && (
+          <div className="shrink-0 flex items-center px-1 border-b border-l border-border bg-surface-alt">
+            <Tooltip label="Collapse timeline" position="left">
+              <ActionIcon variant="subtle" color="gray" size="xs" onClick={onCollapse} aria-label="Collapse timeline">
+                <IconChevronDown size={14} />
+              </ActionIcon>
+            </Tooltip>
+          </div>
+        )}
       </div>
 
       <div className="flex flex-1 overflow-hidden">

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -25,6 +25,7 @@ interface UIState {
   ghostMode: boolean;
   sequenceRevealOpen: boolean;
   layersPanelOpen: boolean;
+  timelinePanelOpen: boolean;
   liveMode: boolean;
   /** True when a shape/draw tool is active in Excalidraw (not selection/hand). */
   drawToolActive: boolean;
@@ -46,6 +47,7 @@ interface UIState {
   toggleGhostMode: () => void;
   toggleSequenceReveal: () => void;
   toggleLayersPanel: () => void;
+  toggleTimelinePanel: () => void;
   setLiveMode: (live: boolean) => void;
   setDrawToolActive: (active: boolean) => void;
   setActivePage: (page: string | null) => void;
@@ -58,6 +60,7 @@ export const useUIStore = create<UIState>()((set, get) => ({
   ghostMode: false,
   sequenceRevealOpen: false,
   layersPanelOpen: true,
+  timelinePanelOpen: true,
   liveMode: false,
   drawToolActive: false,
   activePage: null,
@@ -150,6 +153,9 @@ export const useUIStore = create<UIState>()((set, get) => ({
   },
   toggleLayersPanel: (): void => {
     set((state) => ({ layersPanelOpen: !state.layersPanelOpen }));
+  },
+  toggleTimelinePanel: (): void => {
+    set((state) => ({ timelinePanelOpen: !state.timelinePanelOpen }));
   },
   setLiveMode: (live: boolean): void => {
     set({ liveMode: live });


### PR DESCRIPTION
## Why

The bottom timeline card occupied a fixed 250px of vertical space at all times, even when a user just wanted more room for the canvas. The layers side panel already supports collapsing; this brings the same convenience to the timeline.

## What changed

<img width="1146" height="385" alt="image" src="https://github.com/user-attachments/assets/9c489345-5bc6-44bb-a59b-c34d20f8da5d" />
<img width="1145" height="178" alt="image" src="https://github.com/user-attachments/assets/f05dbc16-ea94-42a9-b5c9-f88e5f256b3f" />


Adds a collapse/expand toggle for the bottom timeline card that mirrors the existing side (layers) panel pattern:

- **`uiStore`** gains `timelinePanelOpen` state (default open) and a `toggleTimelinePanel()` action, alongside the existing `layersPanelOpen` / `toggleLayersPanel`.
- **`TimelinePanel`** takes an optional `onCollapse` prop and renders a chevron collapse button (Mantine `ActionIcon` + `Tooltip`) at the far right of its header row.
- **`App`** only renders the timeline card when open, so the canvas reclaims the space when collapsed, and shows a floating "Show timeline" button at the bottom-right of the canvas to restore it.

## Notes

- When collapsed, the timeline is fully hidden and re-expanded via the floating button, matching how the layers panel behaves. If a slim always-visible bar (keeping playback controls on screen) is preferred instead, that is an easy follow-up.
- The collapse control sits to the right of the ruler cell; the ruler width is measured from its element so the layout adjusts automatically.
- Verified with `eslint` and `tsc -b` (both clean).