### PR TITLE
Harden encrypted sharing and static hosting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app: ${{ steps.filter.outputs.app }}
+      share: ${{ steps.filter.outputs.share }}
       mcp: ${{ steps.filter.outputs.mcp }}
       landing: ${{ steps.filter.outputs.landing }}
     steps:
@@ -33,6 +34,8 @@ jobs:
               - 'index.html'
             mcp:
               - 'mcp-server/**'
+            share:
+              - 'share-worker/**'
             landing:
               - 'landing-page/**'
 
@@ -72,6 +75,24 @@ jobs:
         with:
           name: web-app-dist
           path: dist/
+
+  # ── Share Worker ────────────────────────────────────────────────
+  share-worker-check:
+    name: 'Share Worker: Type Check & Test'
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.share == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: share-worker/package-lock.json
+      - working-directory: share-worker
+        run: npm ci
+      - working-directory: share-worker
+        run: npm run check
 
   # ── MCP Server ─────────────────────────────────────────────────
   mcp-check:

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,9 @@
+# Editor application routes. A future embeddable player must be served by a
+# separate Worker route so it can intentionally use a different frame policy.
+/*
+  Content-Security-Policy: frame-ancestors 'none'
+  Cross-Origin-Resource-Policy: same-origin
+  Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()
+  Referrer-Policy: no-referrer
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Content-Type-Options: nosniff

--- a/share-worker/README.md
+++ b/share-worker/README.md
@@ -1,66 +1,116 @@
 # Excalimate Share Worker
 
-Lightweight Cloudflare Worker + R2 for E2E encrypted animation sharing.
+Cloudflare Worker, R2, and a SQLite-backed Durable Object for end-to-end encrypted
+animation sharing.
 
-## How it works
+## Security model
 
-1. Client encrypts project data with AES-256-GCM (key never leaves the browser)
-2. Encrypted blob is uploaded to `POST /share` → stored in R2
-3. Client builds URL: `https://app.excalimate.com/#share=<id>,<key>` (key in hash, never sent to server)
-4. Recipient opens URL → blob fetched from `GET /share/<id>` → decrypted client-side
+1. The browser compresses project JSON and encrypts it with AES-256-GCM.
+2. `POST /share` stores only the opaque ciphertext in R2.
+3. The response returns a 128-bit share ID, exact `expiresAt`, and a 256-bit
+   deletion capability.
+4. The browser puts only the AES key in the URL fragment. URL fragments are not
+   sent in HTTP requests.
+5. R2 metadata stores only the SHA-256 verifier for the deletion capability.
 
-The server **only stores opaque encrypted blobs**. It cannot read, index, or analyze the content.
+The service cannot decrypt, index, or analyze a shared project. Do not log upload
+bodies, URL fragments, authorization headers, or deletion capabilities.
 
-## Setup
+## API
 
-### 1. Create the R2 bucket
+| Method   | Path         | Description                                                                  |
+| -------- | ------------ | ---------------------------------------------------------------------------- |
+| `POST`   | `/share`     | Upload `application/octet-stream`; returns `{ id, expiresAt, deleteSecret }` |
+| `GET`    | `/share/:id` | Download immutable `application/octet-stream` ciphertext                     |
+| `DELETE` | `/share/:id` | Delete with `Authorization: Bearer <deleteSecret>`                           |
+| `GET`    | `/health`    | Health check                                                                 |
+
+Write requests and preflights require an exact origin from `ALLOWED_ORIGINS`.
+Share IDs are exactly 22 base64url characters. Upload bodies are bounded while
+streaming even when `Content-Length` is absent.
+
+Deletion prevents new Worker reads after R2 deletion. It cannot erase copies that
+a recipient already downloaded, decrypted, or retained in a browser cache.
+
+## Quota and cost controls
+
+`ShareQuota` is one globally named SQLite-backed Durable Object. It reserves exact
+object bytes before each R2 write and enforces both `MAX_TOTAL_SHARES` and
+`MAX_TOTAL_STORAGE_MB`. Failed R2 writes roll back the reservation. Deletes and
+daily expiry alarms release capacity.
+
+New writes use the `excalimate-shares-v2` bucket, so the quota starts from an
+empty, known baseline. The original `excalimate-shares` bucket is bound read-only
+for legacy 8-character links while its existing 30-day retention window drains.
+Remove `LEGACY_SHARE_BUCKET` only after every object that predates this deployment
+has expired.
+
+Public `GET` requests never call the Durable Object, so cached and uncached reads
+do not add quota storage operations. Each successful upload uses one Durable
+Object request plus a small number of indexed SQLite row operations; deletion uses
+one more request. This is more expensive than a process-local counter but provides
+strong, restart-safe admission control and a hard storage ceiling. Cloudflare
+offers SQLite-backed Durable Objects on Workers Free and Paid plans; configure
+billing alerts for R2, Workers, and Durable Objects.
+
+## Initial deployment
+
+From `share-worker`:
 
 ```bash
-cd share-worker
-npx wrangler r2 bucket create excalimate-shares
-```
-
-### 2. Set up lifecycle rules (30-day auto-expiry)
-
-In the Cloudflare dashboard:
-1. Go to **R2** → **excalimate-shares** → **Settings**
-2. Add a lifecycle rule: **Delete objects after 30 days**
-
-### 3. Deploy
-
-```bash
-npm install
+npm ci
+npx wrangler login
+npx wrangler r2 bucket create excalimate-shares-v2
+npm run lifecycle:apply
 npm run deploy
 ```
 
-The worker will be available at `https://excalimate-share.<your-subdomain>.workers.dev`.
+The deploy applies the `v1` SQLite Durable Object migration from
+`wrangler.jsonc`. The API token needs Workers deployment and R2 Storage Write
+permissions.
 
-### 4. Configure custom domain (optional)
+The legacy `excalimate-shares` bucket must already exist. For a completely new
+installation, create it as well. Apply and verify lifecycle policies before
+deploying:
 
-In Cloudflare dashboard, add a custom domain route like `share.excalimate.com`.
+```bash
+npm run lifecycle:apply
+npx wrangler r2 bucket lifecycle list excalimate-shares-v2
+npx wrangler r2 bucket lifecycle list excalimate-shares
+npm run deploy
+```
+
+Cloudflare lifecycle deletion may run up to 24 hours after an object's 30-day age.
+The Worker independently enforces the exact `expiresAt` metadata timestamp, so an
+expired object is inaccessible while physical cleanup is pending.
+
+`r2-lifecycle.json` and `SHARE_TTL_DAYS` must remain aligned. If retention changes,
+update both values and reapply the lifecycle policy.
+
+Originless uploads are intentionally rejected. Existing non-browser clients,
+including the current MCP `share_project` tool, need a separately authenticated
+server-to-server upload contract before they can use this hardened endpoint; that
+client change is outside this worker and app PR.
+
+## Configuration
+
+| Variable               | Default                          | Description                                                                    |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------------------------ |
+| `MAX_SHARE_SIZE_MB`    | `2`                              | Maximum ciphertext body size                                                   |
+| `SHARE_TTL_DAYS`       | `30`                             | Logical share lifetime                                                         |
+| `MAX_TOTAL_SHARES`     | `2000`                           | Durable maximum live reservation count                                         |
+| `MAX_TOTAL_STORAGE_MB` | `4096`                           | Durable maximum reserved ciphertext bytes                                      |
+| `ALLOWED_ORIGINS`      | production and local app origins | Exact comma-separated HTTPS origins; localhost HTTP is allowed for development |
+
+Configuration is parsed strictly. Wildcard origins, malformed numbers, invalid
+URLs, and unsafe ranges fail closed with a sanitized `503` response.
 
 ## Local development
 
 ```bash
-npm install
+npm ci
 npm run dev
-# → http://localhost:8787
 ```
 
-## API
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/share` | Upload encrypted blob. Body: `application/octet-stream`. Returns `{ id }` |
-| `GET` | `/share/:id` | Download encrypted blob. Returns `application/octet-stream` |
-| `GET` | `/health` | Health check |
-
-## Configuration
-
-Environment variables in `wrangler.jsonc`:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MAX_SHARE_SIZE_MB` | `10` | Maximum upload size in MB |
-| `SHARE_TTL_DAYS` | `30` | Days before shares expire |
-| `ALLOWED_ORIGINS` | `https://app.excalimate.com,...` | Comma-separated CORS origins |
+Wrangler provides local R2 and Durable Object bindings. The configured
+`http://localhost:5173` origin supports the Vite development app.

--- a/share-worker/package-lock.json
+++ b/share-worker/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250313.0",
+        "typescript": "~5.9.3",
+        "vitest": "^4.0.18",
         "wrangler": "^4.12.0"
       }
     },
@@ -143,10 +145,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1114,6 +1139,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -1143,6 +1197,270 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -1163,10 +1481,193 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1203,6 +1704,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1246,6 +1754,44 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1271,6 +1817,277 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260625.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
@@ -1292,6 +2109,39 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -1305,6 +2155,89 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -1364,6 +2297,37 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -1377,6 +2341,50 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1384,6 +2392,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "7.28.0",
@@ -1403,6 +2425,191 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/share-worker/package.json
+++ b/share-worker/package.json
@@ -4,12 +4,20 @@
   "private": true,
   "description": "Cloudflare Worker for E2E encrypted animation sharing",
   "scripts": {
+    "check": "npm run typecheck && npm test",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --config ./wrangler.jsonc",
-    "tail": "wrangler tail"
+    "lifecycle:apply": "npm run lifecycle:apply:current && npm run lifecycle:apply:legacy",
+    "lifecycle:apply:current": "wrangler r2 bucket lifecycle set excalimate-shares-v2 --file ./r2-lifecycle.json",
+    "lifecycle:apply:legacy": "wrangler r2 bucket lifecycle set excalimate-shares --file ./r2-lifecycle.json",
+    "test": "vitest run",
+    "tail": "wrangler tail",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250313.0",
+    "typescript": "~5.9.3",
+    "vitest": "^4.0.18",
     "wrangler": "^4.12.0"
   }
 }

--- a/share-worker/r2-lifecycle.json
+++ b/share-worker/r2-lifecycle.json
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "id": "expire-encrypted-shares-after-30-days",
+      "enabled": true,
+      "conditions": {
+        "prefix": ""
+      },
+      "deleteObjectsTransition": {
+        "condition": {
+          "type": "Age",
+          "maxAge": 2592000
+        }
+      }
+    }
+  ]
+}

--- a/share-worker/src/index.test.ts
+++ b/share-worker/src/index.test.ts
@@ -1,0 +1,413 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import worker, { type Env } from './index';
+
+interface StoredObject {
+  body: Uint8Array;
+  customMetadata: Record<string, string>;
+  httpMetadata: {
+    cacheControl?: string;
+    contentType?: string;
+  };
+}
+
+interface UploadResponse {
+  id: string;
+  expiresAt: string;
+  deleteSecret: string;
+}
+
+class MemoryBucket {
+  readonly objects = new Map<string, StoredObject>();
+  getCalls = 0;
+  putCalls = 0;
+
+  async put(
+    key: string,
+    value: ArrayBuffer,
+    options: {
+      customMetadata?: Record<string, string>;
+      httpMetadata?: StoredObject['httpMetadata'];
+    },
+  ): Promise<void> {
+    this.putCalls += 1;
+    this.objects.set(key, {
+      body: new Uint8Array(value.slice(0)),
+      customMetadata: { ...options.customMetadata },
+      httpMetadata: { ...options.httpMetadata },
+    });
+  }
+
+  async get(key: string): Promise<object | null> {
+    this.getCalls += 1;
+    const stored = this.objects.get(key);
+    if (!stored) return null;
+    return {
+      body: new Response(stored.body).body,
+      customMetadata: stored.customMetadata,
+      httpMetadata: stored.httpMetadata,
+    };
+  }
+
+  async head(key: string): Promise<object | null> {
+    const stored = this.objects.get(key);
+    if (!stored) return null;
+    return {
+      customMetadata: stored.customMetadata,
+      httpMetadata: stored.httpMetadata,
+    };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+}
+
+class MemoryQuota {
+  readonly reservations = new Map<string, { size: number; expiresAt: number }>();
+
+  readonly stub = {
+    fetch: async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const request = new Request(input, init);
+      const body = (await request.json()) as Record<string, unknown>;
+      if (new URL(request.url).pathname === '/release') {
+        this.reservations.delete(String(body.id));
+        return Response.json({ released: true });
+      }
+
+      const now = Date.now();
+      for (const [id, reservation] of this.reservations) {
+        if (reservation.expiresAt <= now) this.reservations.delete(id);
+      }
+
+      const id = String(body.id);
+      const size = Number(body.size);
+      const maxShares = Number(body.maxShares);
+      const maxBytes = Number(body.maxBytes);
+      const totalBytes = [...this.reservations.values()].reduce(
+        (total, reservation) => total + reservation.size,
+        0,
+      );
+      const accepted =
+        !this.reservations.has(id) &&
+        this.reservations.size < maxShares &&
+        totalBytes + size <= maxBytes;
+      if (accepted) {
+        this.reservations.set(id, {
+          expiresAt: Number(body.expiresAt),
+          size,
+        });
+      }
+      return Response.json({ accepted });
+    },
+  };
+
+  readonly namespace = {
+    idFromName: () => ({ toString: () => 'global-share-quota' }),
+    get: () => this.stub,
+  };
+}
+
+const allowedOrigin = 'https://app.excalimate.com';
+
+function createHarness(overrides: Partial<Env> = {}) {
+  const bucket = new MemoryBucket();
+  const legacyBucket = new MemoryBucket();
+  const quota = new MemoryQuota();
+  const env: Env = {
+    ALLOWED_ORIGINS: `${allowedOrigin},http://localhost:5173`,
+    MAX_SHARE_SIZE_MB: '1',
+    MAX_TOTAL_SHARES: '2',
+    MAX_TOTAL_STORAGE_MB: '2',
+    SHARE_TTL_DAYS: '30',
+    LEGACY_SHARE_BUCKET: legacyBucket as unknown as R2Bucket,
+    SHARE_BUCKET: bucket as unknown as R2Bucket,
+    SHARE_QUOTA: quota.namespace as unknown as DurableObjectNamespace,
+    ...overrides,
+  };
+  return { bucket, env, legacyBucket, quota };
+}
+
+function uploadRequest(
+  body: BodyInit = new Uint8Array([1, 2, 3, 4]),
+  headers: HeadersInit = {},
+): Request {
+  return new Request('https://share.example/share', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      Origin: allowedOrigin,
+      ...headers,
+    },
+    body,
+  });
+}
+
+async function upload(env: Env, body: BodyInit = new Uint8Array([1, 2, 3, 4])) {
+  const response = await worker.fetch(uploadRequest(body), env);
+  const result = (await response.json()) as UploadResponse;
+  return { response, result };
+}
+
+describe('share worker', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('answers valid CORS preflights with an exact allowed origin', async () => {
+    const { env } = createHarness();
+    const request = new Request('https://share.example/share', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: allowedOrigin,
+        'Access-Control-Request-Headers': 'content-type',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+
+    const response = await worker.fetch(request, env);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(allowedOrigin);
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS');
+    expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type');
+    expect(response.headers.get('Vary')).toContain('Origin');
+  });
+
+  it('rejects disallowed and missing origins before write processing', async () => {
+    const { bucket, env, quota } = createHarness();
+    const disallowed = uploadRequest(new Uint8Array([1]), {
+      Origin: 'https://attacker.example',
+    });
+    const missing = uploadRequest(new Uint8Array([1]));
+    missing.headers.delete('Origin');
+
+    const disallowedResponse = await worker.fetch(disallowed, env);
+    const missingResponse = await worker.fetch(missing, env);
+    const preflightResponse = await worker.fetch(
+      new Request('https://share.example/share', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://attacker.example',
+          'Access-Control-Request-Method': 'POST',
+        },
+      }),
+      env,
+    );
+
+    expect(disallowedResponse.status).toBe(403);
+    expect(missingResponse.status).toBe(403);
+    expect(preflightResponse.status).toBe(403);
+    expect(disallowedResponse.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(bucket.putCalls).toBe(0);
+    expect(quota.reservations.size).toBe(0);
+  });
+
+  it('enforces methods, query-free routes, and exact content type', async () => {
+    const { env } = createHarness();
+
+    const methodResponse = await worker.fetch(
+      new Request('https://share.example/share', { method: 'PUT' }),
+      env,
+    );
+    const parameterizedTypeResponse = await worker.fetch(
+      uploadRequest(new Uint8Array([1]), {
+        'Content-Type': 'application/octet-stream; charset=binary',
+      }),
+      env,
+    );
+    const queryResponse = await worker.fetch(
+      new Request('https://share.example/share?cache-bust=1', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          Origin: allowedOrigin,
+        },
+        body: new Uint8Array([1]),
+      }),
+      env,
+    );
+
+    expect(methodResponse.status).toBe(405);
+    expect(methodResponse.headers.get('Allow')).toBe('POST, OPTIONS');
+    expect(parameterizedTypeResponse.status).toBe(415);
+    expect(queryResponse.status).toBe(400);
+  });
+
+  it('enforces declared and streamed body limits', async () => {
+    const { bucket, env } = createHarness();
+    const declaredResponse = await worker.fetch(
+      uploadRequest(new Uint8Array([1]), { 'Content-Length': '1048577' }),
+      env,
+    );
+    const streamedResponse = await worker.fetch(
+      uploadRequest(new Uint8Array(1024 * 1024 + 1)),
+      env,
+    );
+
+    expect(declaredResponse.status).toBe(413);
+    expect(streamedResponse.status).toBe(413);
+    expect(bucket.putCalls).toBe(0);
+  });
+
+  it('accepts a bounded upload without Content-Length and creates 128-bit IDs', async () => {
+    const { env } = createHarness();
+    const first = await upload(env);
+    const second = await upload(env);
+
+    expect(first.response.status).toBe(201);
+    expect(first.result.id).toMatch(/^[A-Za-z0-9_-]{22}$/);
+    expect(first.result.deleteSecret).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(first.result.id).not.toBe(second.result.id);
+    expect(Date.parse(first.result.expiresAt)).toBeGreaterThan(Date.now());
+  });
+
+  it('strictly rejects malformed share IDs before reading R2', async () => {
+    const { bucket, env } = createHarness();
+
+    for (const id of [
+      'short',
+      'AAAAAAAAAAAAAAAAAAAAA!',
+      'A'.repeat(23),
+      'A'.repeat(7),
+      'A'.repeat(9),
+    ]) {
+      const response = await worker.fetch(new Request(`https://share.example/share/${id}`), env);
+      expect(response.status).toBe(400);
+    }
+    expect(bucket.getCalls).toBe(0);
+  });
+
+  it('keeps strictly formatted legacy IDs readable during bucket migration', async () => {
+    const { env, legacyBucket } = createHarness();
+    const legacyId = 'AbCdEf12';
+    const ciphertext = new Uint8Array([91, 17, 3]);
+    legacyBucket.objects.set(legacyId, {
+      body: ciphertext,
+      customMetadata: {
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+      httpMetadata: {
+        cacheControl: 'public, max-age=60, immutable',
+        contentType: 'application/octet-stream',
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://share.example/share/${legacyId}`),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(ciphertext);
+    expect(legacyBucket.getCalls).toBe(1);
+  });
+
+  it('stores opaque ciphertext and serves it with immutable security headers', async () => {
+    const { bucket, env } = createHarness();
+    const ciphertext = new Uint8Array([0, 255, 17, 88, 31, 201]);
+    const { result } = await upload(env, ciphertext);
+    const stored = bucket.objects.get(result.id);
+
+    expect(stored?.body).toEqual(ciphertext);
+    expect(stored?.customMetadata).toEqual({
+      deleteVerifier: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+      expiresAt: result.expiresAt,
+    });
+    expect(JSON.stringify(stored)).not.toContain(result.deleteSecret);
+
+    const response = await worker.fetch(
+      new Request(`https://share.example/share/${result.id}`, {
+        headers: { Origin: allowedOrigin },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(ciphertext);
+    expect(response.headers.get('Content-Type')).toBe('application/octet-stream');
+    expect(response.headers.get('Cache-Control')).toContain('immutable');
+    expect(response.headers.get('Cache-Control')).toContain('public');
+    expect(response.headers.get('Cross-Origin-Resource-Policy')).toBe('cross-origin');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Request-Id')).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('enforces logical expiry before R2 lifecycle cleanup', async () => {
+    const { bucket, env } = createHarness();
+    const { result } = await upload(env);
+    const stored = bucket.objects.get(result.id);
+    if (!stored) throw new Error('Expected stored object.');
+    stored.customMetadata.expiresAt = new Date(Date.now() - 1).toISOString();
+
+    const response = await worker.fetch(
+      new Request(`https://share.example/share/${result.id}`),
+      env,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('enforces durable count quota before R2 writes', async () => {
+    const { bucket, env, quota } = createHarness({ MAX_TOTAL_SHARES: '1' });
+    const first = await upload(env);
+    const second = await upload(env);
+
+    expect(first.response.status).toBe(201);
+    expect(second.response.status).toBe(429);
+    expect(second.response.headers.get('Retry-After')).toBe('3600');
+    expect(bucket.putCalls).toBe(1);
+    expect(quota.reservations.size).toBe(1);
+  });
+
+  it('deletes only with the returned capability and releases quota', async () => {
+    const { bucket, env, quota } = createHarness({ MAX_TOTAL_SHARES: '1' });
+    const { result } = await upload(env);
+
+    const wrongSecretResponse = await worker.fetch(
+      new Request(`https://share.example/share/${result.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${'A'.repeat(43)}`,
+          Origin: allowedOrigin,
+        },
+      }),
+      env,
+    );
+    expect(wrongSecretResponse.status).toBe(403);
+    expect(bucket.objects.has(result.id)).toBe(true);
+
+    const deleteResponse = await worker.fetch(
+      new Request(`https://share.example/share/${result.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${result.deleteSecret}`,
+          Origin: allowedOrigin,
+        },
+      }),
+      env,
+    );
+    expect(deleteResponse.status).toBe(204);
+    expect(bucket.objects.has(result.id)).toBe(false);
+    expect(quota.reservations.size).toBe(0);
+
+    const replacement = await upload(env);
+    expect(replacement.response.status).toBe(201);
+  });
+
+  it('fails closed on invalid configuration with sanitized errors', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { env } = createHarness({ MAX_TOTAL_SHARES: 'not-a-number' });
+
+    const response = await worker.fetch(new Request('https://share.example/health'), env);
+    const body = (await response.json()) as { error: string; requestId: string };
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe('Service is temporarily unavailable.');
+    expect(JSON.stringify(body)).not.toContain('MAX_TOTAL_SHARES');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(body.requestId).toBe(response.headers.get('X-Request-Id'));
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/share-worker/src/index.ts
+++ b/share-worker/src/index.ts
@@ -1,175 +1,610 @@
-/**
- * Excalimate Share Worker
- *
- * Lightweight Cloudflare Worker + R2 for E2E encrypted sharing.
- * Stores opaque encrypted blobs — never sees the encryption key.
- *
- * Cost-optimized for Cloudflare free tier:
- *   - 10 GB storage / month  → enforced via MAX_TOTAL_SHARES + MAX_SHARE_SIZE_MB
- *   - 1M Class A ops / month → enforced via daily upload cap
- *   - 10M Class B ops / month → mitigated via aggressive Cache-Control
- *
- * Routes:
- *   POST /share         → Upload encrypted blob, returns { id }
- *   GET  /share/:id     → Download encrypted blob
- *   GET  /health        → Health check
- */
+import { ShareQuota } from './quota';
 
-interface Env {
+export { ShareQuota };
+
+export interface Env {
   SHARE_BUCKET: R2Bucket;
-  /** Max upload size in MB (default: 2) */
-  MAX_SHARE_SIZE_MB: string;
-  /** Days before shares expire (default: 30) */
-  SHARE_TTL_DAYS: string;
-  /** Max total shares stored at any time (default: 2000). 2000 × 2MB = 4GB worst case. */
-  MAX_TOTAL_SHARES: string;
-  /** Max uploads per day across all users (default: 500). 500 × 30 = 15k/month, well within 1M Class A. */
-  MAX_DAILY_UPLOADS: string;
-  /** Comma-separated allowed origins */
-  ALLOWED_ORIGINS: string;
+  LEGACY_SHARE_BUCKET: R2Bucket;
+  SHARE_QUOTA: DurableObjectNamespace;
+  MAX_SHARE_SIZE_MB?: string;
+  SHARE_TTL_DAYS?: string;
+  MAX_TOTAL_SHARES?: string;
+  MAX_TOTAL_STORAGE_MB?: string;
+  ALLOWED_ORIGINS?: string;
 }
 
-// In-memory daily upload counter (resets on worker cold start, which is fine —
-// Cloudflare Workers restart frequently, so this is a soft cap, not exact).
-let dailyUploads = 0;
-let dailyResetDate = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+interface ShareConfig {
+  allowedOrigins: Set<string>;
+  maxShareSizeBytes: number;
+  maxTotalShares: number;
+  maxTotalStorageBytes: number;
+  ttlDays: number;
+}
 
-function checkDailyLimit(max: number): boolean {
-  const today = new Date().toISOString().slice(0, 10);
-  if (today !== dailyResetDate) {
-    dailyUploads = 0;
-    dailyResetDate = today;
+interface QuotaReservation {
+  id: string;
+  size: number;
+  expiresAt: number;
+  maxShares: number;
+  maxBytes: number;
+}
+
+interface QuotaResponse {
+  accepted: boolean;
+}
+
+const SHARE_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+const LEGACY_SHARE_ID_PATTERN = /^[A-Za-z0-9_-]{8}$/;
+const DELETE_SECRET_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DAY_MS = 86_400_000;
+const DEFAULT_MAX_SHARE_SIZE_MB = 2;
+const DEFAULT_SHARE_TTL_DAYS = 30;
+const DEFAULT_MAX_TOTAL_SHARES = 2_000;
+const DEFAULT_MAX_TOTAL_STORAGE_MB = 4_096;
+const MAX_CONFIGURED_SHARE_SIZE_MB = 25;
+const MAX_CONFIGURED_TTL_DAYS = 365;
+
+class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly headers?: HeadersInit,
+  ) {
+    super(message);
   }
-  return dailyUploads < max;
 }
 
-function corsHeaders(request: Request, env: Env): HeadersInit {
-  const origin = request.headers.get('Origin') ?? '';
-  const allowed = env.ALLOWED_ORIGINS.split(',').map((s) => s.trim());
-  const isAllowed = allowed.includes(origin) || allowed.includes('*');
+class PayloadTooLargeError extends HttpError {
+  constructor(maxSizeMb: number) {
+    super(413, `Maximum share size is ${maxSizeMb} MB.`);
+  }
+}
+
+function parseInteger(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number {
+  const candidate = value ?? String(fallback);
+  if (!/^(0|[1-9]\d*)$/.test(candidate)) {
+    throw new Error(`${name} must be an integer.`);
+  }
+
+  const parsed = Number(candidate);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} is outside its supported range.`);
+  }
+  return parsed;
+}
+
+function parseAllowedOrigins(value: string | undefined): Set<string> {
+  if (!value?.trim()) {
+    throw new Error('ALLOWED_ORIGINS must contain at least one origin.');
+  }
+
+  const origins = new Set<string>();
+  for (const rawOrigin of value.split(',')) {
+    const origin = rawOrigin.trim();
+    if (!origin || origin === '*') {
+      throw new Error('ALLOWED_ORIGINS cannot contain empty or wildcard origins.');
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error('ALLOWED_ORIGINS contains an invalid URL.');
+    }
+
+    const isLocalHttp =
+      parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1');
+    if (parsed.origin !== origin || (parsed.protocol !== 'https:' && !isLocalHttp)) {
+      throw new Error('ALLOWED_ORIGINS must contain HTTPS origins or local development origins.');
+    }
+    origins.add(origin);
+  }
+
+  return origins;
+}
+
+function parseConfig(env: Env): ShareConfig {
+  const maxShareSizeMb = parseInteger(
+    env.MAX_SHARE_SIZE_MB,
+    DEFAULT_MAX_SHARE_SIZE_MB,
+    'MAX_SHARE_SIZE_MB',
+    1,
+    MAX_CONFIGURED_SHARE_SIZE_MB,
+  );
+  const maxTotalStorageMb = parseInteger(
+    env.MAX_TOTAL_STORAGE_MB,
+    DEFAULT_MAX_TOTAL_STORAGE_MB,
+    'MAX_TOTAL_STORAGE_MB',
+    maxShareSizeMb,
+    100_000,
+  );
+
   return {
-    'Access-Control-Allow-Origin': isAllowed ? origin : '',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Max-Age': '86400',
+    allowedOrigins: parseAllowedOrigins(env.ALLOWED_ORIGINS),
+    maxShareSizeBytes: maxShareSizeMb * 1024 * 1024,
+    maxTotalShares: parseInteger(
+      env.MAX_TOTAL_SHARES,
+      DEFAULT_MAX_TOTAL_SHARES,
+      'MAX_TOTAL_SHARES',
+      1,
+      100_000,
+    ),
+    maxTotalStorageBytes: maxTotalStorageMb * 1024 * 1024,
+    ttlDays: parseInteger(
+      env.SHARE_TTL_DAYS,
+      DEFAULT_SHARE_TTL_DAYS,
+      'SHARE_TTL_DAYS',
+      1,
+      MAX_CONFIGURED_TTL_DAYS,
+    ),
   };
 }
 
-function generateId(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(6));
+function securityHeaders(requestId: string, cacheControl = 'no-store'): Headers {
+  return new Headers({
+    'Cache-Control': cacheControl,
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Request-Id': requestId,
+  });
+}
+
+function addCorsHeaders(
+  headers: Headers,
+  request: Request,
+  config: ShareConfig,
+  methods = 'GET, POST, DELETE, OPTIONS',
+): void {
+  const origin = request.headers.get('Origin');
+  headers.append('Vary', 'Origin');
+  if (!origin || !config.allowedOrigins.has(origin)) return;
+
+  headers.set('Access-Control-Allow-Origin', origin);
+  headers.set('Access-Control-Allow-Methods', methods);
+  headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  headers.set('Access-Control-Expose-Headers', 'X-Request-Id');
+  headers.set('Access-Control-Max-Age', '86400');
+}
+
+function responseHeaders(
+  request: Request,
+  config: ShareConfig,
+  requestId: string,
+  cacheControl = 'no-store',
+  methods?: string,
+): Headers {
+  const headers = securityHeaders(requestId, cacheControl);
+  addCorsHeaders(headers, request, config, methods);
+  return headers;
+}
+
+function jsonResponse(
+  request: Request,
+  config: ShareConfig,
+  requestId: string,
+  body: unknown,
+  status = 200,
+  extraHeaders?: HeadersInit,
+): Response {
+  const headers = responseHeaders(request, config, requestId);
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+  if (extraHeaders) {
+    new Headers(extraHeaders).forEach((value, key) => headers.set(key, value));
+  }
+  return Response.json(body, { status, headers });
+}
+
+function errorResponse(
+  request: Request,
+  config: ShareConfig,
+  requestId: string,
+  error: HttpError,
+): Response {
+  return jsonResponse(
+    request,
+    config,
+    requestId,
+    { error: error.message, requestId },
+    error.status,
+    error.headers,
+  );
+}
+
+function isAllowedOrigin(request: Request, config: ShareConfig): boolean {
+  const origin = request.headers.get('Origin');
+  return origin !== null && config.allowedOrigins.has(origin);
+}
+
+function requireAllowedOrigin(request: Request, config: ShareConfig): void {
+  if (!isAllowedOrigin(request, config)) {
+    throw new HttpError(403, 'Origin is not allowed.');
+  }
+}
+
+function generateToken(byteLength: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
   let binary = '';
-  for (const b of bytes) binary += String.fromCharCode(b);
+  for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const padding = '='.repeat((4 - (value.length % 4)) % 4);
+  const binary = atob(value.replace(/-/g, '+').replace(/_/g, '/') + padding);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function hashDeleteSecret(secret: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+  const bytes = new Uint8Array(digest);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function constantTimeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  const length = Math.max(left.length, right.length);
+  let difference = left.length ^ right.length;
+  for (let index = 0; index < length; index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+async function verifyDeleteSecret(secret: string, verifier: string): Promise<boolean> {
+  const candidateVerifier = await hashDeleteSecret(secret);
+  return constantTimeEqual(decodeBase64Url(candidateVerifier), decodeBase64Url(verifier));
+}
+
+function parseContentLength(request: Request, maxSizeBytes: number): number | null {
+  const rawLength = request.headers.get('Content-Length');
+  if (rawLength === null) return null;
+  if (!/^(0|[1-9]\d*)$/.test(rawLength)) {
+    throw new HttpError(400, 'Content-Length is invalid.');
+  }
+
+  const length = Number(rawLength);
+  if (!Number.isSafeInteger(length)) {
+    throw new HttpError(400, 'Content-Length is invalid.');
+  }
+  if (length > maxSizeBytes) {
+    throw new PayloadTooLargeError(maxSizeBytes / 1024 / 1024);
+  }
+  return length;
+}
+
+async function readBoundedBody(request: Request, maxSizeBytes: number): Promise<ArrayBuffer> {
+  if (!request.body) return new ArrayBuffer(0);
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    totalBytes += value.byteLength;
+    if (totalBytes > maxSizeBytes) {
+      await reader.cancel();
+      throw new PayloadTooLargeError(maxSizeBytes / 1024 / 1024);
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body.buffer;
+}
+
+function quotaStub(env: Env): DurableObjectStub {
+  const id = env.SHARE_QUOTA.idFromName('global-share-quota');
+  return env.SHARE_QUOTA.get(id);
+}
+
+async function reserveQuota(env: Env, reservation: QuotaReservation): Promise<boolean> {
+  const response = await quotaStub(env).fetch('https://quota.internal/reserve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(reservation),
+  });
+  if (!response.ok) throw new Error('Share quota service unavailable.');
+
+  const result = await response.json<QuotaResponse>();
+  return result.accepted;
+}
+
+async function releaseQuota(env: Env, id: string): Promise<void> {
+  const response = await quotaStub(env).fetch('https://quota.internal/release', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
+  });
+  if (!response.ok) throw new Error('Share quota service unavailable.');
+}
+
+function parseShareId(pathname: string): string | null {
+  const match = /^\/share\/([^/]+)$/.exec(pathname);
+  return match?.[1] ?? null;
+}
+
+function assertValidShareId(id: string | null, allowLegacy = false): asserts id is string {
+  if (!id || (!SHARE_ID_PATTERN.test(id) && !(allowLegacy && LEGACY_SHARE_ID_PATTERN.test(id)))) {
+    throw new HttpError(400, 'Share ID is invalid.');
+  }
+}
+
+function assertNoQuery(url: URL): void {
+  if (url.search) {
+    throw new HttpError(400, 'Query parameters are not supported.');
+  }
+}
+
+function parseStoredExpiry(value: string | undefined): number {
+  if (!value) throw new Error('Share expiry metadata is missing.');
+  const expiresAt = Date.parse(value);
+  if (!Number.isFinite(expiresAt)) throw new Error('Share expiry metadata is invalid.');
+  return expiresAt;
+}
+
+async function handleUpload(
+  request: Request,
+  env: Env,
+  config: ShareConfig,
+  requestId: string,
+): Promise<Response> {
+  requireAllowedOrigin(request, config);
+  if (request.headers.get('Content-Type') !== 'application/octet-stream') {
+    throw new HttpError(415, 'Content-Type must be application/octet-stream.');
+  }
+
+  const declaredLength = parseContentLength(request, config.maxShareSizeBytes);
+  const body = await readBoundedBody(request, config.maxShareSizeBytes);
+  if (body.byteLength === 0) throw new HttpError(400, 'Request body is empty.');
+  if (declaredLength !== null && declaredLength !== body.byteLength) {
+    throw new HttpError(400, 'Content-Length does not match the request body.');
+  }
+
+  const id = generateToken(16);
+  const deleteSecret = generateToken(32);
+  const deleteVerifier = await hashDeleteSecret(deleteSecret);
+  const expiresAtMs = Date.now() + config.ttlDays * DAY_MS;
+  const expiresAt = new Date(expiresAtMs).toISOString();
+  const accepted = await reserveQuota(env, {
+    id,
+    size: body.byteLength,
+    expiresAt: expiresAtMs,
+    maxShares: config.maxTotalShares,
+    maxBytes: config.maxTotalStorageBytes,
+  });
+  if (!accepted) {
+    throw new HttpError(429, 'Share storage capacity is currently full.', {
+      'Retry-After': '3600',
+    });
+  }
+
+  try {
+    await env.SHARE_BUCKET.put(id, body, {
+      httpMetadata: {
+        cacheControl: `public, max-age=${config.ttlDays * 86400}, immutable`,
+        contentType: 'application/octet-stream',
+      },
+      customMetadata: {
+        deleteVerifier,
+        expiresAt,
+      },
+    });
+  } catch (error) {
+    await releaseQuota(env, id).catch((releaseError: unknown) => {
+      console.error(`[${requestId}] failed to roll back quota reservation`, {
+        error: releaseError instanceof Error ? releaseError.message : 'Unknown error',
+      });
+    });
+    throw error;
+  }
+
+  return jsonResponse(request, config, requestId, { id, expiresAt, deleteSecret }, 201);
+}
+
+async function handleDownload(
+  request: Request,
+  env: Env,
+  config: ShareConfig,
+  requestId: string,
+  id: string,
+): Promise<Response> {
+  const bucket = LEGACY_SHARE_ID_PATTERN.test(id) ? env.LEGACY_SHARE_BUCKET : env.SHARE_BUCKET;
+  const object = await bucket.get(id);
+  if (!object) throw new HttpError(404, 'Share was not found or has expired.');
+
+  const expiresAt = parseStoredExpiry(object.customMetadata?.expiresAt);
+  if (expiresAt <= Date.now()) {
+    throw new HttpError(404, 'Share was not found or has expired.');
+  }
+
+  const remainingSeconds = Math.max(1, Math.floor((expiresAt - Date.now()) / 1000));
+  const headers = responseHeaders(
+    request,
+    config,
+    requestId,
+    `public, max-age=${remainingSeconds}, immutable`,
+  );
+  headers.set('Content-Type', 'application/octet-stream');
+  return new Response(object.body, { headers });
+}
+
+async function handleDelete(
+  request: Request,
+  env: Env,
+  config: ShareConfig,
+  requestId: string,
+  id: string,
+): Promise<Response> {
+  requireAllowedOrigin(request, config);
+  const object = await env.SHARE_BUCKET.head(id);
+  if (!object) throw new HttpError(404, 'Share was not found or has expired.');
+
+  const authorization = request.headers.get('Authorization') ?? '';
+  const match = /^Bearer ([A-Za-z0-9_-]{43})$/.exec(authorization);
+  const suppliedSecret = match?.[1] ?? '';
+  const verifier = object.customMetadata?.deleteVerifier ?? '';
+  const verifierIsValid = DELETE_SECRET_PATTERN.test(verifier);
+  const secretMatches = verifierIsValid && (await verifyDeleteSecret(suppliedSecret, verifier));
+  if (!match || !secretMatches) {
+    throw new HttpError(403, 'Delete capability is invalid.');
+  }
+
+  await env.SHARE_BUCKET.delete(id);
+  try {
+    await releaseQuota(env, id);
+  } catch (error) {
+    console.error(`[${requestId}] deleted share but failed to release quota`, {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: responseHeaders(request, config, requestId),
+  });
+}
+
+function handlePreflight(
+  request: Request,
+  config: ShareConfig,
+  requestId: string,
+  methods: string[],
+): Response {
+  requireAllowedOrigin(request, config);
+  const requestedMethod = request.headers.get('Access-Control-Request-Method');
+  if (!requestedMethod || !methods.includes(requestedMethod)) {
+    throw new HttpError(405, 'Requested method is not allowed.', {
+      Allow: methods.join(', '),
+    });
+  }
+
+  const requestedHeaders = (request.headers.get('Access-Control-Request-Headers') ?? '')
+    .split(',')
+    .map((header) => header.trim().toLowerCase())
+    .filter(Boolean);
+  if (requestedHeaders.some((header) => !['authorization', 'content-type'].includes(header))) {
+    throw new HttpError(400, 'Requested headers are not allowed.');
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: responseHeaders(
+      request,
+      config,
+      requestId,
+      'no-store',
+      [...methods, 'OPTIONS'].join(', '),
+    ),
+  });
+}
+
+async function routeRequest(
+  request: Request,
+  env: Env,
+  config: ShareConfig,
+  requestId: string,
+): Promise<Response> {
+  const url = new URL(request.url);
+
+  if (url.pathname === '/health') {
+    assertNoQuery(url);
+    if (request.method !== 'GET') {
+      throw new HttpError(405, 'Method is not allowed.', { Allow: 'GET' });
+    }
+    return jsonResponse(request, config, requestId, { status: 'ok' });
+  }
+
+  if (url.pathname === '/share') {
+    assertNoQuery(url);
+    if (request.method === 'OPTIONS') {
+      return handlePreflight(request, config, requestId, ['POST']);
+    }
+    if (request.method !== 'POST') {
+      throw new HttpError(405, 'Method is not allowed.', { Allow: 'POST, OPTIONS' });
+    }
+    return handleUpload(request, env, config, requestId);
+  }
+
+  if (url.pathname.startsWith('/share/')) {
+    assertNoQuery(url);
+    const id = parseShareId(url.pathname);
+
+    if (request.method === 'OPTIONS') {
+      const requestedMethod = request.headers.get('Access-Control-Request-Method');
+      assertValidShareId(id, requestedMethod === 'GET');
+      return handlePreflight(request, config, requestId, ['GET', 'DELETE']);
+    }
+    if (request.method === 'GET') {
+      assertValidShareId(id, true);
+      return handleDownload(request, env, config, requestId, id);
+    }
+    if (request.method === 'DELETE') {
+      assertValidShareId(id);
+      return handleDelete(request, env, config, requestId, id);
+    }
+    assertValidShareId(id);
+    throw new HttpError(405, 'Method is not allowed.', {
+      Allow: 'GET, DELETE, OPTIONS',
+    });
+  }
+
+  throw new HttpError(404, 'Route was not found.');
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
-    const cors = corsHeaders(request, env);
-
-    if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: cors });
-    }
-
-    // ── POST /share ─────────────────────────────────────────────
-    if (request.method === 'POST' && url.pathname === '/share') {
-      const maxSizeBytes = parseInt(env.MAX_SHARE_SIZE_MB || '2', 10) * 1024 * 1024;
-      const maxDaily = parseInt(env.MAX_DAILY_UPLOADS || '500', 10);
-
-      // Enforce daily upload cap (protects Class A operations budget)
-      if (!checkDailyLimit(maxDaily)) {
-        return Response.json(
-          { error: 'Daily upload limit reached. Try again tomorrow.' },
-          { status: 429, headers: cors },
-        );
-      }
-
-      // Check Content-Length before reading body (avoid wasting CPU)
-      const contentLength = parseInt(request.headers.get('Content-Length') ?? '0', 10);
-      if (contentLength > maxSizeBytes) {
-        return Response.json(
-          { error: `Max size: ${env.MAX_SHARE_SIZE_MB || '2'} MB.` },
-          { status: 413, headers: cors },
-        );
-      }
-
-      const body = await request.arrayBuffer();
-      if (body.byteLength === 0) {
-        return Response.json(
-          { error: 'Empty body.' },
-          { status: 400, headers: cors },
-        );
-      }
-      if (body.byteLength > maxSizeBytes) {
-        return Response.json(
-          { error: `Max size: ${env.MAX_SHARE_SIZE_MB || '2'} MB.` },
-          { status: 413, headers: cors },
-        );
-      }
-
-      const id = generateId();
-      const ttlDays = parseInt(env.SHARE_TTL_DAYS || '30', 10);
-
-      await env.SHARE_BUCKET.put(id, body, {
-        httpMetadata: {
-          contentType: 'application/octet-stream',
-          // Immutable content — aggressive CDN caching reduces Class B ops
-          cacheControl: `public, max-age=${ttlDays * 86400}, immutable`,
-        },
-        customMetadata: {
-          expiresAt: new Date(Date.now() + ttlDays * 86400_000).toISOString(),
-        },
+    const requestId = crypto.randomUUID();
+    let config: ShareConfig;
+    try {
+      config = parseConfig(env);
+    } catch (error) {
+      console.error(`[${requestId}] invalid worker configuration`, {
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
-
-      dailyUploads++;
-
-      return Response.json({ id }, { headers: cors });
-    }
-
-    // ── GET /share/:id ──────────────────────────────────────────
-    if (request.method === 'GET' && url.pathname.startsWith('/share/')) {
-      const id = url.pathname.slice('/share/'.length);
-      if (!id || id.length < 4) {
-        return Response.json({ error: 'Invalid ID.' }, { status: 400, headers: cors });
-      }
-
-      const object = await env.SHARE_BUCKET.get(id);
-      if (!object) {
-        return Response.json(
-          { error: 'Not found or expired.' },
-          { status: 404, headers: cors },
-        );
-      }
-
-      // Check expiry — don't delete here (saves a Class A op).
-      // The R2 lifecycle rule handles cleanup in bulk.
-      const expiresAt = object.customMetadata?.expiresAt;
-      if (expiresAt && new Date(expiresAt) < new Date()) {
-        return Response.json(
-          { error: 'Expired.' },
-          { status: 404, headers: cors },
-        );
-      }
-
-      const ttlDays = parseInt(env.SHARE_TTL_DAYS || '30', 10);
-      return new Response(object.body, {
-        headers: {
-          ...cors,
-          'Content-Type': 'application/octet-stream',
-          // Immutable — CDN caches heavily, dramatically reduces Class B R2 reads
-          'Cache-Control': `public, max-age=${ttlDays * 86400}, immutable`,
-        },
-      });
-    }
-
-    // ── GET /health ─────────────────────────────────────────────
-    if (request.method === 'GET' && url.pathname === '/health') {
+      const headers = securityHeaders(requestId);
+      headers.set('Content-Type', 'application/json; charset=utf-8');
       return Response.json(
-        { status: 'ok', dailyUploads, dailyResetDate },
-        { headers: cors },
+        { error: 'Service is temporarily unavailable.', requestId },
+        { status: 503, headers },
       );
     }
 
-    return Response.json({ error: 'Not found.' }, { status: 404, headers: cors });
+    try {
+      return await routeRequest(request, env, config, requestId);
+    } catch (error) {
+      if (error instanceof HttpError) {
+        return errorResponse(request, config, requestId, error);
+      }
+
+      const url = new URL(request.url);
+      console.error(`[${requestId}] unhandled share worker error`, {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        method: request.method,
+        pathname: url.pathname,
+      });
+      return errorResponse(
+        request,
+        config,
+        requestId,
+        new HttpError(500, 'Internal server error.'),
+      );
+    }
   },
-};
+} satisfies ExportedHandler<Env>;

--- a/share-worker/src/quota.ts
+++ b/share-worker/src/quota.ts
@@ -1,0 +1,162 @@
+interface ReserveRequest {
+  id: string;
+  size: number;
+  expiresAt: number;
+  maxShares: number;
+  maxBytes: number;
+}
+
+interface ReleaseRequest {
+  id: string;
+}
+
+interface QuotaRow extends Record<string, SqlStorageValue> {
+  share_count: number;
+  total_bytes: number;
+}
+
+const SHARE_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+const DAY_MS = 86_400_000;
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0;
+}
+
+function isReserveRequest(value: unknown): value is ReserveRequest {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ReserveRequest>;
+  return (
+    typeof candidate.id === 'string' &&
+    SHARE_ID_PATTERN.test(candidate.id) &&
+    isPositiveSafeInteger(candidate.size) &&
+    isPositiveSafeInteger(candidate.expiresAt) &&
+    isPositiveSafeInteger(candidate.maxShares) &&
+    isPositiveSafeInteger(candidate.maxBytes)
+  );
+}
+
+function isReleaseRequest(value: unknown): value is ReleaseRequest {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ReleaseRequest>;
+  return typeof candidate.id === 'string' && SHARE_ID_PATTERN.test(candidate.id);
+}
+
+function quotaExpiry(expiresAt: number): number {
+  return Math.ceil(expiresAt / DAY_MS) * DAY_MS;
+}
+
+export class ShareQuota {
+  private readonly state: DurableObjectState;
+  private readonly sql: SqlStorage;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+    this.sql = state.storage.sql;
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS quota (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        share_count INTEGER NOT NULL DEFAULT 0 CHECK (share_count >= 0),
+        total_bytes INTEGER NOT NULL DEFAULT 0 CHECK (total_bytes >= 0)
+      );
+      INSERT OR IGNORE INTO quota (singleton, share_count, total_bytes) VALUES (1, 0, 0);
+      CREATE TABLE IF NOT EXISTS shares (
+        id TEXT PRIMARY KEY,
+        size INTEGER NOT NULL CHECK (size > 0),
+        expires_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS shares_expiry ON shares (expires_at);
+      CREATE TRIGGER IF NOT EXISTS shares_after_insert
+      AFTER INSERT ON shares
+      BEGIN
+        UPDATE quota
+        SET share_count = share_count + 1,
+            total_bytes = total_bytes + NEW.size
+        WHERE singleton = 1;
+      END;
+      CREATE TRIGGER IF NOT EXISTS shares_after_delete
+      AFTER DELETE ON shares
+      BEGIN
+        UPDATE quota
+        SET share_count = share_count - 1,
+            total_bytes = total_bytes - OLD.size
+        WHERE singleton = 1;
+      END;
+    `);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+      return Response.json({ error: 'Method not allowed.' }, { status: 405 });
+    }
+
+    const pathname = new URL(request.url).pathname;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return Response.json({ error: 'Invalid request.' }, { status: 400 });
+    }
+
+    if (pathname === '/reserve') {
+      if (!isReserveRequest(body)) {
+        return Response.json({ error: 'Invalid request.' }, { status: 400 });
+      }
+      return Response.json({ accepted: await this.reserve(body) });
+    }
+
+    if (pathname === '/release') {
+      if (!isReleaseRequest(body)) {
+        return Response.json({ error: 'Invalid request.' }, { status: 400 });
+      }
+      this.sql.exec('DELETE FROM shares WHERE id = ?', body.id);
+      return Response.json({ released: true });
+    }
+
+    return Response.json({ error: 'Not found.' }, { status: 404 });
+  }
+
+  async alarm(): Promise<void> {
+    this.pruneExpired(Date.now());
+    await this.scheduleNextAlarm();
+  }
+
+  private async reserve(request: ReserveRequest): Promise<boolean> {
+    this.pruneExpired(Date.now());
+    const quota = this.sql
+      .exec<QuotaRow>('SELECT share_count, total_bytes FROM quota WHERE singleton = 1')
+      .one();
+    if (
+      quota.share_count >= request.maxShares ||
+      quota.total_bytes + request.size > request.maxBytes
+    ) {
+      return false;
+    }
+
+    const result = this.sql.exec(
+      'INSERT OR IGNORE INTO shares (id, size, expires_at) VALUES (?, ?, ?)',
+      request.id,
+      request.size,
+      quotaExpiry(request.expiresAt),
+    );
+    if (result.rowsWritten === 0) return false;
+
+    await this.scheduleNextAlarm();
+    return true;
+  }
+
+  private pruneExpired(now: number): void {
+    this.sql.exec('DELETE FROM shares WHERE expires_at <= ?', now);
+  }
+
+  private async scheduleNextAlarm(): Promise<void> {
+    const next = this.sql
+      .exec<{ expires_at: number }>('SELECT expires_at FROM shares ORDER BY expires_at ASC LIMIT 1')
+      .toArray()[0];
+    if (!next) return;
+
+    const currentAlarm = await this.state.storage.getAlarm();
+    if (currentAlarm === null || currentAlarm !== next.expires_at) {
+      await this.state.storage.setAlarm(next.expires_at);
+    }
+  }
+}

--- a/share-worker/vitest.config.ts
+++ b/share-worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/share-worker/wrangler.jsonc
+++ b/share-worker/wrangler.jsonc
@@ -1,23 +1,39 @@
 {
-	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "excalimate-share",
-	"main": "src/index.ts",
-	"compatibility_date": "2025-09-27",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
-	"r2_buckets": [
-		{
-			"bucket_name": "excalimate-shares",
-			"binding": "SHARE_BUCKET"
-		}
-	],
-	"rules": [],
-	"vars": {
-		"MAX_SHARE_SIZE_MB": "2",
-		"SHARE_TTL_DAYS": "30",
-		"MAX_TOTAL_SHARES": "2000",
-		"MAX_DAILY_UPLOADS": "500",
-		"ALLOWED_ORIGINS": "https://app.excalimate.com,https://excalimate.com,https://www.excalimate.com,http://localhost:5173",
-	},
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "excalimate-share",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-09-27",
+  "compatibility_flags": ["nodejs_compat"],
+  "r2_buckets": [
+    {
+      "bucket_name": "excalimate-shares-v2",
+      "binding": "SHARE_BUCKET",
+    },
+    {
+      "bucket_name": "excalimate-shares",
+      "binding": "LEGACY_SHARE_BUCKET",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SHARE_QUOTA",
+        "class_name": "ShareQuota",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ShareQuota"],
+    },
+  ],
+  "rules": [],
+  "vars": {
+    "MAX_SHARE_SIZE_MB": "2",
+    "SHARE_TTL_DAYS": "30",
+    "MAX_TOTAL_SHARES": "2000",
+    "MAX_TOTAL_STORAGE_MB": "4096",
+    "ALLOWED_ORIGINS": "https://app.excalimate.com,https://excalimate.com,https://www.excalimate.com,http://localhost:5173",
+  },
 }

--- a/src/components/Toolbar/FileControls.tsx
+++ b/src/components/Toolbar/FileControls.tsx
@@ -3,7 +3,7 @@ import { Menu, Button, Modal, Select, Divider, TextInput } from '@mantine/core';
 import {
   IconFilePlus, IconFolderOpen, IconDeviceFloppy,
   IconFileImport, IconShare, IconChevronDown, IconSettings, IconMaximize, IconServer, IconCheck,
-  IconCookie,
+  IconCookie, IconTrash,
 } from '@tabler/icons-react';
 import { ImportExcalidrawModal } from './ImportExcalidrawModal';
 import { LoadAnimationModal } from './LoadAnimationModal';
@@ -22,7 +22,7 @@ export function FileControls() {
     handleImportFile, handleImportUrl,
     handleLoadProjectFile, handleLoadCheckpointFile, handleLoadShareUrl,
   } = useFileOperations();
-  const { loading, handleShare } = useShareOperations();
+  const { canRevoke, handleRevokeShare, loading, handleShare, revoking } = useShareOperations();
 
   const [importOpen, setImportOpen] = useState(false);
   const [loadOpen, setLoadOpen] = useState(false);
@@ -59,8 +59,20 @@ export function FileControls() {
 
           <Menu.Divider />
 
-          <Menu.Item leftSection={<IconShare size={16} />} onClick={handleShare} disabled={loading}>
+          <Menu.Item
+            leftSection={<IconShare size={16} />}
+            onClick={handleShare}
+            disabled={loading || revoking}
+          >
             Share
+          </Menu.Item>
+          <Menu.Item
+            color="red"
+            leftSection={<IconTrash size={16} />}
+            onClick={handleRevokeShare}
+            disabled={!canRevoke || loading || revoking}
+          >
+            Revoke last share
           </Menu.Item>
 
           <Menu.Divider />

--- a/src/components/Toolbar/useShareOperations.test.tsx
+++ b/src/components/Toolbar/useShareOperations.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useShareOperations } from './useShareOperations';
+
+const shareId = 'AbCdEfGhIjKlMnOpQrStUv';
+const deleteSecret = 'd'.repeat(43);
+const encryptionKey = 'browser-only-encryption-key';
+const expiresAt = '2030-01-02T03:04:05.000Z';
+
+const mocks = vi.hoisted(() => ({
+  ciphertext: new Uint8Array([0, 12, 250, 19]).buffer,
+  deleteEncryptedShare: vi.fn(),
+  encryptionKey: 'browser-only-encryption-key',
+  notification: vi.fn(),
+  trackShare: vi.fn(),
+  uploadEncryptedShare: vi.fn(),
+  writeText: vi.fn(),
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: mocks.notification },
+}));
+
+vi.mock('../../stores/projectStore', () => ({
+  useProjectStore: {
+    getState: () => ({
+      cameraFrame: { aspectRatio: '16:9' },
+      project: {
+        name: 'Secret project name',
+        scene: { appState: {}, elements: [], files: {} },
+      },
+    }),
+  },
+}));
+
+vi.mock('../../stores/animationStore', () => ({
+  useAnimationStore: {
+    getState: () => ({
+      clipEnd: 1000,
+      clipStart: 0,
+      timeline: { duration: 1000, tracks: [] },
+    }),
+  },
+}));
+
+vi.mock('../../services/encryption', () => ({
+  encryptData: vi.fn().mockResolvedValue(mocks.ciphertext),
+  exportKeyToString: vi.fn().mockResolvedValue(mocks.encryptionKey),
+  generateEncryptionKey: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../services/analytics/posthog', () => ({
+  trackShare: mocks.trackShare,
+}));
+
+vi.mock('../../services/shareApi', () => ({
+  buildEditorShareUrl: (baseUrl: string, id: string, key: string) =>
+    `${baseUrl}#share=${id},${key}`,
+  deleteEncryptedShare: mocks.deleteEncryptedShare,
+  formatShareExpiry: () => 'Jan 2, 2030, 3:04 AM',
+  uploadEncryptedShare: mocks.uploadEncryptedShare,
+}));
+
+describe('useShareOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.uploadEncryptedShare.mockResolvedValue({
+      deleteSecret,
+      expiresAt,
+      id: shareId,
+    });
+    mocks.deleteEncryptedShare.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: mocks.writeText },
+    });
+  });
+
+  it('displays expiresAt without leaking capabilities to UX or analytics', async () => {
+    const { result } = renderHook(() => useShareOperations());
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(mocks.uploadEncryptedShare).toHaveBeenCalledWith(mocks.ciphertext);
+    expect(mocks.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}${window.location.pathname}#share=${shareId},${encryptionKey}`,
+    );
+    expect(mocks.writeText.mock.calls[0][0]).not.toContain(deleteSecret);
+    expect(mocks.trackShare).toHaveBeenCalledWith();
+
+    const successNotification = mocks.notification.mock.calls[0][0] as {
+      message: string;
+    };
+    expect(successNotification.message).toContain('Jan 2, 2030, 3:04 AM');
+    expect(successNotification.message).not.toContain(deleteSecret);
+    expect(successNotification.message).not.toContain(encryptionKey);
+    expect(result.current.canRevoke).toBe(true);
+  });
+
+  it('uses the in-memory deletion capability for explicit revoke', async () => {
+    const { result } = renderHook(() => useShareOperations());
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    await act(async () => {
+      await result.current.handleRevokeShare();
+    });
+
+    expect(mocks.deleteEncryptedShare).toHaveBeenCalledWith({
+      deleteSecret,
+      id: shareId,
+    });
+    expect(mocks.trackShare).toHaveBeenCalledTimes(1);
+    expect(result.current.canRevoke).toBe(false);
+  });
+});

--- a/src/components/Toolbar/useShareOperations.tsx
+++ b/src/components/Toolbar/useShareOperations.tsx
@@ -3,17 +3,20 @@ import { notifications } from '@mantine/notifications';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAnimationStore } from '../../stores/animationStore';
-import {
-  encryptData,
-  exportKeyToString,
-  generateEncryptionKey,
-} from '../../services/encryption';
+import { encryptData, exportKeyToString, generateEncryptionKey } from '../../services/encryption';
 import { trackShare } from '../../services/analytics/posthog';
-
-const SHARE_API_URL = import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
+import {
+  buildEditorShareUrl,
+  deleteEncryptedShare,
+  formatShareExpiry,
+  type ShareDeleteCapability,
+  uploadEncryptedShare,
+} from '../../services/shareApi';
 
 export function useShareOperations() {
   const [loading, setLoading] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [deleteCapability, setDeleteCapability] = useState<ShareDeleteCapability | null>(null);
 
   const handleShare = async () => {
     const project = useProjectStore.getState().project;
@@ -44,24 +47,19 @@ export function useShareOperations() {
       const encrypted = await encryptData(payload, key);
       const keyStr = await exportKeyToString(key);
 
-      // Upload encrypted blob to share service (Cloudflare Worker + R2)
-      const response = await fetch(`${SHARE_API_URL}/share`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        body: encrypted,
-      });
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({ error: response.statusText }));
-        throw new Error((err as { error?: string }).error ?? `Upload failed: ${response.status}`);
-      }
-      const { id } = await response.json() as { id: string };
+      const { id, expiresAt, deleteSecret } = await uploadEncryptedShare(encrypted);
+      setDeleteCapability({ id, deleteSecret });
 
-      const shareUrl = `${window.location.origin}${window.location.pathname}#share=${id},${keyStr}`;
+      const shareUrl = buildEditorShareUrl(
+        `${window.location.origin}${window.location.pathname}`,
+        id,
+        keyStr,
+      );
       await navigator.clipboard.writeText(shareUrl);
       trackShare();
       notifications.show({
         title: 'Share link copied',
-        message: 'E2E encrypted — the server only stores an encrypted blob it cannot read.',
+        message: `E2E encrypted. The link expires ${formatShareExpiry(expiresAt)}.`,
         color: 'green',
         icon: <IconCheck size={16} />,
       });
@@ -77,8 +75,37 @@ export function useShareOperations() {
     }
   };
 
+  const handleRevokeShare = async () => {
+    if (!deleteCapability) return;
+    const revokedCapability = deleteCapability;
+
+    try {
+      setRevoking(true);
+      await deleteEncryptedShare(revokedCapability);
+      setDeleteCapability((current) => (current?.id === revokedCapability.id ? null : current));
+      notifications.show({
+        title: 'Share revoked',
+        message: 'The encrypted share is no longer available from the share service.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (e) {
+      notifications.show({
+        title: 'Revoke failed',
+        message: e instanceof Error ? e.message : 'Unknown error',
+        color: 'red',
+        icon: <IconX size={16} />,
+      });
+    } finally {
+      setRevoking(false);
+    }
+  };
+
   return {
+    canRevoke: deleteCapability !== null,
+    handleRevokeShare,
     loading,
     handleShare,
+    revoking,
   };
 }

--- a/src/services/shareApi.test.ts
+++ b/src/services/shareApi.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildEditorShareUrl,
+  deleteEncryptedShare,
+  formatShareExpiry,
+  uploadEncryptedShare,
+} from './shareApi';
+
+const shareId = 'AbCdEfGhIjKlMnOpQrStUv';
+const deleteSecret = 'd'.repeat(43);
+const encryptionKey = 'browser-only-encryption-key';
+const expiresAt = '2030-01-02T03:04:05.000Z';
+
+describe('share API client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads only ciphertext and parses expiry and deletion capability', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(Response.json({ id: shareId, expiresAt, deleteSecret }, { status: 201 }));
+    const ciphertext = new Uint8Array([0, 12, 250, 19]).buffer;
+
+    const result = await uploadEncryptedShare(ciphertext);
+
+    expect(result).toEqual({ id: shareId, expiresAt, deleteSecret });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://share.excalimate.com/share');
+    expect(String(url)).not.toContain(encryptionKey);
+    expect(String(url)).not.toContain(deleteSecret);
+    expect(init?.headers).toEqual({ 'Content-Type': 'application/octet-stream' });
+    expect(init?.body).toBe(ciphertext);
+  });
+
+  it('keeps the deletion capability out of the public share URL', () => {
+    const url = buildEditorShareUrl('https://app.excalimate.com/', shareId, encryptionKey);
+
+    expect(url).toBe(`https://app.excalimate.com/#share=${shareId},${encryptionKey}`);
+    expect(url).not.toContain(deleteSecret);
+  });
+
+  it('sends deletion capability only in the authorization header', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await deleteEncryptedShare({ id: shareId, deleteSecret });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`https://share.excalimate.com/share/${shareId}`);
+    expect(String(url)).not.toContain(deleteSecret);
+    expect(init?.headers).toEqual({ Authorization: `Bearer ${deleteSecret}` });
+    expect(init?.body).toBeUndefined();
+  });
+
+  it('formats the server-provided expiry for success UX', () => {
+    const formatted = formatShareExpiry(expiresAt);
+
+    expect(formatted).toContain('2030');
+    expect(formatted).not.toBe(expiresAt);
+  });
+});

--- a/src/services/shareApi.ts
+++ b/src/services/shareApi.ts
@@ -1,0 +1,93 @@
+export interface ShareUploadResult {
+  id: string;
+  expiresAt: string;
+  deleteSecret: string;
+}
+
+export interface ShareDeleteCapability {
+  id: string;
+  deleteSecret: string;
+}
+
+const SHARE_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+const DELETE_SECRET_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+function shareApiUrl(): string {
+  return import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
+}
+
+async function responseError(response: Response, fallback: string): Promise<Error> {
+  let message = fallback;
+  try {
+    const body: unknown = await response.json();
+    if (body && typeof body === 'object' && 'error' in body && typeof body.error === 'string') {
+      message = body.error;
+    }
+  } catch {
+    // The status-based fallback remains safe for non-JSON upstream errors.
+  }
+  return new Error(message);
+}
+
+function parseUploadResult(value: unknown): ShareUploadResult {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Share service returned an invalid response.');
+  }
+
+  const candidate = value as Partial<ShareUploadResult>;
+  const expiresAt =
+    typeof candidate.expiresAt === 'string' ? Date.parse(candidate.expiresAt) : Number.NaN;
+  if (
+    typeof candidate.id !== 'string' ||
+    !SHARE_ID_PATTERN.test(candidate.id) ||
+    typeof candidate.deleteSecret !== 'string' ||
+    !DELETE_SECRET_PATTERN.test(candidate.deleteSecret) ||
+    !Number.isFinite(expiresAt)
+  ) {
+    throw new Error('Share service returned an invalid response.');
+  }
+
+  return {
+    id: candidate.id,
+    expiresAt: new Date(expiresAt).toISOString(),
+    deleteSecret: candidate.deleteSecret,
+  };
+}
+
+export async function uploadEncryptedShare(encrypted: ArrayBuffer): Promise<ShareUploadResult> {
+  const response = await fetch(`${shareApiUrl()}/share`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: encrypted,
+  });
+  if (!response.ok) {
+    throw await responseError(response, `Upload failed: ${response.status}`);
+  }
+
+  return parseUploadResult(await response.json());
+}
+
+export async function deleteEncryptedShare(capability: ShareDeleteCapability): Promise<void> {
+  const response = await fetch(`${shareApiUrl()}/share/${capability.id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${capability.deleteSecret}` },
+  });
+  if (!response.ok) {
+    throw await responseError(response, `Revoke failed: ${response.status}`);
+  }
+}
+
+export function buildEditorShareUrl(
+  baseUrl: string,
+  shareId: string,
+  encryptionKey: string,
+): string {
+  return `${baseUrl}#share=${shareId},${encryptionKey}`;
+}
+
+export function formatShareExpiry(expiresAt: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(expiresAt));
+}


### PR DESCRIPTION
## Summary

- harden the share Worker with 128-bit base64url IDs, strict route/config parsing, exact write origins and content type, bounded streaming with or without `Content-Length`, sanitized request-ID errors, and security/cache headers
- add anonymous revocation using a 256-bit deletion capability while storing only its SHA-256 verifier in R2 metadata
- replace the process-local counter with a SQLite-backed Durable Object that enforces live share-count and byte ceilings only on write paths
- isolate new quota-controlled writes in `excalimate-shares-v2` while keeping legacy 8-character shares readable from the original bucket during their 30-day drain window
- add an executable 30-day R2 lifecycle policy, Wrangler migration/bindings, deployment and cost documentation, and share-worker CI
- return and display `expiresAt`, keep the delete capability in memory for explicit revoke UX, and keep encryption/deletion secrets out of network URLs, notifications, and analytics
- add static editor headers for `frame-ancestors 'none'`, HSTS, nosniff, strict referrer policy, CORP, and permissions policy without constraining workers, fonts, export, PostHog, or development connections

## Validation

- 12 share-worker tests cover CORS/preflight, rejected origins, methods/content type, declared and streamed size limits, new and legacy ID formats, upload/download/cache, opacity, logical expiry, quota, deletion, sanitized config failures, and headers
- 286 app tests pass, including expiry UX and secret-leakage/revoke contract tests
- app lint, typecheck, and production build pass
- Wrangler deployment dry-run passes with R2 and SQLite Durable Object bindings
- local Wrangler upload, R2 download, quota reservation, authenticated delete, and post-delete 404 flow passes

## Deployment requirements

1. Create `excalimate-shares-v2`; keep the existing `excalimate-shares` bucket for legacy reads.
2. Run `npm run lifecycle:apply` in `share-worker` and verify the 30-day rule on both buckets.
3. Deploy the Worker so the `v1` SQLite Durable Object migration is applied.
4. Verify production `ALLOWED_ORIGINS`; wildcard and originless writes fail closed.
5. The current originless MCP `share_project` client requires a separate authenticated server-to-server contract before it can use this endpoint; MCP changes are intentionally outside this PR.

## Cost tradeoff

Each upload (and explicit delete) adds one Durable Object request plus a small number of indexed SQLite row operations. Public reads never touch quota storage. This modest write-path cost provides restart-safe count/byte admission control (`2,000` shares / `4,096 MB` by default), while immutable ciphertext caching limits R2 reads and lifecycle cleanup bounds retention.