### PR TITLE
Add V2 project document foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,13 @@
       "name": "excalimate",
       "version": "0.4.1",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@dotlottie/dotlottie-js": "^1.6.3",
         "@excalidraw/excalidraw": "^0.18.0",
+        "@excalimate/project-schema": "*",
         "@mantine/core": "^8.3.17",
         "@mantine/dropzone": "^8.3.17",
         "@mantine/form": "^8.3.17",
@@ -46,6 +50,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^17.4.0",
         "happy-dom": "^20.8.4",
         "prettier": "^3.8.1",
@@ -2038,6 +2043,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@excalimate/project-schema": {
+      "resolved": "packages/project-schema",
+      "link": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -6347,6 +6356,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9254,6 +9273,25 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "packages/project-schema": {
+      "name": "@excalimate/project-schema",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "typescript": "~5.9.3"
+      }
+    },
+    "packages/project-schema/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "license": "MIT",
   "description": "Excalimate — Create keyframe animations from Excalidraw designs, with an MCP server for AI-driven animation",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npm run build --workspace @excalimate/project-schema && tsc -b && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -20,6 +23,7 @@
   "dependencies": {
     "@dotlottie/dotlottie-js": "^1.6.3",
     "@excalidraw/excalidraw": "^0.18.0",
+    "@excalimate/project-schema": "*",
     "@mantine/core": "^8.3.17",
     "@mantine/dropzone": "^8.3.17",
     "@mantine/form": "^8.3.17",
@@ -55,6 +59,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.4.0",
     "happy-dom": "^20.8.4",
     "prettier": "^3.8.1",

--- a/packages/project-schema/package.json
+++ b/packages/project-schema/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@excalimate/project-schema",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3"
+  }
+}

--- a/packages/project-schema/src/index.ts
+++ b/packages/project-schema/src/index.ts
@@ -1,0 +1,643 @@
+import { z } from 'zod';
+
+export const V1_PROJECT_VERSION = '1.0.0' as const;
+export const PROJECT_VERSION = '2.0.0' as const;
+export const CAMERA_FRAME_TARGET_ID = '__camera_frame__' as const;
+
+export const PROJECT_LIMITS = Object.freeze({
+  maxInputBytes: 20 * 1024 * 1024,
+  maxDecompressedBytes: 64 * 1024 * 1024,
+  maxSceneElements: 10_000,
+  maxSceneFiles: 2_000,
+  maxTracks: 10_000,
+  maxKeyframesPerTrack: 10_000,
+  maxTotalKeyframes: 100_000,
+  maxTimelineDurationMs: 24 * 60 * 60 * 1_000,
+  maxIdentifierLength: 256,
+  maxNameLength: 256,
+  maxStringLength: 16 * 1024 * 1024,
+  maxCollectionItems: 200_000,
+  maxNestingDepth: 100,
+  maxVisitedValues: 1_000_000,
+  maxAbsoluteNumber: Number.MAX_SAFE_INTEGER,
+  maxAnimationValue: 1_000_000_000_000,
+});
+
+export const EASING_TYPES = [
+  'linear',
+  'easeIn',
+  'easeOut',
+  'easeInOut',
+  'easeInQuad',
+  'easeOutQuad',
+  'easeInOutQuad',
+  'easeInCubic',
+  'easeOutCubic',
+  'easeInOutCubic',
+  'easeInBack',
+  'easeOutBack',
+  'easeInOutBack',
+  'easeInElastic',
+  'easeOutElastic',
+  'easeInBounce',
+  'easeOutBounce',
+  'step',
+] as const;
+
+export const ANIMATABLE_PROPERTIES = [
+  'opacity',
+  'translateX',
+  'translateY',
+  'scaleX',
+  'scaleY',
+  'rotation',
+  'drawProgress',
+] as const;
+
+export const ASPECT_RATIOS = ['16:9', '4:3', '1:1', '3:2'] as const;
+export const PREFERRED_WORKSPACES = ['magic', 'sequence'] as const;
+
+const identifierSchema = z
+  .string()
+  .min(1)
+  .max(PROJECT_LIMITS.maxIdentifierLength);
+const nameSchema = z.string().max(PROJECT_LIMITS.maxNameLength);
+const finiteNumberSchema = z
+  .number()
+  .finite()
+  .min(-PROJECT_LIMITS.maxAnimationValue)
+  .max(PROJECT_LIMITS.maxAnimationValue);
+
+export const KeyframeSchema = z
+  .object({
+    id: identifierSchema,
+    time: finiteNumberSchema
+      .nonnegative()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs),
+    value: finiteNumberSchema,
+    easing: z.enum(EASING_TYPES),
+  })
+  .strict();
+
+export const AnimationTrackSchema = z
+  .object({
+    id: identifierSchema,
+    targetId: identifierSchema,
+    targetType: z.enum(['element', 'group']),
+    property: z.enum(ANIMATABLE_PROPERTIES),
+    keyframes: z
+      .array(KeyframeSchema)
+      .max(PROJECT_LIMITS.maxKeyframesPerTrack),
+    enabled: z.boolean(),
+  })
+  .strict()
+  .superRefine((track, context) => {
+    const keyframeIds = new Set<string>();
+    for (const keyframe of track.keyframes) {
+      if (keyframeIds.has(keyframe.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['keyframes'],
+          message: `Duplicate keyframe id "${keyframe.id}"`,
+        });
+      }
+      keyframeIds.add(keyframe.id);
+    }
+  });
+
+export const AnimationTimelineSchema = z
+  .object({
+    id: identifierSchema,
+    name: nameSchema,
+    duration: finiteNumberSchema
+      .positive()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs),
+    fps: finiteNumberSchema.int().min(1).max(240),
+    tracks: z.array(AnimationTrackSchema).max(PROJECT_LIMITS.maxTracks),
+  })
+  .strict()
+  .superRefine((timeline, context) => {
+    const trackIds = new Set<string>();
+    let totalKeyframes = 0;
+
+    for (const [trackIndex, track] of timeline.tracks.entries()) {
+      if (trackIds.has(track.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['tracks', trackIndex, 'id'],
+          message: `Duplicate track id "${track.id}"`,
+        });
+      }
+      trackIds.add(track.id);
+      totalKeyframes += track.keyframes.length;
+
+    }
+
+    if (totalKeyframes > PROJECT_LIMITS.maxTotalKeyframes) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tracks'],
+        message: `Timeline exceeds ${PROJECT_LIMITS.maxTotalKeyframes} keyframes`,
+      });
+    }
+  });
+
+export const CameraFrameSchema = z
+  .object({
+    aspectRatio: z.enum(ASPECT_RATIOS),
+    width: finiteNumberSchema.positive(),
+    x: finiteNumberSchema,
+    y: finiteNumberSchema,
+  })
+  .strict();
+
+export const PlaybackSchema = z
+  .object({
+    clipStart: finiteNumberSchema
+      .nonnegative()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs),
+    clipEnd: finiteNumberSchema
+      .positive()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs),
+    cameraFrame: CameraFrameSchema,
+  })
+  .strict()
+  .superRefine((playback, context) => {
+    if (playback.clipEnd <= playback.clipStart) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['clipEnd'],
+        message: 'clipEnd must be greater than clipStart',
+      });
+    }
+  });
+
+const sceneElementSchema = z
+  .object({
+    id: identifierSchema,
+    type: z.string().min(1).max(PROJECT_LIMITS.maxIdentifierLength),
+  })
+  .passthrough();
+
+export const ProjectSceneSchema = z
+  .object({
+    elements: z
+      .array(sceneElementSchema)
+      .max(PROJECT_LIMITS.maxSceneElements),
+    appState: z.record(z.unknown()).default({}),
+    files: z.record(z.unknown()).default({}),
+  })
+  .strict()
+  .superRefine((scene, context) => {
+    const elementIds = new Set<string>();
+    for (const [elementIndex, element] of scene.elements.entries()) {
+      if (elementIds.has(element.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['elements', elementIndex, 'id'],
+          message: `Duplicate scene element id "${element.id}"`,
+        });
+      }
+      elementIds.add(element.id);
+
+      const fileId = element['fileId'];
+      if (
+        typeof fileId === 'string' &&
+        fileId.length > 0 &&
+        !Object.hasOwn(scene.files, fileId)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['elements', elementIndex, 'fileId'],
+          message: `Scene element references missing file "${fileId}"`,
+        });
+      }
+    }
+
+    if (Object.keys(scene.files).length > PROJECT_LIMITS.maxSceneFiles) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['files'],
+        message: `Scene exceeds ${PROJECT_LIMITS.maxSceneFiles} files`,
+      });
+    }
+  });
+
+export const ProjectMetadataSchema = z
+  .object({
+    id: identifierSchema,
+    name: nameSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+export const ProjectDocumentSchema = z
+  .object({
+    version: z.literal(PROJECT_VERSION),
+    metadata: ProjectMetadataSchema,
+    scene: ProjectSceneSchema,
+    timeline: AnimationTimelineSchema,
+    playback: PlaybackSchema,
+    authoring: z.record(z.unknown()).optional(),
+    preferredWorkspace: z.enum(PREFERRED_WORKSPACES).optional(),
+  })
+  .strict()
+  .superRefine((project, context) => {
+    validateProjectRelationships(project, context);
+  });
+
+export const V1ProjectDocumentSchema = z
+  .object({
+    version: z.literal(V1_PROJECT_VERSION),
+    id: identifierSchema,
+    name: nameSchema,
+    scene: ProjectSceneSchema,
+    timeline: AnimationTimelineSchema,
+    clipStart: finiteNumberSchema
+      .nonnegative()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs)
+      .optional(),
+    clipEnd: finiteNumberSchema
+      .positive()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs)
+      .optional(),
+    cameraFrame: CameraFrameSchema.optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const legacyTransferSchema = z
+  .object({
+    name: nameSchema.optional(),
+    scene: ProjectSceneSchema,
+    timeline: AnimationTimelineSchema.nullish(),
+    clipStart: finiteNumberSchema
+      .nonnegative()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs)
+      .optional(),
+    clipEnd: finiteNumberSchema
+      .positive()
+      .max(PROJECT_LIMITS.maxTimelineDurationMs)
+      .optional(),
+    cameraFrame: CameraFrameSchema.nullish(),
+    playback: PlaybackSchema.optional(),
+    authoring: z.record(z.unknown()).optional(),
+    preferredWorkspace: z.enum(PREFERRED_WORKSPACES).optional(),
+  })
+  .passthrough();
+
+export type AnimatableProperty = (typeof ANIMATABLE_PROPERTIES)[number];
+export type EasingType = (typeof EASING_TYPES)[number];
+export type AspectRatio = (typeof ASPECT_RATIOS)[number];
+export type PreferredWorkspace = (typeof PREFERRED_WORKSPACES)[number];
+export type Keyframe = z.infer<typeof KeyframeSchema>;
+export type AnimationTrack = z.infer<typeof AnimationTrackSchema>;
+export type AnimationTimeline = z.infer<typeof AnimationTimelineSchema>;
+export type CameraFrame = z.infer<typeof CameraFrameSchema>;
+export type Playback = z.infer<typeof PlaybackSchema>;
+export type ProjectScene = z.infer<typeof ProjectSceneSchema>;
+export type ProjectMetadata = z.infer<typeof ProjectMetadataSchema>;
+export type ProjectDocument = z.infer<typeof ProjectDocumentSchema>;
+export type V1ProjectDocument = z.infer<typeof V1ProjectDocumentSchema>;
+
+export interface ProjectContent {
+  name?: string;
+  scene: ProjectScene;
+  timeline: AnimationTimeline;
+  playback: Playback;
+  authoring?: Record<string, unknown>;
+  preferredWorkspace?: PreferredWorkspace;
+}
+
+export class ProjectValidationError extends Error {
+  readonly details: readonly string[];
+
+  constructor(message: string, details: readonly string[] = []) {
+    super(message);
+    this.name = 'ProjectValidationError';
+    this.details = details;
+  }
+}
+
+export function assertInputByteLimit(
+  byteLength: number,
+  limit = PROJECT_LIMITS.maxInputBytes,
+  label = 'Project payload',
+): void {
+  if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+    throw new ProjectValidationError(`${label} has an invalid byte length`);
+  }
+  if (byteLength > limit) {
+    throw new ProjectValidationError(
+      `${label} exceeds the ${formatBytes(limit)} limit`,
+    );
+  }
+}
+
+export function decodeProjectDocument(json: string): ProjectDocument {
+  assertInputByteLimit(new TextEncoder().encode(json).byteLength);
+  return parseProjectDocument(parseJson(json, 'project'));
+}
+
+export function encodeProjectDocument(project: ProjectDocument): string {
+  let json: string;
+  try {
+    json = JSON.stringify(project);
+  } catch (error) {
+    throw new ProjectValidationError(
+      `Project could not be serialized: ${getErrorMessage(error)}`,
+    );
+  }
+
+  assertInputByteLimit(
+    new TextEncoder().encode(json).byteLength,
+    PROJECT_LIMITS.maxDecompressedBytes,
+    'Serialized project',
+  );
+  const validated = parseProjectDocument(parseJson(json, 'project'));
+  const encoded = JSON.stringify(validated);
+  assertInputByteLimit(
+    new TextEncoder().encode(encoded).byteLength,
+    PROJECT_LIMITS.maxInputBytes,
+  );
+  return encoded;
+}
+
+export function parseProjectDocument(input: unknown): ProjectDocument {
+  assertResourceSafety(input);
+  const version = readVersion(input);
+
+  if (version === PROJECT_VERSION) {
+    return parseWithSchema(ProjectDocumentSchema, input, 'Invalid V2 project');
+  }
+  if (version === V1_PROJECT_VERSION) {
+    return migrateV1Project(input);
+  }
+
+  throw new ProjectValidationError(
+    `Unsupported project version "${version ?? 'missing'}"`,
+  );
+}
+
+export function migrateV1Project(input: unknown): ProjectDocument {
+  assertResourceSafety(input);
+  const version = readVersion(input);
+  if (version === PROJECT_VERSION) {
+    return parseWithSchema(ProjectDocumentSchema, input, 'Invalid V2 project');
+  }
+  if (version !== V1_PROJECT_VERSION) {
+    throw new ProjectValidationError(
+      `Expected project version "${V1_PROJECT_VERSION}" or "${PROJECT_VERSION}"`,
+    );
+  }
+
+  const legacy = parseWithSchema(
+    V1ProjectDocumentSchema,
+    input,
+    'Invalid V1 project',
+  );
+  const clipStart = legacy.clipStart ?? 0;
+  const clipEnd = legacy.clipEnd ?? legacy.timeline.duration;
+  const migrated: ProjectDocument = {
+    version: PROJECT_VERSION,
+    metadata: {
+      id: legacy.id,
+      name: legacy.name,
+      createdAt: legacy.createdAt,
+      updatedAt: legacy.updatedAt,
+    },
+    scene: legacy.scene,
+    timeline: legacy.timeline,
+    playback: {
+      clipStart,
+      clipEnd,
+      cameraFrame: legacy.cameraFrame ?? createDefaultCameraFrame(),
+    },
+  };
+
+  return parseWithSchema(
+    ProjectDocumentSchema,
+    migrated,
+    'Migrated project is invalid',
+  );
+}
+
+export function parseProjectContent(input: unknown): ProjectContent {
+  assertResourceSafety(input);
+  const version = readVersion(input);
+  if (version !== undefined) {
+    const project = parseProjectDocument(input);
+    return {
+      name: project.metadata.name,
+      scene: project.scene,
+      timeline: project.timeline,
+      playback: project.playback,
+      authoring: project.authoring,
+      preferredWorkspace: project.preferredWorkspace,
+    };
+  }
+
+  const transfer = parseWithSchema(
+    legacyTransferSchema,
+    input,
+    'Invalid project transfer payload',
+  );
+  const timeline = transfer.timeline ?? createDefaultTimeline();
+  const playback =
+    transfer.playback ??
+    ({
+      clipStart: transfer.clipStart ?? 0,
+      clipEnd: transfer.clipEnd ?? timeline.duration,
+      cameraFrame: transfer.cameraFrame ?? createDefaultCameraFrame(),
+    } satisfies Playback);
+  const content: ProjectContent = {
+    name: transfer.name,
+    scene: transfer.scene,
+    timeline,
+    playback,
+    authoring: transfer.authoring,
+    preferredWorkspace: transfer.preferredWorkspace,
+  };
+
+  validateContentRelationships(content);
+  return content;
+}
+
+export function decodeProjectContent(json: string): ProjectContent {
+  assertInputByteLimit(new TextEncoder().encode(json).byteLength);
+  return parseProjectContent(parseJson(json, 'project transfer payload'));
+}
+
+export function createDefaultTimeline(): AnimationTimeline {
+  return {
+    id: 'timeline',
+    name: 'Animation 1',
+    duration: 30_000,
+    fps: 60,
+    tracks: [],
+  };
+}
+
+export function createDefaultCameraFrame(): CameraFrame {
+  return {
+    aspectRatio: '16:9',
+    width: 1280,
+    x: 640,
+    y: 360,
+  };
+}
+
+function validateProjectRelationships(
+  project: ProjectDocument,
+  context: z.RefinementCtx,
+): void {
+  const sceneElementIds = new Set(
+    project.scene.elements.map((element) => element.id),
+  );
+  for (const [trackIndex, track] of project.timeline.tracks.entries()) {
+    if (
+      track.targetType === 'element' &&
+      track.targetId !== CAMERA_FRAME_TARGET_ID &&
+      !sceneElementIds.has(track.targetId)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['timeline', 'tracks', trackIndex, 'targetId'],
+        message: `Track references missing scene element "${track.targetId}"`,
+      });
+    }
+  }
+}
+
+function validateContentRelationships(content: ProjectContent): void {
+  const syntheticProject: ProjectDocument = {
+    version: PROJECT_VERSION,
+    metadata: {
+      id: 'transfer',
+      name: content.name ?? '',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    },
+    scene: content.scene,
+    timeline: content.timeline,
+    playback: content.playback,
+    authoring: content.authoring,
+    preferredWorkspace: content.preferredWorkspace,
+  };
+  parseWithSchema(
+    ProjectDocumentSchema,
+    syntheticProject,
+    'Invalid project transfer payload',
+  );
+}
+
+function assertResourceSafety(input: unknown): void {
+  const stack: Array<{ value: unknown; depth: number; exit?: boolean }> = [
+    { value: input, depth: 0 },
+  ];
+  const activeObjects = new WeakSet<object>();
+  let visitedValues = 0;
+
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item) break;
+    const { value, depth, exit } = item;
+    if (exit && typeof value === 'object' && value !== null) {
+      activeObjects.delete(value);
+      continue;
+    }
+    visitedValues += 1;
+
+    if (visitedValues > PROJECT_LIMITS.maxVisitedValues) {
+      throw new ProjectValidationError('Project contains too many values');
+    }
+    if (depth > PROJECT_LIMITS.maxNestingDepth) {
+      throw new ProjectValidationError('Project nesting is too deep');
+    }
+    if (typeof value === 'string') {
+      if (value.length > PROJECT_LIMITS.maxStringLength) {
+        throw new ProjectValidationError('Project contains an oversized string');
+      }
+      continue;
+    }
+    if (typeof value === 'number') {
+      if (
+        !Number.isFinite(value) ||
+        Math.abs(value) > PROJECT_LIMITS.maxAbsoluteNumber
+      ) {
+        throw new ProjectValidationError(
+          'Project contains an invalid numeric value',
+        );
+      }
+      continue;
+    }
+    if (typeof value !== 'object' || value === null) continue;
+    if (activeObjects.has(value)) {
+      throw new ProjectValidationError('Project contains a circular reference');
+    }
+    activeObjects.add(value);
+    stack.push({ value, depth, exit: true });
+
+    if (Array.isArray(value)) {
+      if (value.length > PROJECT_LIMITS.maxCollectionItems) {
+        throw new ProjectValidationError('Project contains an oversized array');
+      }
+      for (const child of value) {
+        stack.push({ value: child, depth: depth + 1 });
+      }
+      continue;
+    }
+
+    const entries = Object.entries(value);
+    if (entries.length > PROJECT_LIMITS.maxCollectionItems) {
+      throw new ProjectValidationError('Project contains an oversized object');
+    }
+    for (const [key, child] of entries) {
+      if (key.length > PROJECT_LIMITS.maxIdentifierLength) {
+        throw new ProjectValidationError('Project contains an oversized key');
+      }
+      stack.push({ value: child, depth: depth + 1 });
+    }
+  }
+}
+
+function parseJson(json: string, label: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new ProjectValidationError(`Invalid JSON: failed to parse ${label}`);
+  }
+}
+
+function parseWithSchema<T>(
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
+  input: unknown,
+  message: string,
+): T {
+  const result = schema.safeParse(input);
+  if (result.success) return result.data;
+
+  const details = result.error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : 'document';
+    return `${path}: ${issue.message}`;
+  });
+  throw new ProjectValidationError(`${message}: ${details[0]}`, details);
+}
+
+function readVersion(input: unknown): string | undefined {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return undefined;
+  }
+  const version = Reflect.get(input, 'version');
+  return typeof version === 'string' ? version : undefined;
+}
+
+function formatBytes(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MiB`;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unknown error';
+}

--- a/packages/project-schema/tsconfig.json
+++ b/packages/project-schema/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -15,6 +15,7 @@ import { useAnimationStore } from '../../stores/animationStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useAppHotkeys } from '../../hooks/useAppHotkeys';
+import { useAutoSave } from '../../hooks/useAutoSave';
 import { ConsentBanner } from '../ConsentBanner';
 import { getPlaybackController } from '../../core/engine/playbackSingleton';
 import { useShareLoader } from './useShareLoader';
@@ -37,7 +38,12 @@ export function App() {
   useAppHotkeys();
 
   getPlaybackController();
-  useShareLoader();
+  const shareLoadState = useShareLoader();
+  const recoveryReady = useAutoSave({
+    restoreLocal: shareLoadState === 'idle',
+    enabled: shareLoadState !== 'loading',
+  });
+  const startupReady = shareLoadState !== 'loading' && recoveryReady;
 
   // Prevent browser zoom on Ctrl+Scroll anywhere in the app.
   // The Excalidraw canvas handles its own zoom internally.
@@ -122,7 +128,7 @@ export function App() {
         <NavigationProgress />
         {activePage === 'mcp-guide' ? (
           <McpSetupGuide />
-        ) : (
+        ) : startupReady ? (
         <div className="flex flex-col h-screen w-screen bg-surface text-text">
           {/* Top toolbar */}
           <Toolbar />
@@ -264,7 +270,7 @@ export function App() {
       </div>
       )}
     </div>
-        )}
+        ) : null}
         <ConsentBanner />
         </ModalsProvider>
       </MantineProvider>

--- a/src/components/App/useShareLoader.test.ts
+++ b/src/components/App/useShareLoader.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AnimationProject } from '../../core/models/Project';
+import { useShareLoader } from './useShareLoader';
+
+const mocks = vi.hoisted(() => ({
+  loadShareUrl: vi.fn(),
+  loadProjectDocumentIntoStores: vi.fn(),
+  showNotification: vi.fn(),
+}));
+
+vi.mock('../../services/FileService', () => ({
+  loadShareUrl: mocks.loadShareUrl,
+}));
+
+vi.mock('../../services/ProjectDocumentService', () => ({
+  loadProjectDocumentIntoStores: mocks.loadProjectDocumentIntoStores,
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: mocks.showNotification },
+}));
+
+describe('useShareLoader', () => {
+  afterEach(() => {
+    mocks.loadShareUrl.mockReset();
+    mocks.loadProjectDocumentIntoStores.mockReset();
+    mocks.showNotification.mockReset();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('clears the share hash after loading so recovery can own later refreshes', async () => {
+    window.location.hash = '#share=synthetic,key';
+    const project = {} as AnimationProject;
+    mocks.loadShareUrl.mockResolvedValue(project);
+
+    const { result } = renderHook(() => useShareLoader(), {
+      wrapper: StrictMode,
+    });
+    expect(result.current).toBe('loading');
+
+    await waitFor(() => expect(result.current).toBe('loaded'));
+    expect(mocks.loadProjectDocumentIntoStores).toHaveBeenCalledWith(project);
+    expect(mocks.loadShareUrl).toHaveBeenCalledTimes(1);
+    expect(window.location.hash).toBe('');
+  });
+
+  it('clears a failed share hash before allowing local editing', async () => {
+    window.location.hash = '#share=missing,key';
+    mocks.loadShareUrl.mockRejectedValue(new Error('Share not found'));
+
+    const { result } = renderHook(() => useShareLoader());
+    await waitFor(() => expect(result.current).toBe('failed'));
+
+    expect(window.location.hash).toBe('');
+    expect(mocks.showNotification).toHaveBeenCalled();
+  });
+});

--- a/src/components/App/useShareLoader.ts
+++ b/src/components/App/useShareLoader.ts
@@ -1,51 +1,50 @@
-import { useEffect, useState } from 'react';
-import { extractTargets } from '../Canvas/extractTargets';
-import { computeFrameAtTime } from '../../core/engine/playbackSingleton';
-import { useAnimationStore } from '../../stores/animationStore';
-import { useProjectStore } from '../../stores/projectStore';
-import { useUIStore } from '../../stores/uiStore';
-import { decryptData, importKeyFromString } from '../../services/encryption';
+import { useEffect, useRef, useState } from 'react';
+import { notifications } from '@mantine/notifications';
+import { loadShareUrl } from '../../services/FileService';
+import { loadProjectDocumentIntoStores } from '../../services/ProjectDocumentService';
 
-export function useShareLoader(): void {
-  const [shareLoaded, setShareLoaded] = useState(false);
+export type ShareLoadState = 'idle' | 'loading' | 'loaded' | 'failed';
+
+export function useShareLoader(): ShareLoadState {
+  const [shareHash] = useState<string | null>(() =>
+    window.location.hash.startsWith('#share=')
+      ? window.location.hash
+      : null,
+  );
+  const [state, setState] = useState<ShareLoadState>(
+    shareHash ? 'loading' : 'idle',
+  );
+  const loadStarted = useRef(false);
 
   useEffect(() => {
-    if (shareLoaded) return;
-    const hash = window.location.hash;
-    if (!hash.startsWith('#share=')) return;
-    setShareLoaded(true);
+    if (!shareHash || loadStarted.current) return;
+    loadStarted.current = true;
 
-    const parts = hash.slice('#share='.length).split(',');
-    if (parts.length < 2) return;
-    const [shareId, keyStr] = parts;
+    void loadShareUrl(shareHash)
+      .then((project) => {
+        loadProjectDocumentIntoStores(project);
+        clearShareHash();
+        setState('loaded');
+      })
+      .catch((error: unknown) => {
+        clearShareHash();
+        setState('failed');
+        notifications.show({
+          title: 'Unable to load shared animation',
+          message:
+            error instanceof Error ? error.message : 'The share is invalid.',
+          color: 'red',
+        });
+      });
+  }, [shareHash]);
 
-    (async () => {
-      try {
-        const shareApiUrl = import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
-        const response = await fetch(`${shareApiUrl}/share/${shareId}`);
-        if (!response.ok) throw new Error('Share not found');
-        const encrypted = await response.arrayBuffer();
-        const key = await importKeyFromString(keyStr);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data = await decryptData<any>(encrypted, key);
+  return state;
+}
 
-        if (data.scene?.elements) {
-          useProjectStore.getState().createNewProject('Shared Animation', {
-            elements: data.scene.elements,
-            appState: data.scene.appState ?? {},
-            files: data.scene.files ?? {},
-          });
-          const targets = extractTargets(data.scene.elements);
-          useProjectStore.getState().setTargets(targets);
-          if (data.timeline) useAnimationStore.getState().setTimeline(data.timeline);
-          if (data.cameraFrame) useProjectStore.getState().setCameraFrame(data.cameraFrame);
-          if (data.clipStart !== undefined) useAnimationStore.getState().setClipRange(data.clipStart, data.clipEnd);
-          useUIStore.getState().setMode('animate');
-          computeFrameAtTime(0);
-        }
-      } catch (e) {
-        console.error('Failed to load shared animation:', e);
-      }
-    })();
-  }, [shareLoaded]);
+function clearShareHash(): void {
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${window.location.pathname}${window.location.search}`,
+  );
 }

--- a/src/components/Toolbar/useFileOperations.ts
+++ b/src/components/Toolbar/useFileOperations.ts
@@ -2,6 +2,8 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useAnimationStore } from '../../stores/animationStore';
 import type { ExcalidrawSceneData } from '../../types/excalidraw';
 import type { AspectRatio } from '../../stores/projectStore';
+import { createTimeline } from '../../core/models/Timeline';
+import { fromProjectDocument } from '../../core/models/Project';
 import {
   parseExcalidrawFileBlob,
   parseProjectFileBlob,
@@ -11,18 +13,18 @@ import {
   saveProjectFile,
 } from '../../services/FileService';
 import { extractTargets } from '../Canvas/extractTargets';
-import { computeFrameAtTime } from '../../core/engine/playbackSingleton';
-import { useUIStore } from '../../stores/uiStore';
+import {
+  captureProjectDocument,
+  loadProjectDocumentIntoStores,
+} from '../../services/ProjectDocumentService';
 import { trackNewProject, trackSaveProject, trackLoadProject, trackImport } from '../../services/analytics/posthog';
 
 function resetTimeline() {
-  useAnimationStore.getState().setTimeline({
-    id: crypto.randomUUID?.() ?? Date.now().toString(),
-    name: 'Animation 1',
-    duration: 30000,
-    fps: 60,
-    tracks: [],
-  });
+  const timeline = createTimeline();
+  useAnimationStore.getState().setTimeline(timeline);
+  useAnimationStore
+    .getState()
+    .setClipRange(0, Math.min(10_000, timeline.duration));
 }
 
 function importScene(name: string, scene: ExcalidrawSceneData) {
@@ -52,17 +54,9 @@ export function useFileOperations() {
       return;
     }
     try {
-      const timeline = useAnimationStore.getState().timeline;
-      const { clipStart, clipEnd } = useAnimationStore.getState();
-      const cameraFrame = useProjectStore.getState().cameraFrame;
-      await saveProjectFile({
-        ...project,
-        timeline,
-        clipStart,
-        clipEnd,
-        cameraFrame,
-        updatedAt: new Date().toISOString(),
-      });
+      const document = captureProjectDocument();
+      if (!document) throw new Error('No project to save');
+      await saveProjectFile(fromProjectDocument(document));
       useProjectStore.getState().markClean();
       trackSaveProject();
     } catch (e) {
@@ -86,54 +80,19 @@ export function useFileOperations() {
   /** Load a .excanim project file (from drag & drop) */
   const handleLoadProjectFile = async (file: File) => {
     const project = await parseProjectFileBlob(file);
-    useProjectStore.getState().loadProject(project);
-    if (project.cameraFrame) {
-      useProjectStore.getState().setCameraFrame(project.cameraFrame);
-    }
-    const targets = extractTargets(project.scene.elements);
-    useProjectStore.getState().setTargets(targets);
-    useAnimationStore.getState().setTimeline(project.timeline);
-    if (project.clipStart !== undefined && project.clipEnd !== undefined) {
-      useAnimationStore.getState().setClipRange(project.clipStart, project.clipEnd);
-    }
-    useUIStore.getState().setMode('animate');
-    computeFrameAtTime(0);
+    loadProjectDocumentIntoStores(project);
     trackLoadProject('file');
   };
 
   /** Load an MCP checkpoint file (from drag & drop) */
   const handleLoadCheckpointFile = async (file: File) => {
-    const checkpoint = await parseMcpCheckpointBlob(file);
-    useProjectStore.getState().createNewProject('MCP Checkpoint', checkpoint.scene);
-    const targets = extractTargets(checkpoint.scene.elements);
-    useProjectStore.getState().setTargets(targets);
-    if (checkpoint.timeline) {
-      useAnimationStore.getState().setTimeline(checkpoint.timeline);
-    } else {
-      resetTimeline();
-    }
-    if (checkpoint.cameraFrame) {
-      useProjectStore.getState().setCameraFrame(checkpoint.cameraFrame);
-    }
-    useAnimationStore.getState().setClipRange(checkpoint.clipStart, checkpoint.clipEnd);
-    useUIStore.getState().setMode('animate');
-    computeFrameAtTime(0);
+    loadProjectDocumentIntoStores(await parseMcpCheckpointBlob(file));
     trackLoadProject('checkpoint');
   };
 
   /** Load from an E2E encrypted share URL */
   const handleLoadShareUrl = async (url: string) => {
-    const data = await loadShareUrl(url);
-    useProjectStore.getState().createNewProject('Shared Animation', data.scene);
-    const targets = extractTargets(data.scene.elements);
-    useProjectStore.getState().setTargets(targets);
-    if (data.timeline) useAnimationStore.getState().setTimeline(data.timeline);
-    if (data.cameraFrame) useProjectStore.getState().setCameraFrame(data.cameraFrame);
-    if (data.clipStart !== undefined && data.clipEnd !== undefined) {
-      useAnimationStore.getState().setClipRange(data.clipStart, data.clipEnd);
-    }
-    useUIStore.getState().setMode('animate');
-    computeFrameAtTime(0);
+    loadProjectDocumentIntoStores(await loadShareUrl(url));
     trackLoadProject('share_url');
   };
 

--- a/src/components/Toolbar/useShareOperations.tsx
+++ b/src/components/Toolbar/useShareOperations.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import { useProjectStore } from '../../stores/projectStore';
-import { useAnimationStore } from '../../stores/animationStore';
 import {
   encryptData,
   exportKeyToString,
   generateEncryptionKey,
 } from '../../services/encryption';
 import { trackShare } from '../../services/analytics/posthog';
+import { captureProjectDocument } from '../../services/ProjectDocumentService';
 
 const SHARE_API_URL = import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
 
@@ -27,18 +27,8 @@ export function useShareOperations() {
     }
     try {
       setLoading(true);
-      const timeline = useAnimationStore.getState().timeline;
-      const { clipStart, clipEnd } = useAnimationStore.getState();
-      const cameraFrame = useProjectStore.getState().cameraFrame;
-
-      const payload = {
-        name: project.name,
-        scene: project.scene,
-        timeline,
-        clipStart,
-        clipEnd,
-        cameraFrame,
-      };
+      const payload = captureProjectDocument();
+      if (!payload) throw new Error('No project to share');
 
       const key = await generateEncryptionKey();
       const encrypted = await encryptData(payload, key);

--- a/src/core/models/Project.ts
+++ b/src/core/models/Project.ts
@@ -1,65 +1,168 @@
 import { nanoid } from 'nanoid';
+import {
+  PROJECT_VERSION,
+  createDefaultCameraFrame,
+  parseProjectDocument,
+} from '@excalimate/project-schema';
+import type {
+  ProjectContent,
+  ProjectDocument,
+  ProjectScene,
+} from '@excalimate/project-schema';
 import type { AnimationTimeline } from '../../types/animation';
 import type { ExcalidrawSceneData } from '../../types/excalidraw';
 import type { CameraFrame } from '../../stores/projectStore';
-import { createTimeline, validateTimeline } from './Timeline';
+import { createTimeline } from './Timeline';
 
-export const PROJECT_VERSION = '1.0.0';
+export { PROJECT_VERSION };
 
-export interface AnimationProject {
-  id: string;
-  version: string;
-  name: string;
+/**
+ * App-facing compatibility shape. Canonical V2 fields are always present, while
+ * the flat aliases keep existing Studio consumers incremental.
+ */
+export type AnimationProject = Omit<
+  ProjectDocument,
+  'scene' | 'timeline' | 'playback'
+> & {
   scene: ExcalidrawSceneData;
   timeline: AnimationTimeline;
+  playback: {
+    clipStart: number;
+    clipEnd: number;
+    cameraFrame: CameraFrame;
+  };
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
   clipStart?: number;
   clipEnd?: number;
   cameraFrame?: CameraFrame;
-  createdAt: string;
-  updatedAt: string;
-}
+};
 
 export function createProject(
   name: string,
   scene: ExcalidrawSceneData,
 ): AnimationProject {
   const now = new Date().toISOString();
-  return {
-    id: nanoid(),
+  const timeline = createTimeline();
+  const cameraFrame = createDefaultCameraFrame();
+  const project = fromProjectDocument({
     version: PROJECT_VERSION,
-    name,
-    scene,
-    timeline: createTimeline(),
-    createdAt: now,
-    updatedAt: now,
+    metadata: {
+      id: nanoid(),
+      name,
+      createdAt: now,
+      updatedAt: now,
+    },
+    scene: toProjectScene(scene),
+    timeline,
+    playback: {
+      clipStart: 0,
+      clipEnd: Math.min(10_000, timeline.duration),
+      cameraFrame,
+    },
+  });
+  return { ...project, scene };
+}
+
+export function createProjectFromContent(
+  fallbackName: string,
+  content: ProjectContent,
+): AnimationProject {
+  const project = createProject(content.name ?? fallbackName, fromProjectScene(content.scene));
+  return fromProjectDocument({
+    version: PROJECT_VERSION,
+    metadata: project.metadata,
+    scene: content.scene,
+    timeline: content.timeline,
+    playback: content.playback,
+    authoring: content.authoring,
+    preferredWorkspace: content.preferredWorkspace,
+  });
+}
+
+export function fromProjectDocument(
+  document: ProjectDocument,
+): AnimationProject {
+  return {
+    ...document,
+    scene: fromProjectScene(document.scene),
+    id: document.metadata.id,
+    name: document.metadata.name,
+    createdAt: document.metadata.createdAt,
+    updatedAt: document.metadata.updatedAt,
+    clipStart: document.playback.clipStart,
+    clipEnd: document.playback.clipEnd,
+    cameraFrame: document.playback.cameraFrame,
+  };
+}
+
+export function toProjectDocument(
+  project: AnimationProject,
+): ProjectDocument {
+  return {
+    version: PROJECT_VERSION,
+    metadata: {
+      id: project.id,
+      name: project.name,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    },
+    scene: toProjectScene(project.scene),
+    timeline: project.timeline,
+    playback: {
+      clipStart: project.clipStart ?? project.playback.clipStart,
+      clipEnd: project.clipEnd ?? project.playback.clipEnd,
+      cameraFrame: project.cameraFrame ?? project.playback.cameraFrame,
+    },
+    authoring: project.authoring,
+    preferredWorkspace: project.preferredWorkspace,
   };
 }
 
 export function validateProject(
   project: unknown,
 ): project is AnimationProject {
-  if (typeof project !== 'object' || project === null) return false;
-
-  const obj = project as Record<string, unknown>;
-
-  if (typeof obj.id !== 'string' || obj.id.length === 0) return false;
-  if (typeof obj.version !== 'string' || obj.version.length === 0) return false;
-  if (typeof obj.name !== 'string') return false;
-  if (typeof obj.createdAt !== 'string' || obj.createdAt.length === 0)
+  try {
+    if (isCompatibilityProject(project)) {
+      parseProjectDocument(toProjectDocument(project));
+    } else {
+      parseProjectDocument(project);
+    }
+    return true;
+  } catch {
     return false;
-  if (typeof obj.updatedAt !== 'string' || obj.updatedAt.length === 0)
-    return false;
+  }
+}
 
-  // Validate scene
-  if (typeof obj.scene !== 'object' || obj.scene === null) return false;
-  const scene = obj.scene as Record<string, unknown>;
-  if (!Array.isArray(scene.elements)) return false;
-  if (typeof scene.appState !== 'object' || scene.appState === null)
-    return false;
-  if (typeof scene.files !== 'object' || scene.files === null) return false;
+function isCompatibilityProject(
+  value: unknown,
+): value is AnimationProject {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record['id'] === 'string' &&
+    typeof record['name'] === 'string' &&
+    typeof record['createdAt'] === 'string' &&
+    typeof record['updatedAt'] === 'string' &&
+    typeof record['metadata'] === 'object' &&
+    typeof record['playback'] === 'object'
+  );
+}
 
-  // Validate timeline
-  if (!validateTimeline(obj.timeline)) return false;
+function toProjectScene(scene: ExcalidrawSceneData): ProjectScene {
+  return {
+    elements: scene.elements as unknown as ProjectScene['elements'],
+    appState: scene.appState as Record<string, unknown>,
+    files: scene.files as Record<string, unknown>,
+  };
+}
 
-  return true;
+function fromProjectScene(scene: ProjectScene): ExcalidrawSceneData {
+  return {
+    elements: scene.elements as unknown as ExcalidrawSceneData['elements'],
+    appState: scene.appState as ExcalidrawSceneData['appState'],
+    files: scene.files as ExcalidrawSceneData['files'],
+  };
 }

--- a/src/core/models/Timeline.ts
+++ b/src/core/models/Timeline.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
+import { AnimationTimelineSchema } from '@excalimate/project-schema';
 import type { AnimationTimeline, AnimationTrack } from '../../types/animation';
-import { validateTrack } from './Track';
 
 export function createTimeline(
   name: string = 'Animation 1',
@@ -50,22 +50,5 @@ export function findTracksForTarget(
 export function validateTimeline(
   timeline: unknown,
 ): timeline is AnimationTimeline {
-  if (typeof timeline !== 'object' || timeline === null) return false;
-
-  const obj = timeline as Record<string, unknown>;
-
-  if (typeof obj.id !== 'string' || obj.id.length === 0) return false;
-  if (typeof obj.name !== 'string') return false;
-  if (
-    typeof obj.duration !== 'number' ||
-    !Number.isFinite(obj.duration) ||
-    obj.duration <= 0
-  )
-    return false;
-  if (typeof obj.fps !== 'number' || !Number.isFinite(obj.fps) || obj.fps <= 0)
-    return false;
-  if (!Array.isArray(obj.tracks)) return false;
-  if (!obj.tracks.every((t: unknown) => validateTrack(t))) return false;
-
-  return true;
+  return AnimationTimelineSchema.safeParse(timeline).success;
 }

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -25,6 +25,9 @@ export {
 export {
   PROJECT_VERSION,
   createProject,
+  createProjectFromContent,
+  fromProjectDocument,
+  toProjectDocument,
   validateProject,
 } from './Project';
 

--- a/src/core/utils/projectSchema.test.ts
+++ b/src/core/utils/projectSchema.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  PROJECT_LIMITS,
+  PROJECT_VERSION,
+  ProjectValidationError,
+  assertInputByteLimit,
+  decodeProjectDocument,
+  encodeProjectDocument,
+  migrateV1Project,
+  parseProjectContent,
+  parseProjectDocument,
+} from '@excalimate/project-schema';
+import { AnimationEngine } from '../engine/AnimationEngine';
+import {
+  SYNTHETIC_V1_PROJECT,
+  createSyntheticV2Project,
+} from '../../test-fixtures/projectDocuments';
+
+describe('shared project schema contracts', () => {
+  it('migrates V1 to V2 idempotently without changing rendered frames', () => {
+    const before = new AnimationEngine().computeFrame(
+      SYNTHETIC_V1_PROJECT.timeline,
+      500,
+    );
+    const migrated = migrateV1Project(
+      structuredClone(SYNTHETIC_V1_PROJECT),
+    );
+    const migratedAgain = migrateV1Project(structuredClone(migrated));
+    const after = new AnimationEngine().computeFrame(migrated.timeline, 500);
+
+    expect(migrated.version).toBe(PROJECT_VERSION);
+    expect(migratedAgain).toEqual(migrated);
+    expect(migrated.timeline).toEqual(SYNTHETIC_V1_PROJECT.timeline);
+    expect([...after.entries()]).toEqual([...before.entries()]);
+    expect(migrated.playback).toEqual({
+      clipStart: 100,
+      clipEnd: 1_800,
+      cameraFrame: SYNTHETIC_V1_PROJECT.cameraFrame,
+    });
+  });
+
+  it('round-trips the complete V2 document', () => {
+    const project = createSyntheticV2Project();
+    expect(decodeProjectDocument(encodeProjectDocument(project))).toEqual(
+      project,
+    );
+  });
+
+  it('normalizes safe defaults for legacy checkpoint/share payloads', () => {
+    const content = parseProjectContent({
+      scene: SYNTHETIC_V1_PROJECT.scene,
+    });
+
+    expect(content.timeline.tracks).toEqual([]);
+    expect(content.playback.clipStart).toBe(0);
+    expect(content.playback.clipEnd).toBe(content.timeline.duration);
+    expect(content.playback.cameraFrame.aspectRatio).toBe('16:9');
+  });
+
+  it('rejects unsupported versions instead of guessing', () => {
+    expect(() =>
+      parseProjectDocument({
+        ...createSyntheticV2Project(),
+        version: '2.1.0',
+      }),
+    ).toThrow('Unsupported project version');
+  });
+
+  it.each([
+    ['non-finite values', { path: ['timeline', 'tracks', 0, 'keyframes', 0, 'value'], value: Infinity }],
+    ['overlong names', { path: ['metadata', 'name'], value: 'x'.repeat(PROJECT_LIMITS.maxNameLength + 1) }],
+    ['excessive duration', { path: ['timeline', 'duration'], value: PROJECT_LIMITS.maxTimelineDurationMs + 1 }],
+    ['invalid clip range', { path: ['playback', 'clipEnd'], value: 50 }],
+    ['missing element reference', { path: ['timeline', 'tracks', 0, 'targetId'], value: 'missing-element' }],
+  ])('rejects hostile %s', (_label, mutation) => {
+    const project = createSyntheticV2Project();
+    setPath(project, mutation.path, mutation.value);
+    expect(() => parseProjectDocument(project)).toThrow(ProjectValidationError);
+  });
+
+  it('rejects missing file references', () => {
+    const project = createSyntheticV2Project();
+    project.scene.elements[0]['fileId'] = 'missing-file';
+    expect(() => parseProjectDocument(project)).toThrow(
+      'references missing file',
+    );
+  });
+
+  it('does not accept inherited object names as file references', () => {
+    const project = createSyntheticV2Project();
+    project.scene.elements[0]['fileId'] = 'toString';
+    expect(() => parseProjectDocument(project)).toThrow(
+      'references missing file',
+    );
+  });
+
+  it('allows the reserved synthetic camera animation target', () => {
+    const project = createSyntheticV2Project();
+    project.timeline.tracks[0].targetId = '__camera_frame__';
+    expect(parseProjectDocument(project).timeline.tracks[0].targetId).toBe(
+      '__camera_frame__',
+    );
+  });
+
+  it('accepts finite Excalidraw epoch timestamps', () => {
+    const project = createSyntheticV2Project();
+    project.scene.elements[0]['updated'] = Date.now();
+    expect(parseProjectDocument(project).scene.elements[0]['updated']).toBe(
+      project.scene.elements[0]['updated'],
+    );
+  });
+
+  it('preserves bounded keyframes and clips beyond declared duration', () => {
+    const project = createSyntheticV2Project();
+    project.timeline.duration = 500;
+    project.playback.clipEnd = 1_800;
+    const parsed = parseProjectDocument(project);
+    expect(parsed.timeline.tracks[0].keyframes[1].time).toBe(1_000);
+    expect(parsed.playback.clipEnd).toBe(1_800);
+  });
+
+  it('enforces scene count and encoded byte limits', () => {
+    const project = createSyntheticV2Project();
+    project.scene.elements = Array.from(
+      { length: PROJECT_LIMITS.maxSceneElements + 1 },
+      (_, index) => ({ id: `element-${index}`, type: 'rectangle' }),
+    );
+    expect(() => parseProjectDocument(project)).toThrow();
+    expect(() =>
+      assertInputByteLimit(PROJECT_LIMITS.maxInputBytes + 1),
+    ).toThrow('limit');
+  });
+
+  it('rejects circular unknown metadata before schema parsing', () => {
+    const project = createSyntheticV2Project();
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    project.authoring = circular;
+    expect(() => parseProjectDocument(project)).toThrow(
+      'circular reference',
+    );
+  });
+});
+
+function setPath(
+  target: object,
+  path: Array<string | number>,
+  value: unknown,
+): void {
+  let current: Record<string | number, unknown> = target as Record<
+    string | number,
+    unknown
+  >;
+  for (const segment of path.slice(0, -1)) {
+    current = current[segment] as Record<string | number, unknown>;
+  }
+  const finalSegment = path.at(-1);
+  if (finalSegment !== undefined) current[finalSegment] = value;
+}

--- a/src/core/utils/serialization.test.ts
+++ b/src/core/utils/serialization.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest';
+import type { ProjectDocument } from '@excalimate/project-schema';
 import type { AnimationProject } from '../../core/models/Project';
 import { PROJECT_VERSION, createProject } from '../models/Project';
 import {
@@ -16,7 +17,17 @@ function createTestProject(
     appState: {},
     files: {},
   });
-  return { ...base, id: 'test-id', ...overrides };
+  const project = { ...base, id: 'test-id', ...overrides };
+  return {
+    ...project,
+    metadata: {
+      ...project.metadata,
+      id: project.id,
+      name: project.name,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    },
+  };
 }
 
 describe('serializeProject', () => {
@@ -29,16 +40,18 @@ describe('serializeProject', () => {
   it('includes version info', () => {
     const project = createTestProject();
     const json = serializeProject(project);
-    const parsed = JSON.parse(json) as AnimationProject;
+    const parsed = JSON.parse(json) as ProjectDocument;
     expect(parsed.version).toBe(PROJECT_VERSION);
   });
 
   it('preserves project fields', () => {
     const project = createTestProject({ name: 'My Animation' });
     const json = serializeProject(project);
-    const parsed = JSON.parse(json) as AnimationProject;
-    expect(parsed.name).toBe('My Animation');
-    expect(parsed.id).toBe('test-id');
+    const parsed = JSON.parse(json) as ProjectDocument;
+    expect(parsed.metadata.name).toBe('My Animation');
+    expect(parsed.metadata.id).toBe('test-id');
+    expect(parsed.playback.cameraFrame).toEqual(project.cameraFrame);
+    expect('clipStart' in parsed).toBe(false);
   });
 });
 
@@ -56,23 +69,29 @@ describe('deserializeProject', () => {
 
   it('throws on non-object JSON', () => {
     expect(() => deserializeProject('"just a string"')).toThrow(
-      'expected an object',
+      'Unsupported project version',
     );
   });
 
   it('throws on missing version field', () => {
     const json = JSON.stringify({ id: 'x', name: 'y' });
-    expect(() => deserializeProject(json)).toThrow('missing "version"');
+    expect(() => deserializeProject(json)).toThrow(
+      'Unsupported project version "missing"',
+    );
   });
 
   it('throws on missing id field', () => {
-    const json = JSON.stringify({ version: PROJECT_VERSION, name: 'y' });
-    expect(() => deserializeProject(json)).toThrow('missing "id"');
+    const project = createTestProject();
+    const parsed = JSON.parse(serializeProject(project)) as ProjectDocument;
+    const json = JSON.stringify({ ...parsed, metadata: { ...parsed.metadata, id: undefined } });
+    expect(() => deserializeProject(json)).toThrow('metadata.id');
   });
 
   it('throws on missing name field', () => {
-    const json = JSON.stringify({ version: PROJECT_VERSION, id: 'x' });
-    expect(() => deserializeProject(json)).toThrow('missing "name"');
+    const project = createTestProject();
+    const parsed = JSON.parse(serializeProject(project)) as ProjectDocument;
+    const json = JSON.stringify({ ...parsed, metadata: { ...parsed.metadata, name: 42 } });
+    expect(() => deserializeProject(json)).toThrow('metadata.name');
   });
 
   it('throws on incompatible version', () => {
@@ -81,7 +100,7 @@ describe('deserializeProject', () => {
       id: 'x',
       name: 'y',
     });
-    expect(() => deserializeProject(json)).toThrow('Incompatible');
+    expect(() => deserializeProject(json)).toThrow('Unsupported');
   });
 });
 

--- a/src/core/utils/serialization.ts
+++ b/src/core/utils/serialization.ts
@@ -1,46 +1,24 @@
-import type { AnimationProject } from '../../types';
-import { PROJECT_VERSION } from '../models/Project';
+import {
+  decodeProjectDocument,
+  encodeProjectDocument,
+} from '@excalimate/project-schema';
+import type { AnimationProject } from '../models/Project';
+import {
+  fromProjectDocument,
+  toProjectDocument,
+} from '../models/Project';
 
-/** Serialize a project to JSON string with version info */
+/** Serialize an app project as the canonical V2 document. */
 export function serializeProject(project: AnimationProject): string {
-  return JSON.stringify({ ...project, version: PROJECT_VERSION });
+  return encodeProjectDocument(toProjectDocument(project));
 }
 
-/** Deserialize a project from JSON string, with version checking */
+/** Deserialize and validate V2 documents or explicitly migrate V1 documents. */
 export function deserializeProject(json: string): AnimationProject {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    throw new Error('Invalid JSON: failed to parse project data');
-  }
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error('Invalid project data: expected an object');
-  }
-
-  const obj = parsed as Record<string, unknown>;
-
-  if (typeof obj['version'] !== 'string') {
-    throw new Error('Invalid project data: missing "version" field');
-  }
-  if (typeof obj['id'] !== 'string') {
-    throw new Error('Invalid project data: missing "id" field');
-  }
-  if (typeof obj['name'] !== 'string') {
-    throw new Error('Invalid project data: missing "name" field');
-  }
-
-  if (!isCompatibleVersion(obj['version'] as string, PROJECT_VERSION)) {
-    throw new Error(
-      `Incompatible project version: "${obj['version']}" is not compatible with current version "${PROJECT_VERSION}"`,
-    );
-  }
-
-  return parsed as AnimationProject;
+  return fromProjectDocument(decodeProjectDocument(json));
 }
 
-/** Check if a version string is compatible (semver major must match) */
+/** Retained for callers that compare semver major compatibility. */
 export function isCompatibleVersion(
   version: string,
   currentVersion: string,

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,44 +1,109 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { notifications } from '@mantine/notifications';
+import type { ProjectDocument } from '@excalimate/project-schema';
 import { useProjectStore } from '../stores/projectStore';
 import { useAnimationStore } from '../stores/animationStore';
+import {
+  captureProjectDocument,
+  loadProjectDocumentIntoStores,
+} from '../services/ProjectDocumentService';
+import {
+  IndexedDbRecoveryStore,
+} from '../services/recovery/IndexedDbRecoveryStore';
 
-const AUTOSAVE_KEY = 'excalidraw-animate-autosave';
-const DEBOUNCE_MS = 2000;
+const DEBOUNCE_MS = 2_000;
+const recoveryStore = new IndexedDbRecoveryStore();
 
-export function useAutoSave() {
-  const { project } = useProjectStore();
-  const { timeline } = useAnimationStore();
+export function useAutoSave(
+  options: { restoreLocal?: boolean; enabled?: boolean } = {},
+): boolean {
+  const restoreLocal = options.restoreLocal ?? true;
+  const enabled = options.enabled ?? true;
+  const project = useProjectStore((state) => state.project);
+  const cameraFrame = useProjectStore((state) => state.cameraFrame);
+  const timeline = useAnimationStore((state) => state.timeline);
+  const clipStart = useAnimationStore((state) => state.clipStart);
+  const clipEnd = useAnimationStore((state) => state.clipEnd);
+  const [recoveryReady, setRecoveryReady] = useState(!restoreLocal);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveErrorShownRef = useRef(false);
 
   useEffect(() => {
-    if (!project) return;
+    let cancelled = false;
+    const restore = async () => {
+      if (!restoreLocal) return;
+      try {
+        const snapshot = await recoveryStore.latest();
+        if (!snapshot || cancelled) return;
+        loadProjectDocumentIntoStores(snapshot.document);
+        notifications.show({
+          title: 'Project recovered',
+          message: 'Restored the latest local recovery snapshot.',
+          color: 'blue',
+        });
+      } catch (error) {
+        if (!cancelled) showRecoveryError('Recovery unavailable', error);
+      } finally {
+        if (!cancelled) setRecoveryReady(true);
+      }
+    };
 
+    void restore();
+    return () => {
+      cancelled = true;
+    };
+  }, [restoreLocal]);
+
+  useEffect(() => {
+    if (!enabled || !recoveryReady || !project) return;
     if (timerRef.current) clearTimeout(timerRef.current);
 
     timerRef.current = setTimeout(() => {
-      try {
-        const data = JSON.stringify({ project, timeline });
-        localStorage.setItem(AUTOSAVE_KEY, data);
-      } catch (e) {
-        console.warn('Auto-save failed:', e);
-      }
+      void (async () => {
+        try {
+          const document = captureProjectDocument();
+          if (!document) return;
+          await recoveryStore.save(document);
+          saveErrorShownRef.current = false;
+        } catch (error) {
+          if (saveErrorShownRef.current) return;
+          saveErrorShownRef.current = true;
+          showRecoveryError('Local recovery failed', error);
+        }
+      })();
     }, DEBOUNCE_MS);
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [project, timeline]);
+  }, [
+    cameraFrame,
+    clipEnd,
+    clipStart,
+    enabled,
+    project,
+    recoveryReady,
+    timeline,
+  ]);
+
+  return recoveryReady;
 }
 
-export function loadAutoSave(): { project: unknown; timeline: unknown } | null {
-  try {
-    const data = localStorage.getItem(AUTOSAVE_KEY);
-    return data ? (JSON.parse(data) as { project: unknown; timeline: unknown }) : null;
-  } catch {
-    return null;
-  }
+export async function loadAutoSave(): Promise<ProjectDocument | null> {
+  return (await recoveryStore.latest())?.document ?? null;
 }
 
-export function clearAutoSave(): void {
-  localStorage.removeItem(AUTOSAVE_KEY);
+export async function clearAutoSave(): Promise<void> {
+  await recoveryStore.clear();
+}
+
+function showRecoveryError(title: string, error: unknown): void {
+  notifications.show({
+    title,
+    message:
+      error instanceof Error
+        ? error.message
+        : 'The browser could not access local recovery storage.',
+    color: 'red',
+  });
 }

--- a/src/services/FileService.test.ts
+++ b/src/services/FileService.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PROJECT_LIMITS,
+  PROJECT_VERSION,
+} from '@excalimate/project-schema';
+import {
+  loadShareUrl,
+  parseMcpCheckpointBlob,
+  parseProjectFileBlob,
+} from './FileService';
+import {
+  decryptData,
+  encryptData,
+  exportKeyToString,
+  generateEncryptionKey,
+} from './encryption';
+import { SYNTHETIC_V1_PROJECT } from '../test-fixtures/projectDocuments';
+
+vi.mock('../vendor/loadScene', () => ({
+  loadScene: vi.fn(),
+}));
+
+describe('FileService project ingestion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('migrates a V1 .excanim file while preserving playback data', async () => {
+    const project = await parseProjectFileBlob(
+      jsonBlob(SYNTHETIC_V1_PROJECT),
+    );
+
+    expect(project.version).toBe(PROJECT_VERSION);
+    expect(project.timeline).toEqual(SYNTHETIC_V1_PROJECT.timeline);
+    expect(project.clipStart).toBe(SYNTHETIC_V1_PROJECT.clipStart);
+    expect(project.clipEnd).toBe(SYNTHETIC_V1_PROJECT.clipEnd);
+    expect(project.cameraFrame).toEqual(SYNTHETIC_V1_PROJECT.cameraFrame);
+  });
+
+  it('normalizes and validates legacy MCP checkpoint data', async () => {
+    const project = await parseMcpCheckpointBlob(
+      jsonBlob({
+        name: 'Synthetic checkpoint',
+        scene: SYNTHETIC_V1_PROJECT.scene,
+        timeline: SYNTHETIC_V1_PROJECT.timeline,
+        clipStart: 100,
+        clipEnd: 1_800,
+        cameraFrame: SYNTHETIC_V1_PROJECT.cameraFrame,
+      }),
+    );
+
+    expect(project.name).toBe('Synthetic checkpoint');
+    expect(project.playback.clipEnd).toBe(1_800);
+  });
+
+  it('rejects checkpoint references to missing scene elements', async () => {
+    const timeline = structuredClone(SYNTHETIC_V1_PROJECT.timeline);
+    timeline.tracks[0].targetId = 'missing-element';
+
+    await expect(
+      parseMcpCheckpointBlob(
+        jsonBlob({ scene: SYNTHETIC_V1_PROJECT.scene, timeline }),
+      ),
+    ).rejects.toThrow('missing scene element');
+  });
+
+  it('rejects files before reading when their byte size exceeds the limit', async () => {
+    const blob = new Blob([
+      new Uint8Array(PROJECT_LIMITS.maxInputBytes + 1),
+    ]);
+    await expect(parseProjectFileBlob(blob)).rejects.toThrow('limit');
+  });
+
+  it('validates decrypted legacy share payloads through the shared contract', async () => {
+    const key = await generateEncryptionKey();
+    const keyString = await exportKeyToString(key);
+    const encrypted = await encryptData(
+      {
+        name: 'Synthetic share',
+        scene: SYNTHETIC_V1_PROJECT.scene,
+        timeline: SYNTHETIC_V1_PROJECT.timeline,
+        clipStart: 100,
+        clipEnd: 1_800,
+        cameraFrame: SYNTHETIC_V1_PROJECT.cameraFrame,
+      },
+      key,
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(encrypted, { status: 200 })),
+    );
+
+    const project = await loadShareUrl(
+      `#share=synthetic-share,${keyString}`,
+    );
+    expect(project.name).toBe('Synthetic share');
+    expect(project.timeline).toEqual(SYNTHETIC_V1_PROJECT.timeline);
+    expect(project.playback.cameraFrame).toEqual(
+      SYNTHETIC_V1_PROJECT.cameraFrame,
+    );
+  });
+
+  it('rejects encrypted payloads over the centralized byte limit', async () => {
+    await expect(
+      decryptData(
+        new ArrayBuffer(PROJECT_LIMITS.maxInputBytes + 1),
+        {} as CryptoKey,
+      ),
+    ).rejects.toThrow('limit');
+  });
+});
+
+function jsonBlob(value: unknown): Blob {
+  return new Blob([JSON.stringify(value)], { type: 'application/json' });
+}

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -1,6 +1,17 @@
 import { fileOpen, fileSave } from 'browser-fs-access';
+import {
+  PROJECT_LIMITS,
+  ProjectSceneSchema,
+  assertInputByteLimit,
+  decodeProjectContent,
+  parseProjectContent,
+} from '@excalimate/project-schema';
+import type { ProjectScene } from '@excalimate/project-schema';
 import type { ExcalidrawSceneData } from '../types/excalidraw';
 import type { AnimationProject } from '../core/models/Project';
+import {
+  createProjectFromContent,
+} from '../core/models/Project';
 import {
   serializeProject,
   deserializeProject,
@@ -9,7 +20,7 @@ import { loadScene } from '../vendor/loadScene';
 import { parseExcalidrawUrl } from '../vendor/parseUrl';
 
 /**
- * Import an Excalidraw file (.excalidraw or .json)
+ * Import an Excalidraw file (.excalidraw or .json).
  */
 export async function importExcalidrawFile(): Promise<ExcalidrawSceneData> {
   const file = await fileOpen({
@@ -17,42 +28,24 @@ export async function importExcalidrawFile(): Promise<ExcalidrawSceneData> {
     extensions: ['.excalidraw', '.json'],
     mimeTypes: ['application/json'],
   });
-
-  const text = await file.text();
-  const data = JSON.parse(text);
-
-  // Validate it has Excalidraw structure
-  if (!data.elements || !Array.isArray(data.elements)) {
-    throw new Error('Invalid Excalidraw file: missing elements array');
-  }
-
-  return {
-    elements: data.elements,
-    appState: data.appState ?? {},
-    files: data.files ?? {},
-  };
+  return parseExcalidrawFileBlob(file);
 }
 
 /**
- * Parse an Excalidraw file from a File/Blob object (for drag & drop / programmatic import).
+ * Parse an Excalidraw file from a File/Blob object.
  */
-export async function parseExcalidrawFileBlob(file: File): Promise<ExcalidrawSceneData> {
-  const text = await file.text();
-  const data = JSON.parse(text);
-
-  if (!data.elements || !Array.isArray(data.elements)) {
-    throw new Error('Invalid Excalidraw file: missing elements array');
-  }
-
-  return {
-    elements: data.elements,
-    appState: data.appState ?? {},
-    files: data.files ?? {},
-  };
+export async function parseExcalidrawFileBlob(
+  file: Blob,
+): Promise<ExcalidrawSceneData> {
+  const data = parseJson(
+    await readBlobText(file, 'Excalidraw file'),
+    'Excalidraw file',
+  );
+  return fromProjectScene(parseScene(data, 'Invalid Excalidraw file'));
 }
 
 /**
- * Save an animation project to .excanim file
+ * Save an animation project to a canonical V2 .excanim file.
  */
 export async function saveProjectFile(
   project: AnimationProject,
@@ -68,7 +61,7 @@ export async function saveProjectFile(
 }
 
 /**
- * Load an animation project from .excanim file
+ * Load an animation project from .excanim file.
  */
 export async function loadProjectFile(): Promise<AnimationProject> {
   const file = await fileOpen({
@@ -77,21 +70,20 @@ export async function loadProjectFile(): Promise<AnimationProject> {
     mimeTypes: ['application/json'],
   });
 
-  const text = await file.text();
-  return deserializeProject(text);
+  return parseProjectFileBlob(file);
 }
 
 /**
- * Parse an animation project from a File/Blob (for drag & drop).
+ * Parse an animation project from a File/Blob.
  */
-export async function parseProjectFileBlob(file: File): Promise<AnimationProject> {
-  const text = await file.text();
-  return deserializeProject(text);
+export async function parseProjectFileBlob(
+  file: Blob,
+): Promise<AnimationProject> {
+  return deserializeProject(await readBlobText(file, 'Project file'));
 }
 
 /**
- * Load an MCP checkpoint file (.json from Excalimate MCP server).
- * Returns scene data and animation timeline for import into the app.
+ * Load an MCP checkpoint file and normalize it into a V2 project.
  */
 export async function loadMcpCheckpoint(): Promise<McpCheckpointData> {
   const file = await fileOpen({
@@ -103,38 +95,18 @@ export async function loadMcpCheckpoint(): Promise<McpCheckpointData> {
   return parseMcpCheckpointBlob(file);
 }
 
-export interface McpCheckpointData {
-  scene: ExcalidrawSceneData;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  timeline: any;
-  clipStart: number;
-  clipEnd: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  cameraFrame: any;
-}
+export type McpCheckpointData = AnimationProject;
 
 /**
- * Parse an MCP checkpoint from a File/Blob (for drag & drop).
+ * Parse an MCP checkpoint from a File/Blob.
  */
-export async function parseMcpCheckpointBlob(file: File): Promise<McpCheckpointData> {
-  const text = await file.text();
-  const data = JSON.parse(text);
-
-  if (!data.scene?.elements) {
-    throw new Error('Invalid checkpoint: missing scene.elements');
-  }
-
-  return {
-    scene: {
-      elements: data.scene.elements,
-      appState: data.scene.appState ?? {},
-      files: data.scene.files ?? {},
-    },
-    timeline: data.timeline ?? null,
-    clipStart: data.clipStart ?? 0,
-    clipEnd: data.clipEnd ?? 10000,
-    cameraFrame: data.cameraFrame ?? null,
-  };
+export async function parseMcpCheckpointBlob(
+  file: Blob,
+): Promise<McpCheckpointData> {
+  const content = decodeProjectContent(
+    await readBlobText(file, 'MCP checkpoint'),
+  );
+  return createProjectFromContent('MCP Checkpoint', content);
 }
 
 /**
@@ -150,78 +122,145 @@ export async function importFromUrl(url: string): Promise<ExcalidrawSceneData> {
   }
 
   const data = await loadScene(parsed.id, parsed.key);
-
-  if (!data.elements || data.elements.length === 0) {
+  const scene = parseScene(data, 'Invalid shared Excalidraw scene');
+  if (scene.elements.length === 0) {
     throw new Error('The shared scene contains no elements.');
   }
-
-  return {
-    elements: data.elements,
-    appState: data.appState ?? {},
-    files: data.files ?? {},
-  };
+  return fromProjectScene(scene);
 }
 
 export { parseExcalidrawUrl } from '../vendor/parseUrl';
 
-export interface SharedAnimationData {
-  scene: ExcalidrawSceneData;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  timeline?: any;
-  clipStart?: number;
-  clipEnd?: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  cameraFrame?: any;
-}
+export type SharedAnimationData = AnimationProject;
 
 /**
- * Load a shared animation from an E2E encrypted share URL.
- * Format: https://app.excalimate.com/#share=ID,KEY
+ * Load an E2E encrypted share and normalize V1, V2, or legacy transfer data.
  */
-export async function loadShareUrl(shareUrl: string): Promise<SharedAnimationData> {
-  // Lazy import to avoid pulling crypto into the main bundle
+export async function loadShareUrl(
+  shareUrl: string,
+): Promise<SharedAnimationData> {
   const { importKeyFromString, decryptData } = await import('./encryption');
-
-  // Parse the URL — accept full URLs or just the hash fragment
-  let shareId: string;
-  let keyStr: string;
-
-  const hashMatch = shareUrl.match(/#share=([^,]+),(.+)/);
-  if (hashMatch) {
-    shareId = hashMatch[1];
-    keyStr = hashMatch[2];
-  } else {
-    // Try as raw "ID,KEY"
-    const parts = shareUrl.split(',');
-    if (parts.length >= 2) {
-      shareId = parts[0].trim();
-      keyStr = parts[1].trim();
-    } else {
-      throw new Error('Invalid share URL. Expected format: https://.../#share=ID,KEY');
-    }
-  }
-
-  const shareApiUrl = import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
-  const response = await fetch(`${shareApiUrl}/share/${shareId}`);
+  const { shareId, keyString } = parseShareReference(shareUrl);
+  const shareApiUrl =
+    import.meta.env.VITE_SHARE_API_URL ?? 'https://share.excalimate.com';
+  const response = await fetch(
+    `${shareApiUrl}/share/${encodeURIComponent(shareId)}`,
+  );
   if (!response.ok) throw new Error('Shared animation not found.');
-  const encrypted = await response.arrayBuffer();
-  const key = await importKeyFromString(keyStr);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data = await decryptData<any>(encrypted, key);
 
-  if (!data.scene?.elements) {
-    throw new Error('Invalid shared data: missing scene elements.');
+  const encrypted = await readResponseBytes(response, 'Encrypted share');
+  const key = await importKeyFromString(keyString);
+  const data = await decryptData(encrypted, key);
+  const content = parseProjectContent(data);
+  return createProjectFromContent('Shared Animation', content);
+}
+
+async function readBlobText(blob: Blob, label: string): Promise<string> {
+  assertInputByteLimit(blob.size, PROJECT_LIMITS.maxInputBytes, label);
+  const text = await blob.text();
+  assertInputByteLimit(
+    new TextEncoder().encode(text).byteLength,
+    PROJECT_LIMITS.maxInputBytes,
+    label,
+  );
+  return text;
+}
+
+async function readResponseBytes(
+  response: Response,
+  label: string,
+): Promise<ArrayBuffer> {
+  const declaredLength = response.headers.get('content-length');
+  if (declaredLength !== null) {
+    const byteLength = Number(declaredLength);
+    assertInputByteLimit(byteLength, PROJECT_LIMITS.maxInputBytes, label);
   }
 
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    assertInputByteLimit(
+      buffer.byteLength,
+      PROJECT_LIMITS.maxInputBytes,
+      label,
+    );
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > PROJECT_LIMITS.maxInputBytes) {
+      await reader.cancel();
+      throw new Error(`${label} exceeds the download limit`);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes.buffer;
+}
+
+function parseShareReference(shareUrl: string): {
+  shareId: string;
+  keyString: string;
+} {
+  const hashMatch = shareUrl.match(/#share=([^,]+),([^&\s]+)/);
+  const rawParts = hashMatch
+    ? [hashMatch[1], hashMatch[2]]
+    : shareUrl.split(',', 2);
+  const shareId = rawParts[0]?.trim();
+  const keyString = rawParts[1]?.trim();
+
+  if (
+    !shareId ||
+    !keyString ||
+    !/^[A-Za-z0-9_-]{1,128}$/.test(shareId) ||
+    !/^[A-Za-z0-9_-]{1,128}$/.test(keyString)
+  ) {
+    throw new Error(
+      'Invalid share URL. Expected format: https://.../#share=ID,KEY',
+    );
+  }
+  return { shareId, keyString };
+}
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${label} contains invalid JSON`);
+  }
+}
+
+function parseScene(input: unknown, label: string): ProjectScene {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error(`${label}: expected an object`);
+  }
+  const record = input as Record<string, unknown>;
+  const result = ProjectSceneSchema.safeParse({
+    elements: record['elements'],
+    appState: record['appState'] ?? {},
+    files: record['files'] ?? {},
+  });
+  if (!result.success) {
+    throw new Error(`${label}: ${result.error.issues[0]?.message}`);
+  }
+  return result.data;
+}
+
+function fromProjectScene(scene: ProjectScene): ExcalidrawSceneData {
   return {
-    scene: {
-      elements: data.scene.elements,
-      appState: data.scene.appState ?? {},
-      files: data.scene.files ?? {},
-    },
-    timeline: data.timeline,
-    clipStart: data.clipStart,
-    clipEnd: data.clipEnd,
-    cameraFrame: data.cameraFrame,
+    elements: scene.elements as unknown as ExcalidrawSceneData['elements'],
+    appState: scene.appState as ExcalidrawSceneData['appState'],
+    files: scene.files as ExcalidrawSceneData['files'],
   };
 }

--- a/src/services/ProjectDocumentService.test.ts
+++ b/src/services/ProjectDocumentService.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAnimationStore } from '../stores/animationStore';
+import { useProjectStore } from '../stores/projectStore';
+import { createSyntheticV2Project } from '../test-fixtures/projectDocuments';
+import {
+  captureProjectDocument,
+  loadProjectDocumentIntoStores,
+} from './ProjectDocumentService';
+
+describe('ProjectDocumentService', () => {
+  beforeEach(() => {
+    useProjectStore.setState({
+      project: null,
+      targets: [],
+      isDirty: false,
+      cameraFrame: {
+        aspectRatio: '16:9',
+        width: 1280,
+        x: 640,
+        y: 360,
+      },
+    });
+  });
+
+  it('round-trips timeline, short clips, and camera without store normalization', () => {
+    const document = createSyntheticV2Project();
+    document.timeline = {
+      ...document.timeline,
+      duration: 50,
+      tracks: [],
+    };
+    document.playback = {
+      clipStart: 0,
+      clipEnd: 50,
+      cameraFrame: {
+        aspectRatio: '1:1',
+        width: 500,
+        x: 120,
+        y: 80,
+      },
+    };
+
+    loadProjectDocumentIntoStores(document, {
+      activateAnimationMode: false,
+    });
+    const captured = captureProjectDocument();
+
+    expect(useAnimationStore.getState().clipEnd).toBe(50);
+    expect(captured?.timeline).toEqual(document.timeline);
+    expect(captured?.playback).toEqual(document.playback);
+  });
+});

--- a/src/services/ProjectDocumentService.ts
+++ b/src/services/ProjectDocumentService.ts
@@ -1,0 +1,58 @@
+import { parseProjectDocument } from '@excalimate/project-schema';
+import type { ProjectDocument } from '@excalimate/project-schema';
+import {
+  fromProjectDocument,
+  toProjectDocument,
+} from '../core/models/Project';
+import type { AnimationProject } from '../core/models/Project';
+import { computeFrameAtTime } from '../core/engine/playbackSingleton';
+import { useAnimationStore } from '../stores/animationStore';
+import { useProjectStore } from '../stores/projectStore';
+import { useUIStore } from '../stores/uiStore';
+import { extractTargets } from '../components/Canvas/extractTargets';
+
+export function captureProjectDocument(): ProjectDocument | null {
+  const project = useProjectStore.getState().project;
+  if (!project) return null;
+
+  const { timeline, clipStart, clipEnd } = useAnimationStore.getState();
+  const cameraFrame = useProjectStore.getState().cameraFrame;
+  const updatedAt = new Date().toISOString();
+  return parseProjectDocument(
+    toProjectDocument({
+      ...project,
+      timeline,
+      playback: { clipStart, clipEnd, cameraFrame },
+      clipStart,
+      clipEnd,
+      cameraFrame,
+      updatedAt,
+      metadata: { ...project.metadata, updatedAt },
+    }),
+  );
+}
+
+export function loadProjectDocumentIntoStores(
+  project: AnimationProject | ProjectDocument,
+  options: { activateAnimationMode?: boolean } = {},
+): AnimationProject {
+  const appProject =
+    'id' in project ? project : fromProjectDocument(project);
+  useProjectStore.getState().loadProject(appProject);
+  useProjectStore
+    .getState()
+    .setTargets(extractTargets(appProject.scene.elements));
+  // setTargets may auto-fit a default-position frame; restore the exact document frame.
+  useProjectStore.getState().loadProject(appProject);
+  useAnimationStore.setState({
+    timeline: appProject.timeline,
+    clipStart: appProject.playback.clipStart,
+    clipEnd: appProject.playback.clipEnd,
+  });
+
+  if (options.activateAnimationMode ?? true) {
+    useUIStore.getState().setMode('animate');
+    computeFrameAtTime(0);
+  }
+  return appProject;
+}

--- a/src/services/encryption.ts
+++ b/src/services/encryption.ts
@@ -17,6 +17,11 @@
  *   Load:  extractKey(URL) → download(encrypted) → decrypt(encrypted, key) → decompress → data
  */
 
+import {
+  PROJECT_LIMITS,
+  assertInputByteLimit,
+} from '@excalimate/project-schema';
+
 /**
  * Generate a random AES-GCM 256-bit encryption key.
  */
@@ -56,19 +61,27 @@ async function compress(data: Uint8Array): Promise<Uint8Array> {
 /**
  * Decompress gzip data via the Compression Streams API.
  */
-async function decompress(data: Uint8Array): Promise<Uint8Array> {
+async function decompress(
+  data: Uint8Array,
+  maxOutputBytes: number,
+): Promise<Uint8Array> {
   const ds = new DecompressionStream('gzip');
   const writer = ds.writable.getWriter();
   writer.write(data as unknown as BufferSource);
   writer.close();
   const reader = ds.readable.getReader();
   const chunks: Uint8Array[] = [];
+  let total = 0;
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
+    total += value.length;
+    if (total > maxOutputBytes) {
+      await reader.cancel();
+      throw new Error('Decompressed share payload exceeds the safety limit');
+    }
     chunks.push(value);
   }
-  const total = chunks.reduce((n, c) => n + c.length, 0);
   const result = new Uint8Array(total);
   let offset = 0;
   for (const chunk of chunks) {
@@ -88,6 +101,11 @@ const COMPRESSED_MAGIC = 0x1F; // gzip magic byte — naturally present
  */
 export async function encryptData(data: unknown, key: CryptoKey): Promise<ArrayBuffer> {
   const plaintext = new TextEncoder().encode(JSON.stringify(data));
+  assertInputByteLimit(
+    plaintext.byteLength,
+    PROJECT_LIMITS.maxDecompressedBytes,
+    'Share payload',
+  );
   const compressed = await compress(plaintext);
 
   // Generate a random IV for each encryption (12 bytes for AES-GCM)
@@ -101,6 +119,11 @@ export async function encryptData(data: unknown, key: CryptoKey): Promise<ArrayB
   const result = new Uint8Array(iv.byteLength + encrypted.byteLength);
   result.set(iv, 0);
   result.set(new Uint8Array(encrypted), iv.byteLength);
+  assertInputByteLimit(
+    result.byteLength,
+    PROJECT_LIMITS.maxInputBytes,
+    'Encrypted share',
+  );
   return result.buffer;
 }
 
@@ -109,7 +132,18 @@ export async function encryptData(data: unknown, key: CryptoKey): Promise<ArrayB
  * Expects the IV prepended to the ciphertext (as produced by encryptData).
  * Handles both compressed (new) and uncompressed (legacy) payloads.
  */
-export async function decryptData<T = unknown>(encrypted: ArrayBuffer, key: CryptoKey): Promise<T> {
+export async function decryptData(
+  encrypted: ArrayBuffer,
+  key: CryptoKey,
+): Promise<unknown> {
+  assertInputByteLimit(
+    encrypted.byteLength,
+    PROJECT_LIMITS.maxInputBytes,
+    'Encrypted share',
+  );
+  if (encrypted.byteLength <= 12) {
+    throw new Error('Encrypted share payload is truncated');
+  }
   const data = new Uint8Array(encrypted);
   const iv = data.slice(0, 12);
   const ciphertext = data.slice(12);
@@ -123,9 +157,17 @@ export async function decryptData<T = unknown>(encrypted: ArrayBuffer, key: Cryp
   // Detect gzip magic bytes for backward compatibility with uncompressed payloads
   let plaintext: string;
   if (raw.length >= 2 && raw[0] === COMPRESSED_MAGIC && raw[1] === 0x8B) {
-    const decompressed = await decompress(raw);
+    const decompressed = await decompress(
+      raw,
+      PROJECT_LIMITS.maxDecompressedBytes,
+    );
     plaintext = new TextDecoder().decode(decompressed);
   } else {
+    assertInputByteLimit(
+      raw.byteLength,
+      PROJECT_LIMITS.maxDecompressedBytes,
+      'Decrypted share',
+    );
     plaintext = new TextDecoder().decode(raw);
   }
 
@@ -155,6 +197,9 @@ export async function importKeyFromString(keyStr: string): Promise<CryptoKey> {
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
 
+  if (bytes.length !== 16 && bytes.length !== 32) {
+    throw new Error('Invalid encryption key length');
+  }
   const keyLength = bytes.length === 16 ? 128 : 256;
 
   return window.crypto.subtle.importKey(

--- a/src/services/recovery/IndexedDbRecoveryStore.test.ts
+++ b/src/services/recovery/IndexedDbRecoveryStore.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import { createSyntheticV2Project } from '../../test-fixtures/projectDocuments';
+import { IndexedDbRecoveryStore } from './IndexedDbRecoveryStore';
+
+describe('IndexedDbRecoveryStore', () => {
+  let store: IndexedDbRecoveryStore;
+
+  beforeEach(() => {
+    store = new IndexedDbRecoveryStore(new IDBFactory(), 3);
+  });
+
+  it('round-trips validated recovery snapshots', async () => {
+    const document = createSyntheticV2Project();
+    await store.save(document, 100);
+
+    expect(await store.latest()).toEqual({
+      id: 'synthetic-project:100',
+      projectId: 'synthetic-project',
+      savedAt: 100,
+      document,
+    });
+  });
+
+  it('retains only the configured recovery history', async () => {
+    const document = createSyntheticV2Project();
+    await store.save(document, 100);
+    await store.save(document, 200);
+    await store.save(document, 300);
+    await store.save(document, 400);
+
+    expect((await store.list()).map((snapshot) => snapshot.savedAt)).toEqual([
+      200, 300, 400,
+    ]);
+  });
+
+  it('clears one project without deleting other recovery entries', async () => {
+    const first = createSyntheticV2Project();
+    const second = {
+      ...createSyntheticV2Project(),
+      metadata: {
+        ...createSyntheticV2Project().metadata,
+        id: 'other-project',
+      },
+    };
+    await store.save(first, 100);
+    await store.save(second, 200);
+
+    await store.clear(first.metadata.id);
+
+    expect((await store.list()).map((snapshot) => snapshot.projectId)).toEqual([
+      'other-project',
+    ]);
+  });
+
+  it('rejects invalid documents before writing', async () => {
+    const document = createSyntheticV2Project();
+    document.timeline.duration = Number.POSITIVE_INFINITY;
+    await expect(store.save(document)).rejects.toThrow();
+    expect(await store.list()).toEqual([]);
+  });
+});

--- a/src/services/recovery/IndexedDbRecoveryStore.ts
+++ b/src/services/recovery/IndexedDbRecoveryStore.ts
@@ -1,0 +1,202 @@
+import { parseProjectDocument } from '@excalimate/project-schema';
+import type { ProjectDocument } from '@excalimate/project-schema';
+
+const DATABASE_NAME = 'excalimate-recovery';
+const DATABASE_VERSION = 1;
+const SNAPSHOT_STORE = 'snapshots';
+const SAVED_AT_INDEX = 'savedAt';
+const PROJECT_ID_INDEX = 'projectId';
+
+export const MAX_RECOVERY_SNAPSHOTS = 10;
+
+export interface RecoverySnapshot {
+  id: string;
+  projectId: string;
+  savedAt: number;
+  document: ProjectDocument;
+}
+
+export class IndexedDbRecoveryStore {
+  private readonly indexedDb: IDBFactory;
+  private readonly maxSnapshots: number;
+  private databasePromise: Promise<IDBDatabase> | null = null;
+
+  constructor(
+    indexedDb: IDBFactory = globalThis.indexedDB,
+    maxSnapshots = MAX_RECOVERY_SNAPSHOTS,
+  ) {
+    this.indexedDb = indexedDb;
+    this.maxSnapshots = maxSnapshots;
+  }
+
+  async save(
+    document: ProjectDocument,
+    savedAt = Date.now(),
+  ): Promise<RecoverySnapshot> {
+    const validated = parseProjectDocument(document);
+    const snapshot: RecoverySnapshot = {
+      id: `${validated.metadata.id}:${savedAt}`,
+      projectId: validated.metadata.id,
+      savedAt,
+      document: validated,
+    };
+    const database = await this.open();
+    const transaction = database.transaction(SNAPSHOT_STORE, 'readwrite');
+    const completion = transactionComplete(transaction);
+    transaction.objectStore(SNAPSHOT_STORE).put(snapshot);
+    await completion;
+    await this.prune();
+    return snapshot;
+  }
+
+  async latest(): Promise<RecoverySnapshot | null> {
+    const database = await this.open();
+    const transaction = database.transaction(SNAPSHOT_STORE, 'readonly');
+    const completion = transactionComplete(transaction);
+    const cursor = await requestResult<IDBCursorWithValue | null>(
+      transaction
+        .objectStore(SNAPSHOT_STORE)
+        .index(SAVED_AT_INDEX)
+        .openCursor(null, 'prev'),
+    );
+    const record: unknown = cursor?.value;
+    await completion;
+    return record === undefined ? null : parseRecoverySnapshot(record);
+  }
+
+  async list(): Promise<RecoverySnapshot[]> {
+    const database = await this.open();
+    const transaction = database.transaction(SNAPSHOT_STORE, 'readonly');
+    const completion = transactionComplete(transaction);
+    const request = transaction
+      .objectStore(SNAPSHOT_STORE)
+      .index(SAVED_AT_INDEX)
+      .getAll();
+    const records = await requestResult<unknown[]>(request);
+    await completion;
+    return records.map(parseRecoverySnapshot);
+  }
+
+  async clear(projectId?: string): Promise<void> {
+    const database = await this.open();
+    const transaction = database.transaction(SNAPSHOT_STORE, 'readwrite');
+    const completion = transactionComplete(transaction);
+    const store = transaction.objectStore(SNAPSHOT_STORE);
+
+    if (projectId === undefined) {
+      store.clear();
+    } else {
+      const keys = await requestResult<IDBValidKey[]>(
+        store.index(PROJECT_ID_INDEX).getAllKeys(projectId),
+      );
+      for (const key of keys) store.delete(key);
+    }
+    await completion;
+  }
+
+  close(): void {
+    if (!this.databasePromise) return;
+    void this.databasePromise.then((database) => database.close());
+    this.databasePromise = null;
+  }
+
+  private open(): Promise<IDBDatabase> {
+    this.databasePromise ??= new Promise<IDBDatabase>((resolve, reject) => {
+      if (!this.indexedDb) {
+        reject(new Error('IndexedDB is not available in this browser'));
+        return;
+      }
+
+      const request = this.indexedDb.open(DATABASE_NAME, DATABASE_VERSION);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        const store = database.createObjectStore(SNAPSHOT_STORE, {
+          keyPath: 'id',
+        });
+        store.createIndex(SAVED_AT_INDEX, SAVED_AT_INDEX);
+        store.createIndex(PROJECT_ID_INDEX, PROJECT_ID_INDEX);
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () =>
+        reject(request.error ?? new Error('Unable to open recovery database'));
+      request.onblocked = () =>
+        reject(new Error('Recovery database upgrade was blocked'));
+    });
+    return this.databasePromise;
+  }
+
+  private async prune(): Promise<void> {
+    const database = await this.open();
+    const transaction = database.transaction(SNAPSHOT_STORE, 'readwrite');
+    const completion = transactionComplete(transaction);
+    const store = transaction.objectStore(SNAPSHOT_STORE);
+    const count = await requestResult(store.count());
+    const excess = count - this.maxSnapshots;
+    if (excess > 0) {
+      await deleteOldestRecords(store.index(SAVED_AT_INDEX), store, excess);
+    }
+    await completion;
+  }
+}
+
+function parseRecoverySnapshot(input: unknown): RecoverySnapshot {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('Recovery snapshot is invalid');
+  }
+  const record = input as Record<string, unknown>;
+  if (
+    typeof record['id'] !== 'string' ||
+    typeof record['projectId'] !== 'string' ||
+    typeof record['savedAt'] !== 'number' ||
+    !Number.isFinite(record['savedAt'])
+  ) {
+    throw new Error('Recovery snapshot metadata is invalid');
+  }
+  return {
+    id: record['id'],
+    projectId: record['projectId'],
+    savedAt: record['savedAt'],
+    document: parseProjectDocument(record['document']),
+  };
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+function deleteOldestRecords(
+  index: IDBIndex,
+  store: IDBObjectStore,
+  count: number,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let remaining = count;
+    const request = index.openKeyCursor();
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor || remaining <= 0) {
+        resolve();
+        return;
+      }
+      store.delete(cursor.primaryKey);
+      remaining -= 1;
+      cursor.continue();
+    };
+    request.onerror = () =>
+      reject(request.error ?? new Error('Unable to prune recovery history'));
+  });
+}

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,20 +1,15 @@
 import { create } from 'zustand';
 import { nanoid } from 'nanoid';
+import type {
+  AspectRatio,
+  CameraFrame,
+} from '@excalimate/project-schema';
+import { CAMERA_FRAME_TARGET_ID } from '@excalimate/project-schema';
 import type { AnimationProject } from '../core/models/Project';
 import { createProject } from '../core/models/Project';
 import type { ExcalidrawSceneData, AnimatableTarget } from '../types/excalidraw';
 
-export type AspectRatio = '16:9' | '4:3' | '1:1' | '3:2';
-
-export interface CameraFrame {
-  aspectRatio: AspectRatio;
-  /** Width in scene coordinate units. Height derived from aspect ratio. */
-  width: number;
-  /** Center X in scene coordinates */
-  x: number;
-  /** Center Y in scene coordinates */
-  y: number;
-}
+export type { AspectRatio, CameraFrame };
 
 export const ASPECT_RATIOS: Record<AspectRatio, number> = {
   '16:9': 16 / 9,
@@ -31,7 +26,7 @@ export const EXPORT_WIDTHS: Record<AspectRatio, number> = {
   '3:2': 1620,
 };
 
-export const CAMERA_FRAME_TARGET_ID = '__camera_frame__';
+export { CAMERA_FRAME_TARGET_ID };
 
 export function getFrameHeight(frame: CameraFrame): number {
   return frame.width / ASPECT_RATIOS[frame.aspectRatio];
@@ -75,18 +70,33 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
   cameraFrame: { aspectRatio: '16:9', width: 1280, x: 640, y: 360 },
 
   createNewProject: (name: string, scene: ExcalidrawSceneData): void => {
-    set({ project: createProject(name, scene), isDirty: false });
+    const project = createProject(name, scene);
+    set({
+      project,
+      cameraFrame: project.playback.cameraFrame,
+      isDirty: false,
+    });
   },
 
   loadProject: (project: AnimationProject): void => {
-    set({ project, isDirty: false });
+    set({
+      project,
+      cameraFrame: project.playback.cameraFrame,
+      isDirty: false,
+    });
   },
 
   updateScene: (scene: ExcalidrawSceneData): void => {
     const { project } = get();
     if (!project) return;
+    const updatedAt = new Date().toISOString();
     set({
-      project: { ...project, scene, updatedAt: new Date().toISOString() },
+      project: {
+        ...project,
+        scene,
+        updatedAt,
+        metadata: { ...project.metadata, updatedAt },
+      },
       isDirty: true,
     });
   },
@@ -94,8 +104,14 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
   updateProjectName: (name: string): void => {
     const { project } = get();
     if (!project) return;
+    const updatedAt = new Date().toISOString();
     set({
-      project: { ...project, name, updatedAt: new Date().toISOString() },
+      project: {
+        ...project,
+        name,
+        updatedAt,
+        metadata: { ...project.metadata, name, updatedAt },
+      },
       isDirty: true,
     });
   },

--- a/src/test-fixtures/projectDocuments.ts
+++ b/src/test-fixtures/projectDocuments.ts
@@ -1,0 +1,74 @@
+import type {
+  ProjectDocument,
+  V1ProjectDocument,
+} from '@excalimate/project-schema';
+import { migrateV1Project } from '@excalimate/project-schema';
+
+export const SYNTHETIC_V1_PROJECT = {
+  version: '1.0.0',
+  id: 'synthetic-project',
+  name: 'Synthetic animation',
+  scene: {
+    elements: [
+      {
+        id: 'synthetic-rectangle',
+        type: 'rectangle',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+    ],
+    appState: { viewBackgroundColor: '#ffffff' },
+    files: {},
+  },
+  timeline: {
+    id: 'synthetic-timeline',
+    name: 'Synthetic timeline',
+    duration: 2_000,
+    fps: 60,
+    tracks: [
+      {
+        id: 'synthetic-opacity-track',
+        targetId: 'synthetic-rectangle',
+        targetType: 'element',
+        property: 'opacity',
+        enabled: true,
+        keyframes: [
+          {
+            id: 'synthetic-keyframe-start',
+            time: 0,
+            value: 0,
+            easing: 'linear',
+          },
+          {
+            id: 'synthetic-keyframe-end',
+            time: 1_000,
+            value: 1,
+            easing: 'linear',
+          },
+        ],
+      },
+    ],
+  },
+  clipStart: 100,
+  clipEnd: 1_800,
+  cameraFrame: {
+    aspectRatio: '16:9',
+    width: 1_200,
+    x: 600,
+    y: 337.5,
+  },
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-02T00:00:00.000Z',
+} satisfies V1ProjectDocument;
+
+export function createSyntheticV2Project(): ProjectDocument {
+  return {
+    ...migrateV1Project(structuredClone(SYNTHETIC_V1_PROJECT)),
+    authoring: {
+      note: 'Synthetic test metadata',
+    },
+    preferredWorkspace: 'sequence',
+  };
+}

--- a/src/types/animation.ts
+++ b/src/types/animation.ts
@@ -1,55 +1,22 @@
-export type AnimatableProperty =
-  | 'opacity'
-  | 'translateX'
-  | 'translateY'
-  | 'scaleX'
-  | 'scaleY'
-  | 'rotation'
-  | 'drawProgress';
+import {
+  ANIMATABLE_PROPERTIES,
+  EASING_TYPES,
+} from '@excalimate/project-schema';
+import type {
+  AnimatableProperty,
+  AnimationTimeline,
+  AnimationTrack,
+  EasingType,
+  Keyframe,
+} from '@excalimate/project-schema';
 
-export type EasingType =
-  | 'linear'
-  | 'easeIn'
-  | 'easeOut'
-  | 'easeInOut'
-  | 'easeInQuad'
-  | 'easeOutQuad'
-  | 'easeInOutQuad'
-  | 'easeInCubic'
-  | 'easeOutCubic'
-  | 'easeInOutCubic'
-  | 'easeInBack'
-  | 'easeOutBack'
-  | 'easeInOutBack'
-  | 'easeInElastic'
-  | 'easeOutElastic'
-  | 'easeInBounce'
-  | 'easeOutBounce'
-  | 'step';
-
-export interface Keyframe {
-  id: string;
-  time: number; // ms from timeline start
-  value: number;
-  easing: EasingType; // easing to NEXT keyframe
-}
-
-export interface AnimationTrack {
-  id: string;
-  targetId: string;
-  targetType: 'element' | 'group';
-  property: AnimatableProperty;
-  keyframes: Keyframe[];
-  enabled: boolean;
-}
-
-export interface AnimationTimeline {
-  id: string;
-  name: string;
-  duration: number; // total duration in ms
-  fps: number; // default 60
-  tracks: AnimationTrack[];
-}
+export type {
+  AnimatableProperty,
+  AnimationTimeline,
+  AnimationTrack,
+  EasingType,
+  Keyframe,
+};
 
 export interface ElementAnimationState {
   targetId: string;
@@ -76,33 +43,4 @@ export const PROPERTY_DEFAULTS: Record<AnimatableProperty, number> = {
 };
 
 // All valid easing types for validation
-export const EASING_TYPES: readonly EasingType[] = [
-  'linear',
-  'easeIn',
-  'easeOut',
-  'easeInOut',
-  'easeInQuad',
-  'easeOutQuad',
-  'easeInOutQuad',
-  'easeInCubic',
-  'easeOutCubic',
-  'easeInOutCubic',
-  'easeInBack',
-  'easeOutBack',
-  'easeInOutBack',
-  'easeInElastic',
-  'easeOutElastic',
-  'easeInBounce',
-  'easeOutBounce',
-  'step',
-] as const;
-
-export const ANIMATABLE_PROPERTIES: readonly AnimatableProperty[] = [
-  'opacity',
-  'translateX',
-  'translateY',
-  'scaleX',
-  'scaleY',
-  'rotation',
-  'drawProgress',
-] as const;
+export { ANIMATABLE_PROPERTIES, EASING_TYPES };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,8 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@excalimate/project-schema": ["packages/project-schema/src/index.ts"]
     },
 
     /* Linting */
@@ -30,5 +31,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "packages/project-schema/src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { fileURLToPath, URL } from 'node:url'
 
 import { cloudflare } from "@cloudflare/vite-plugin";
 
@@ -10,6 +11,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': '/src',
+      '@excalimate/project-schema': fileURLToPath(
+        new URL('./packages/project-schema/src/index.ts', import.meta.url),
+      ),
     },
   },
   build: {
@@ -26,10 +30,10 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/test-setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'packages/**/*.test.ts'],
     coverage: {
       reporter: ['text', 'lcov'],
-      include: ['src/**/*.{ts,tsx}'],
+      include: ['src/**/*.{ts,tsx}', 'packages/project-schema/src/**/*.ts'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/test-setup.ts', 'src/vite-env.d.ts'],
     },
   },


### PR DESCRIPTION
## Summary
- add a private browser/server-neutral `@excalimate/project-schema` workspace package with strict Zod V2 contracts, centralized resource limits, JSON codecs, transfer validation, and explicit idempotent `1.0.0` to `2.0.0` migration
- unify scene, canonical timeline, playback clip/camera state, metadata, optional authoring metadata, and preferred workspace while preserving current app exports and flat-field adapters
- route `.excanim`, MCP checkpoint, and encrypted share ingestion through bounded unknown-input validation; new saves and shares emit complete V2 documents
- replace dormant localStorage whole-document autosave with debounced native IndexedDB recovery, bounded snapshot history, startup restore, visible failures, and share/recovery startup coordination
- add redacted synthetic contract, ingestion, share, store round-trip, StrictMode startup, and IndexedDB tests

## Migration tradeoffs
- reads accept exactly `1.0.0` and `2.0.0`; unsupported versions are rejected rather than guessed, and all subsequent saves use V2
- Excalidraw internals remain opaque/preserved, while envelope shape, byte/decompression limits, nesting, counts, strings, finite numbers, timeline values, and references are enforced
- bounded keyframes and clips beyond declared timeline duration remain unchanged because the existing engine treats the timeline’s effective duration as the later keyframe
- legacy checkpoint/share payloads remain accepted with safe defaults; new shares carry the canonical V2 envelope

## Validation
- `npm test` — 15 files, 309 tests
- `npx eslint .`
- `npm run build`