### PR TITLE
Harden MCP localhost transport and isolate sessions

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -12,15 +12,13 @@ The fastest way to use Excalimate with AI is to combine the deployed web app wit
 
 ```bash
 npx @excalimate/mcp-server
-# → Listening on http://localhost:3001/mcp
-# → Live preview SSE at http://localhost:3001/live
+# -> MCP server listening on http://127.0.0.1:3001/mcp
 
 # Custom port:
 npx @excalimate/mcp-server --port 4000
 ```
 
-Port priority: CLI arg (`--port` / `-p`) > `PORT` env var > default `3001`.
-Also supports `--port=4000` syntax.
+HTTP mode binds to `127.0.0.1` by default. Port priority is CLI (`--port` / `-p`), then `PORT`, then `3001`. `--port=4000` is also supported.
 
 Or install globally:
 
@@ -29,26 +27,29 @@ npm install -g @excalimate/mcp-server
 excalimate-mcp
 ```
 
-### Step 2: Open the web app
+### Step 2: Connect your AI
 
-Go to [app.excalimate.com](https://app.excalimate.com) in your browser and click **📡 Live** in the toolbar. The app connects to `localhost:3001` automatically.
+Point your AI tool to `http://127.0.0.1:3001/mcp`. When the MCP session initializes, the server prints a unique pairing URL:
 
-You can configure the MCP server URL in **File → Preferences**. The app persists this setting in localStorage, shows connection progress (progress bar + notifications), provides smart error dialogs, and warns about HTTPS→HTTP mixed-content connections.
+```text
+[excalimate] Preview paired for session ...:
+http://127.0.0.1:3001/p/UNGUESSABLE_PREVIEW_ID
+```
 
-### Step 3: Connect your AI
+Each MCP transport has isolated project state and its own unguessable preview ID.
 
-Point your AI tool to `http://localhost:3001/mcp` as an MCP server. Then ask it to create a diagram and animate it — you'll see elements appear and animate in your browser in real-time.
+### Step 3: Open the web app
 
-**That's it.** The AI draws and animates, you see it live, and you can edit alongside it.
+Go to [app.excalimate.com](https://app.excalimate.com), open **File → Preferences**, and use the printed pairing URL as the MCP server URL. Click **Live** in the toolbar. The app appends `/live` and `/state` to that base URL, so it follows only the paired MCP session.
 
 ## Features
 
-- **23 tools** for scene creation, animation, camera control, export, checkpointing, and sharing
+- **29 tools** for scene creation, animation, camera control, inspection, checkpointing, and sharing
 - **Dual transport**: stdio (Claude Desktop) + Streamable HTTP (cloud deployment)
-- **Live preview**: Real-time updates in [app.excalimate.com](https://app.excalimate.com) via SSE
+- **Paired live preview**: Per-session real-time updates via an unguessable preview URL
 - **Sequence reveal**: Staggered element reveal animations in one tool call
 - **Camera animation**: Pan/zoom keyframes for cinematic effects
-- **Checkpoint persistence**: Save/load complete scene + animation state
+- **Session-scoped checkpoints**: Save/load complete state without crossing HTTP transport boundaries
 - **Runtime versioning**: Server version is read from `package.json`
 
 ## Installation & Usage
@@ -57,13 +58,47 @@ Point your AI tool to `http://localhost:3001/mcp` as an MCP server. Then ask it 
 
 ```bash
 npx @excalimate/mcp-server
-# → http://localhost:3001/mcp
+# -> http://127.0.0.1:3001/mcp
 
 # Custom port:
 npx @excalimate/mcp-server -p 4000
 ```
 
-Open [app.excalimate.com](https://app.excalimate.com) and click **📡 Live**, then configure your AI tool below.
+Configure your AI tool below. After it initializes an MCP session, copy the printed preview pairing URL into the web app's MCP server URL preference and click **Live**.
+
+### HTTP security and configuration
+
+The default loopback binding rejects DNS-rebinding-style Host values and browser requests from origins outside the allowlist. Origin, Host, authentication, and Fetch Metadata checks are applied consistently to `/mcp`, `/live`, and `/state`.
+
+```bash
+# Network exposure requires an explicit token.
+excalimate-mcp \
+  --host 192.168.1.20 \
+  --auth-token "replace-with-at-least-16-characters" \
+  --allowed-hosts 192.168.1.20 \
+  --allowed-origins https://app.excalimate.com
+
+# Wildcard binds also require concrete allowed Host values.
+excalimate-mcp \
+  --host 0.0.0.0 \
+  --auth-token "replace-with-at-least-16-characters" \
+  --allowed-hosts 192.168.1.20,my-machine.local
+```
+
+Use `Authorization: Bearer TOKEN` for `/mcp`. Authenticated servers print a preview URL containing a session-scoped derived access key, so the web app does not need the MCP bearer token.
+
+| Setting | Default | Environment |
+|---|---:|---|
+| Bind host | `127.0.0.1` | `EXCALIMATE_HOST` |
+| Allowed browser origins | local Vite + Excalimate domains | `EXCALIMATE_ALLOWED_ORIGINS` (`CORS_ORIGIN` compatible) |
+| Allowed Host values | loopback names, or the explicit bind host | `EXCALIMATE_ALLOWED_HOSTS` |
+| JSON body limit | 1 MiB | `EXCALIMATE_BODY_LIMIT_BYTES` |
+| Request timeout | 30 seconds | `EXCALIMATE_REQUEST_TIMEOUT_MS` |
+| Concurrent MCP sessions | 16 | `EXCALIMATE_MAX_SESSIONS` |
+| Preview SSE clients | 32 | `EXCALIMATE_MAX_SSE_CLIENTS` |
+| Session idle TTL | 30 minutes | `EXCALIMATE_SESSION_TTL_MS` |
+
+Run `excalimate-mcp --help` for CLI options. Project resource limits also bound elements, tracks, keyframes, strings, nesting, animation times, total state size, and per-session mutation rate.
 
 ### Configure your AI tool
 
@@ -79,13 +114,13 @@ Add to your VS Code MCP config (`.vscode/mcp.json` or user-level `mcp.json`):
   "servers": {
     "excalimate": {
       "type": "http",
-      "url": "http://localhost:3001/mcp"
+      "url": "http://127.0.0.1:3001/mcp"
     }
   }
 }
 ```
 
-Start the MCP server first (`npx @excalimate/mcp-server`), open [app.excalimate.com](https://app.excalimate.com), click **📡 Live**, then ask Copilot to create a diagram. You'll see it appear in real-time.
+Start the MCP server, let Copilot initialize it, then copy the printed preview pairing URL into the web app before clicking **Live**.
 
 **stdio mode (no live preview):**
 
@@ -130,10 +165,10 @@ Claude Code supports HTTP MCP servers. Start the server first, then add it:
 
 ```bash
 npx @excalimate/mcp-server &
-claude mcp add excalimate http://localhost:3001/mcp
+claude mcp add excalimate http://127.0.0.1:3001/mcp
 ```
 
-Open [app.excalimate.com](https://app.excalimate.com) and click **📡 Live** — you'll see the AI's changes in real-time.
+Copy the pairing URL printed after Claude initializes the MCP session into the web app, then click **Live**.
 
 </details>
 
@@ -144,9 +179,9 @@ In Cursor settings, go to **MCP Servers** and add:
 
 - **Name:** `excalimate`
 - **Type:** `http`
-- **URL:** `http://localhost:3001/mcp`
+- **URL:** `http://127.0.0.1:3001/mcp`
 
-Start the MCP server (`npx @excalimate/mcp-server`), open [app.excalimate.com](https://app.excalimate.com), click **📡 Live**, then use Cursor's agent to create diagrams with live preview.
+Start the server and Cursor, then use the printed preview pairing URL in the web app.
 
 </details>
 
@@ -159,13 +194,13 @@ Add to your Windsurf MCP config:
 {
   "mcpServers": {
     "excalimate": {
-      "serverUrl": "http://localhost:3001/mcp"
+      "serverUrl": "http://127.0.0.1:3001/mcp"
     }
   }
 }
 ```
 
-Start the MCP server, open [app.excalimate.com](https://app.excalimate.com), click **📡 Live**, and use Cascade to create animated diagrams in real-time.
+Start the server and Cascade, then use the printed preview pairing URL in the web app.
 
 </details>
 
@@ -175,10 +210,10 @@ Start the MCP server, open [app.excalimate.com](https://app.excalimate.com), cli
 Point your MCP client to:
 
 ```
-http://localhost:3001/mcp
+http://127.0.0.1:3001/mcp
 ```
 
-Start the server with `npx @excalimate/mcp-server`, open [app.excalimate.com](https://app.excalimate.com), and click **📡 Live**. Any tool that supports Streamable HTTP MCP transport will work with live preview.
+Start the server and initialize the MCP client, then use the printed preview pairing URL in the web app.
 
 </details>
 
@@ -227,6 +262,24 @@ node dist/index.js --stdio  # stdio mode
 | `set_camera_frame` | Set camera position/size/aspect + creates t=0 keyframes |
 | `add_camera_keyframe` | Animate camera pan/zoom |
 | `add_camera_keyframes_batch` | Bulk camera keyframes |
+
+`add_keyframes_batch`, `add_scale_animation`, `add_camera_keyframes_batch`, and the animation arrays in `create_animated_scene` now accept nested arrays directly. JSON-encoded strings remain accepted on the same tool names for compatibility and return a deprecation notice.
+
+```json
+{
+  "keyframes": [
+    {
+      "targetId": "box1",
+      "property": "opacity",
+      "time": 500,
+      "value": 1,
+      "easing": "easeOut"
+    }
+  ]
+}
+```
+
+Snapshots include `revision` and `sequence`. Deltas include `baseRevision`, `revision`, and `sequence`; clients that detect a gap should fetch the paired `/state` endpoint for a complete snapshot.
 
 ### Inspection Tools
 | Tool | Description |

--- a/mcp-server/bench/harness/McpTestClient.ts
+++ b/mcp-server/bench/harness/McpTestClient.ts
@@ -1,9 +1,10 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createServer } from '../../src/server.js';
+import type { ExcalimateMcpServer } from '../../src/server.js';
 import type { CheckpointStore } from '../../src/checkpoint-store.js';
 import type { StateDelta } from '../../src/server/stateContext.js';
+import type { ServerState } from '../../src/types.js';
 
 export interface ToolCallResult {
   name: string;
@@ -17,13 +18,13 @@ export interface ToolCallResult {
  */
 export class McpTestClient {
   private client: Client;
-  private server: McpServer;
+  private server: ExcalimateMcpServer;
   private clientTransport: InMemoryTransport;
   private serverTransport: InMemoryTransport;
 
   private constructor(
     client: Client,
-    server: McpServer,
+    server: ExcalimateMcpServer,
     clientTransport: InMemoryTransport,
     serverTransport: InMemoryTransport,
   ) {
@@ -76,5 +77,13 @@ export class McpTestClient {
   async close(): Promise<void> {
     await this.clientTransport.close();
     await this.serverTransport.close();
+  }
+
+  getState(): ServerState {
+    return this.server.stateContext.getState();
+  }
+
+  getStateJSON(): string {
+    return this.server.stateContext.getStateJSON();
   }
 }

--- a/mcp-server/bench/harness/metrics.ts
+++ b/mcp-server/bench/harness/metrics.ts
@@ -1,6 +1,5 @@
 import type { ToolCallResult } from './McpTestClient.js';
 import type { TrafficReport } from './SseTrafficMonitor.js';
-import { getSharedStateJSON } from '../../src/server/stateContext.js';
 
 export interface BenchmarkResult {
   scenario: string;
@@ -26,8 +25,8 @@ export function collectMetrics(
   totalTimeMs: number,
   traffic: TrafficReport,
   state: { elementCount: number; trackCount: number; keyframeCount: number },
+  stateJson: string,
 ): BenchmarkResult {
-  const stateJson = getSharedStateJSON();
   const memUsage = process.memoryUsage();
 
   return {

--- a/mcp-server/bench/scenarios/batch-tools.bench.ts
+++ b/mcp-server/bench/scenarios/batch-tools.bench.ts
@@ -7,7 +7,6 @@ import { McpTestClient } from '../harness/McpTestClient.js';
 import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
 import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
 import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
-import { getSharedState } from '../../src/server/stateContext.js';
 
 export async function runBatchTools(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
   const store = new MemoryCheckpointStore();
@@ -24,7 +23,7 @@ export async function runBatchTools(scene: FixtureScene, sceneSize: string): Pro
   const { totalDurationMs, results } = await client.callToolSequence(calls);
   await new Promise(r => setTimeout(r, 100));
 
-  const state = getSharedState();
+  const state = client.getState();
   const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
 
   const metrics = collectMetrics(
@@ -34,6 +33,7 @@ export async function runBatchTools(scene: FixtureScene, sceneSize: string): Pro
     totalDurationMs,
     monitor.report(),
     { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+    client.getStateJSON(),
   );
 
   await client.close();

--- a/mcp-server/bench/scenarios/composite-tool.bench.ts
+++ b/mcp-server/bench/scenarios/composite-tool.bench.ts
@@ -7,7 +7,6 @@ import { McpTestClient } from '../harness/McpTestClient.js';
 import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
 import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
 import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
-import { getSharedState } from '../../src/server/stateContext.js';
 
 export async function runCompositeTool(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
   const store = new MemoryCheckpointStore();
@@ -30,7 +29,7 @@ export async function runCompositeTool(scene: FixtureScene, sceneSize: string): 
 
   await new Promise(r => setTimeout(r, 100));
 
-  const state = getSharedState();
+  const state = client.getState();
   const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
 
   const metrics = collectMetrics(
@@ -40,6 +39,7 @@ export async function runCompositeTool(scene: FixtureScene, sceneSize: string): 
     totalDurationMs,
     monitor.report(),
     { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+    client.getStateJSON(),
   );
 
   await client.close();

--- a/mcp-server/bench/scenarios/individual-tools.bench.ts
+++ b/mcp-server/bench/scenarios/individual-tools.bench.ts
@@ -7,7 +7,6 @@ import { McpTestClient } from '../harness/McpTestClient.js';
 import { SseTrafficMonitor } from '../harness/SseTrafficMonitor.js';
 import { MemoryCheckpointStore } from '../harness/MemoryCheckpointStore.js';
 import { collectMetrics, type BenchmarkResult } from '../harness/metrics.js';
-import { getSharedState } from '../../src/server/stateContext.js';
 
 export async function runIndividualTools(scene: FixtureScene, sceneSize: string): Promise<BenchmarkResult> {
   const store = new MemoryCheckpointStore();
@@ -43,7 +42,7 @@ export async function runIndividualTools(scene: FixtureScene, sceneSize: string)
   const { totalDurationMs, results } = await client.callToolSequence(calls);
   await new Promise(r => setTimeout(r, 100));
 
-  const state = getSharedState();
+  const state = client.getState();
   const kfCount = state.timeline.tracks.reduce((s, t) => s + t.keyframes.length, 0);
 
   const metrics = collectMetrics(
@@ -53,6 +52,7 @@ export async function runIndividualTools(scene: FixtureScene, sceneSize: string)
     totalDurationMs,
     monitor.report(),
     { elementCount: state.scene.elements.length, trackCount: state.timeline.tracks.length, keyframeCount: kfCount },
+    client.getStateJSON(),
   );
 
   await client.close();

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",
-        "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
@@ -21,7 +20,6 @@
         "excalimate-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.0.0",
         "tsx": "^4.22.4",
@@ -535,15 +533,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -30,6 +30,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "test": "npm run build && tsx --test test/mcp.test.ts",
     "prepublishOnly": "npm run build",
     "bench": "tsx bench/run.ts",
     "bench:json": "tsx bench/run.ts --json"
@@ -40,7 +41,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.0",
-    "cors": "^2.8.5",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
@@ -48,7 +48,6 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "tsx": "^4.22.4",

--- a/mcp-server/src/checkpoint-store.ts
+++ b/mcp-server/src/checkpoint-store.ts
@@ -92,12 +92,12 @@ export class FileCheckpointStore implements CheckpointStore {
           const code = (err as NodeJS.ErrnoException).code;
           // ENOENT is expected (concurrent delete) — log anything else
           if (code !== 'ENOENT') {
-            console.warn(`[checkpoint] Failed to prune ${f.name}:`, err);
+            console.warn(`[checkpoint] Failed to prune ${f.name}`);
           }
         }
       }));
-    } catch (err) {
-      console.warn('[checkpoint] Prune scan failed:', err);
+    } catch {
+      console.warn('[checkpoint] Prune scan failed');
     } finally {
       this._pruning = false;
     }

--- a/mcp-server/src/httpServer.ts
+++ b/mcp-server/src/httpServer.ts
@@ -1,220 +1,735 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import cors from 'cors';
 import crypto from 'node:crypto';
+import { createServer as createNodeServer } from 'node:http';
+import type { Server as NodeHttpServer } from 'node:http';
 import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import type { Request, Response } from 'express';
-import { getSharedStateJSON } from './server.js';
+import type { ExcalimateMcpServer } from './server.js';
+import type { ResourceLimits } from './server/limits.js';
+import type { StateChangeListener, StateDelta } from './server/stateContext.js';
+import { createRequestId, runWithRequestId } from './requestContext.js';
 
-function getCorsOrigin() {
-  const raw = process.env.CORS_ORIGIN;
+const DEFAULT_ALLOWED_ORIGINS = [
+  'http://localhost:5173',
+  'https://app.excalimate.com',
+  'https://excalimate.com',
+  'https://www.excalimate.com',
+];
 
-  // No CORS origin configured: allow local dev + production domains
-  if (!raw || !raw.trim()) {
-    return [
-      'http://localhost:5173',
-      'https://app.excalimate.com',
-      'https://excalimate.com',
-      'https://www.excalimate.com',
-    ];
-  }
+export interface HTTPServerOptions {
+  host?: string;
+  port?: number;
+  authToken?: string;
+  allowedOrigins?: string[];
+  allowedHosts?: string[];
+  bodyLimitBytes?: number;
+  requestTimeoutMs?: number;
+  maxSessions?: number;
+  maxSseClients?: number;
+  sessionTtlMs?: number;
+  cleanupIntervalMs?: number;
+  maxRequestsPerMinute?: number;
+  resourceLimits?: Partial<ResourceLimits>;
+  installSignalHandlers?: boolean;
+}
 
-  const origins = raw
-    .split(',')
-    .map((o) => o.trim())
-    .filter((o) => o.length > 0);
+export interface ResolvedHTTPServerOptions {
+  host: string;
+  port: number;
+  authToken?: string;
+  allowedOrigins: string[];
+  allowedHosts: string[];
+  bodyLimitBytes: number;
+  requestTimeoutMs: number;
+  maxSessions: number;
+  maxSseClients: number;
+  sessionTtlMs: number;
+  cleanupIntervalMs: number;
+  maxRequestsPerMinute: number;
+  resourceLimits?: Partial<ResourceLimits>;
+  installSignalHandlers: boolean;
+  loopback: boolean;
+}
 
-  if (origins.length === 0) {
-    return [
-      'http://localhost:5173',
-      'https://app.excalimate.com',
-      'https://excalimate.com',
-      'https://www.excalimate.com',
-    ];
-  }
-
-  if (origins.length === 1) {
-    return origins[0];
-  }
-
-  // Multiple allowed origins: validate incoming origin against the list
-  return (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-    // Allow requests without an Origin header (e.g., same-origin or non-browser clients)
-    if (!origin) {
-      return callback(null, true);
-    }
-
-    if (origins.includes(origin)) {
-      return callback(null, true);
-    }
-
-    return callback(new Error('Not allowed by CORS'), false);
+export interface HTTPServerHandle {
+  readonly server: NodeHttpServer;
+  readonly host: string;
+  readonly port: number;
+  close: () => Promise<void>;
+  getStats: () => {
+    sessions: number;
+    pendingSessions: number;
+    sseClients: number;
   };
 }
 
-export async function startHTTPServer(
-  factoryWithSSE: (sseClients: Set<Response>, broadcastSSE: (data: string) => void) => McpServer,
-  portOverride?: number,
-): Promise<void> {
-  const port = portOverride ?? parseInt(process.env.PORT ?? '3001', 10);
-  const app = express();
-  app.use(helmet()); // Security headers
-  app.use(cors({
-    origin: getCorsOrigin(),
-  }));
+export type HTTPServerFactory = (
+  onStateChange: StateChangeListener,
+  resourceLimits?: Partial<ResourceLimits>,
+) => ExcalimateMcpServer;
 
-  // Rate limiting
-  const limiter = rateLimit({
-    windowMs: 60 * 1000, // 1 minute
-    max: 200, // 200 requests per minute
+interface SessionRecord {
+  server: ExcalimateMcpServer;
+  transport: StreamableHTTPServerTransport;
+  previewId: string;
+  previewAccessKey?: string;
+  sseClients: Set<Response>;
+  lastActivity: number;
+  sessionId?: string;
+  closing: boolean;
+  closePromise?: Promise<void>;
+  broadcastQueue: Promise<void>;
+  activeRequests: number;
+  abortControllers: Set<AbortController>;
+}
+
+function parseInteger(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+  allowZero = false,
+): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || (allowZero ? parsed < 0 : parsed <= 0)) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return parsed;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const normalized = normalizeHostname(host);
+  return normalized === 'localhost' ||
+    normalized === '::1' ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+
+function isWildcardHost(host: string): boolean {
+  const normalized = normalizeHostname(host);
+  return normalized === '0.0.0.0' || normalized === '::';
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value.split(',').map((entry) => entry.trim()).filter(Boolean);
+}
+
+function normalizeOrigins(origins: string[]): string[] {
+  const normalized = new Set<string>();
+  for (const origin of origins) {
+    if (origin === '*') throw new Error('Wildcard origins are not allowed');
+    let parsed: URL;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error('Invalid allowed origin');
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Allowed origins must use HTTP or HTTPS');
+    }
+    normalized.add(parsed.origin);
+  }
+  if (normalized.size === 0) throw new Error('At least one allowed origin is required');
+  return [...normalized];
+}
+
+export function resolveHTTPServerOptions(
+  input: HTTPServerOptions = {},
+): ResolvedHTTPServerOptions {
+  const host = input.host ?? process.env.EXCALIMATE_HOST ?? process.env.HOST ?? '127.0.0.1';
+  const loopback = isLoopbackHost(host);
+  const authToken = input.authToken ?? process.env.EXCALIMATE_AUTH_TOKEN;
+  if (authToken !== undefined && authToken.length < 16) {
+    throw new Error('Authentication tokens must be at least 16 characters');
+  }
+  if (!loopback && !authToken) {
+    throw new Error('Non-loopback HTTP binding requires an explicit authentication token');
+  }
+
+  const configuredHosts =
+    input.allowedHosts ?? parseList(process.env.EXCALIMATE_ALLOWED_HOSTS);
+  if (isWildcardHost(host) && (!configuredHosts || configuredHosts.length === 0)) {
+    throw new Error('Wildcard binding requires explicit allowed hosts');
+  }
+  const allowedHosts = configuredHosts ?? (
+    loopback
+      ? ['localhost', '127.0.0.1', '::1', host]
+      : [host]
+  );
+  const normalizedHosts = [...new Set(allowedHosts.map(normalizeHostname))];
+  if (normalizedHosts.some((entry) => entry === '' || isWildcardHost(entry))) {
+    throw new Error('Allowed hosts must be concrete hostnames or IP addresses');
+  }
+
+  const configuredOrigins =
+    input.allowedOrigins ??
+    parseList(process.env.EXCALIMATE_ALLOWED_ORIGINS ?? process.env.CORS_ORIGIN) ??
+    DEFAULT_ALLOWED_ORIGINS;
+
+  return {
+    host,
+    port: input.port ?? parseInteger(process.env.PORT, 3001, 'port', true),
+    authToken,
+    allowedOrigins: normalizeOrigins(configuredOrigins),
+    allowedHosts: normalizedHosts,
+    bodyLimitBytes: input.bodyLimitBytes ??
+      parseInteger(process.env.EXCALIMATE_BODY_LIMIT_BYTES, 1024 * 1024, 'body limit'),
+    requestTimeoutMs: input.requestTimeoutMs ??
+      parseInteger(process.env.EXCALIMATE_REQUEST_TIMEOUT_MS, 30_000, 'request timeout'),
+    maxSessions: input.maxSessions ??
+      parseInteger(process.env.EXCALIMATE_MAX_SESSIONS, 16, 'session limit'),
+    maxSseClients: input.maxSseClients ??
+      parseInteger(process.env.EXCALIMATE_MAX_SSE_CLIENTS, 32, 'SSE client limit'),
+    sessionTtlMs: input.sessionTtlMs ??
+      parseInteger(process.env.EXCALIMATE_SESSION_TTL_MS, 30 * 60_000, 'session TTL'),
+    cleanupIntervalMs: input.cleanupIntervalMs ??
+      parseInteger(process.env.EXCALIMATE_CLEANUP_INTERVAL_MS, 60_000, 'cleanup interval'),
+    maxRequestsPerMinute: input.maxRequestsPerMinute ??
+      parseInteger(process.env.EXCALIMATE_MAX_REQUESTS_PER_MINUTE, 200, 'request rate limit'),
+    resourceLimits: input.resourceLimits,
+    installSignalHandlers: input.installSignalHandlers ?? true,
+    loopback,
+  };
+}
+
+function parseHostHeader(value: string): { hostname: string; port?: number } | null {
+  if (value.includes(',') || value.includes('/') || value.includes('@')) return null;
+  try {
+    const parsed = new URL(`http://${value}`);
+    const port = parsed.port === '' ? undefined : Number(parsed.port);
+    if (port !== undefined && (!Number.isSafeInteger(port) || port <= 0 || port > 65_535)) {
+      return null;
+    }
+    return { hostname: normalizeHostname(parsed.hostname), port };
+  } catch {
+    return null;
+  }
+}
+
+function secureEqual(actual: string | undefined, expected: string | undefined): boolean {
+  if (actual === undefined || expected === undefined) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length &&
+    crypto.timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function bearerToken(req: Request): string | undefined {
+  const authorization = req.get('authorization');
+  if (authorization?.startsWith('Bearer ')) return authorization.slice(7);
+  return req.get('x-excalimate-token');
+}
+
+function rpcId(req: Request): string | number | null {
+  const body = req.body as { id?: unknown } | undefined;
+  return typeof body?.id === 'string' || typeof body?.id === 'number' ? body.id : null;
+}
+
+function sendProtocolError(
+  req: Request,
+  res: Response,
+  status: number,
+  code: number,
+  message: string,
+): void {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  const requestId = res.locals.requestId as string;
+  res.status(status).json({
+    jsonrpc: '2.0',
+    error: {
+      code,
+      message,
+      data: { requestId },
+    },
+    id: rpcId(req),
+  });
+}
+
+function discardLateResponseWrites(res: Response): void {
+  // The SDK may finish a handler after our deadline response. Replace only the
+  // already-ended response's write methods so that late protocol output cannot
+  // emit ERR_HTTP_HEADERS_SENT stacks or corrupt a reused socket.
+  Object.defineProperties(res, {
+    writeHead: { configurable: true, value: () => res },
+    setHeader: { configurable: true, value: () => res },
+    write: { configurable: true, value: () => false },
+    end: { configurable: true, value: () => res },
+  });
+}
+
+function previewAccessKey(authToken: string | undefined, previewId: string): string | undefined {
+  if (!authToken) return undefined;
+  return crypto.createHmac('sha256', authToken).update(previewId).digest('base64url');
+}
+
+function previewPath(record: SessionRecord): string {
+  return record.previewAccessKey
+    ? `/p/${record.previewId}/${record.previewAccessKey}`
+    : `/p/${record.previewId}`;
+}
+
+export async function startHTTPServer(
+  factory: HTTPServerFactory,
+  inputOptions: HTTPServerOptions = {},
+): Promise<HTTPServerHandle> {
+  const options = resolveHTTPServerOptions(inputOptions);
+  if (!options.loopback) {
+    console.warn(
+      `[excalimate] SECURITY WARNING: HTTP mode is exposed on ${options.host}. ` +
+      'Token authentication, strict Host validation, and strict Origin validation are enabled.',
+    );
+  }
+
+  const app = express();
+  const allowedOrigins = new Set(options.allowedOrigins);
+  const allowedHosts = new Set(options.allowedHosts);
+  const sessions = new Map<string, SessionRecord>();
+  const previews = new Map<string, SessionRecord>();
+  const records = new Set<SessionRecord>();
+  let pendingSessions = 0;
+  let sseClientCount = 0;
+  let closing = false;
+
+  app.disable('x-powered-by');
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const requestId = createRequestId();
+    res.locals.requestId = requestId;
+    res.setHeader('X-Request-ID', requestId);
+    runWithRequestId(requestId, next);
+  });
+  app.use(helmet());
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const rawHost = req.get('host');
+    const parsedHost = rawHost ? parseHostHeader(rawHost) : null;
+    if (
+      !parsedHost ||
+      !allowedHosts.has(parsedHost.hostname) ||
+      (parsedHost.port !== undefined && parsedHost.port !== req.socket.localPort)
+    ) {
+      sendProtocolError(req, res, 421, -32600, 'Unrecognized Host header');
+      return;
+    }
+
+    const origin = req.get('origin');
+    // Browsers send Sec-Fetch-Site. Some non-browser fetch implementations only
+    // synthesize Sec-Fetch-Mode, so treating that header alone as browser proof
+    // would reject legitimate MCP clients.
+    const hasFetchMetadata = req.get('sec-fetch-site') !== undefined;
+    if ((origin || hasFetchMetadata) && (!origin || !allowedOrigins.has(origin))) {
+      sendProtocolError(req, res, 403, -32600, 'Origin is not allowed');
+      return;
+    }
+
+    if (origin) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+      res.setHeader(
+        'Access-Control-Expose-Headers',
+        'Mcp-Session-Id, X-Request-ID, X-Excalimate-Preview-URL',
+      );
+    }
+    if (req.method === 'OPTIONS') {
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Authorization, Content-Type, MCP-Protocol-Version, MCP-Session-Id, X-Excalimate-Token',
+      );
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+      res.status(204).end();
+      return;
+    }
+    next();
+  });
+  app.use(rateLimit({
+    windowMs: 60_000,
+    limit: options.maxRequestsPerMinute,
     standardHeaders: true,
     legacyHeaders: false,
-  });
-  app.use(limiter);
+    handler: (req, res) => {
+      sendProtocolError(req, res, 429, -32000, 'Request rate limit exceeded');
+    },
+  }));
+  app.use(express.json({
+    limit: options.bodyLimitBytes,
+    strict: true,
+  }));
 
-  app.use(express.json());
+  function detachRecord(record: SessionRecord): void {
+    if (record.sessionId) sessions.delete(record.sessionId);
+    previews.delete(record.previewId);
+    for (const controller of record.abortControllers) controller.abort();
+    for (const client of record.sseClients) {
+      sseClientCount--;
+      if (!client.writableEnded) client.end();
+    }
+    record.sseClients.clear();
+    record.server.stateContext.close();
+  }
 
-  // SSE clients for live state broadcasting
-  const sseClients = new Set<Response>();
-
-  /** Safely broadcast to all SSE clients, removing dead ones on failure. */
-  function broadcastSSE(data: string): void {
-    for (const client of sseClients) {
+  function closeRecord(record: SessionRecord, closeTransport = true): Promise<void> {
+    if (record.closePromise) return record.closePromise;
+    if (record.closing) return Promise.resolve();
+    record.closing = true;
+    detachRecord(record);
+    record.closePromise = (async () => {
+      if (!closeTransport) return;
       try {
-        client.write(`data: ${data}\n\n`);
+        await record.server.close();
       } catch {
-        sseClients.delete(client);
+        const requestId = createRequestId();
+        console.error(`[excalimate] Session cleanup failed (request ID: ${requestId})`);
+      }
+    })();
+    void record.closePromise.finally(() => {
+      if (record.activeRequests === 0) records.delete(record);
+    });
+    return record.closePromise;
+  }
+
+  async function broadcast(record: SessionRecord, delta: StateDelta): Promise<void> {
+    if (record.closing || record.sseClients.size === 0) return;
+    const data = JSON.stringify({ type: 'state', state: delta });
+
+    for (const client of [...record.sseClients]) {
+      if (client.destroyed || client.writableEnded) {
+        record.sseClients.delete(client);
+        sseClientCount--;
+        continue;
+      }
+      try {
+        const accepted = client.write(`id: ${delta.sequence}\ndata: ${data}\n\n`);
+        if (!accepted) {
+          record.sseClients.delete(client);
+          sseClientCount--;
+          client.end();
+        }
+      } catch {
+        record.sseClients.delete(client);
+        sseClientCount--;
+        client.end();
       }
     }
   }
 
-  // Factory that wires SSE broadcasting
-  const factory = () => factoryWithSSE(sseClients, broadcastSSE);
-
-  // Session map: keep server + transport alive across requests
-  const sessions = new Map<
-    string,
-    { server: McpServer; transport: StreamableHTTPServerTransport; lastActivity: number }
-  >();
-
-  // Periodically clean up stale sessions (no activity for 30 minutes)
-  const SESSION_TTL_MS = 30 * 60 * 1000;
-  const sessionCleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [sid, session] of sessions) {
-      if (now - session.lastActivity > SESSION_TTL_MS) {
-        sessions.delete(sid);
-      }
+  function authorizeMcp(req: Request, res: Response, next: NextFunction): void {
+    if (!options.authToken || secureEqual(bearerToken(req), options.authToken)) {
+      next();
+      return;
     }
-  }, 60 * 1000);
-  sessionCleanupTimer.unref();
+    res.setHeader('WWW-Authenticate', 'Bearer');
+    sendProtocolError(req, res, 401, -32000, 'Authentication required');
+  }
 
-  app.all('/mcp', async (req: Request, res: Response) => {
-    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  function findPreview(req: Request): SessionRecord | undefined {
+    const previewId =
+      (typeof req.params.previewId === 'string' ? req.params.previewId : undefined) ??
+      (typeof req.query.preview === 'string' ? req.query.preview : undefined);
+    return previewId ? previews.get(previewId) : undefined;
+  }
 
-    // Route to existing session
-    if (sessionId && sessions.has(sessionId)) {
-      const session = sessions.get(sessionId)!;
-      session.lastActivity = Date.now();
-      try {
-        await session.transport.handleRequest(req, res, req.body);
-      } catch (error) {
-        console.error('MCP session error:', error);
-        if (!res.headersSent) {
-          res.status(500).json({
-            jsonrpc: '2.0',
-            error: { code: -32603, message: 'Internal server error' },
-            id: null,
-          });
+  function authorizePreview(req: Request, record: SessionRecord): boolean {
+    if (!options.authToken) return true;
+    const accessKey = typeof req.params.accessKey === 'string'
+      ? req.params.accessKey
+      : undefined;
+    return secureEqual(accessKey, record.previewAccessKey) ||
+      secureEqual(bearerToken(req), options.authToken);
+  }
+
+  async function handleMcpRequest(
+    req: Request,
+    res: Response,
+    record: SessionRecord,
+  ): Promise<void> {
+    let timedOut = false;
+    const controller = new AbortController();
+    record.activeRequests++;
+    record.abortControllers.add(controller);
+    const timer = req.method === 'GET'
+      ? undefined
+      : setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        sendProtocolError(req, res, 504, -32001, 'MCP request timed out');
+        discardLateResponseWrites(res);
+        // Detach immediately, but let the in-flight SDK request settle before
+        // closing its transport. Closing it here can strand the handler promise.
+        void closeRecord(record, false);
+      }, options.requestTimeoutMs);
+
+    try {
+      await runWithRequestId(
+        res.locals.requestId as string,
+        () => record.transport.handleRequest(req, res, req.body),
+        controller.signal,
+      );
+    } catch {
+      if (!timedOut) {
+        sendProtocolError(req, res, 500, -32603, 'Internal MCP server error');
+      }
+      await closeRecord(record);
+    } finally {
+      if (timer) clearTimeout(timer);
+      record.abortControllers.delete(controller);
+      record.activeRequests--;
+      if (timedOut) {
+        try {
+          await record.server.close();
+        } catch {
+          const requestId = createRequestId();
+          console.error(`[excalimate] Timed-out session cleanup failed (request ID: ${requestId})`);
         }
       }
+      if (record.closing && record.activeRequests === 0) {
+        await record.closePromise;
+        records.delete(record);
+      }
+    }
+  }
+
+  app.all('/mcp', authorizeMcp, async (req: Request, res: Response) => {
+    const sessionId = req.get('mcp-session-id');
+    if (sessionId) {
+      const existing = sessions.get(sessionId);
+      if (!existing || existing.closing) {
+        sendProtocolError(req, res, 404, -32000, 'MCP session not found');
+        return;
+      }
+      existing.lastActivity = Date.now();
+      await handleMcpRequest(req, res, existing);
       return;
     }
 
-    // New session
-    const server = factory();
+    if (records.size >= options.maxSessions) {
+      sendProtocolError(req, res, 503, -32000, 'MCP session limit reached');
+      return;
+    }
+
+    pendingSessions++;
+    const previewId = crypto.randomBytes(24).toString('base64url');
+    const onStateChange: StateChangeListener = (delta) => {
+      record.broadcastQueue = record.broadcastQueue.then(() => broadcast(record, delta)).catch(() => {
+        const requestId = createRequestId();
+        console.error(`[excalimate] SSE broadcast failed (request ID: ${requestId})`);
+      });
+    };
+    let server: ExcalimateMcpServer;
+    try {
+      server = factory(onStateChange, options.resourceLimits);
+    } catch {
+      pendingSessions--;
+      sendProtocolError(req, res, 500, -32603, 'Internal MCP server error');
+      return;
+    }
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => crypto.randomUUID(),
-    });
+      enableJsonResponse: true,
+      onsessioninitialized: (newSessionId) => {
+        record.sessionId = newSessionId;
+        record.lastActivity = Date.now();
+        sessions.set(newSessionId, record);
+        previews.set(record.previewId, record);
+        pendingSessions--;
 
+        const baseUrl = `http://${req.get('host')}${previewPath(record)}`;
+        console.log(`[excalimate] Preview paired for session ${newSessionId}: ${baseUrl}`);
+      },
+      onsessionclosed: () => {
+        void closeRecord(record);
+      },
+    });
+    const record: SessionRecord = {
+      server,
+      transport,
+      previewId,
+      previewAccessKey: previewAccessKey(options.authToken, previewId),
+      sseClients: new Set(),
+      lastActivity: Date.now(),
+      closing: false,
+      broadcastQueue: Promise.resolve(),
+      activeRequests: 0,
+      abortControllers: new Set(),
+    };
+    records.add(record);
+    res.setHeader(
+      'X-Excalimate-Preview-URL',
+      `http://${req.get('host')}${previewPath(record)}`,
+    );
     transport.onclose = () => {
-      const sid = transport.sessionId;
-      if (sid) sessions.delete(sid);
-      // Don't call server.close() here — it would call transport.close()
-      // again, causing infinite recursion. The SDK handles cleanup internally.
+      void closeRecord(record, false);
     };
 
     try {
       await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-
-      // Store session after first successful request (session ID is now set)
-      const sid = transport.sessionId;
-      if (sid) {
-        sessions.set(sid, { server, transport, lastActivity: Date.now() });
-      }
-    } catch (error) {
-      console.error('MCP error:', error);
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
+      await handleMcpRequest(req, res, record);
+    } catch {
+      sendProtocolError(req, res, 500, -32603, 'Internal MCP server error');
+      await closeRecord(record);
+    } finally {
+      if (!record.sessionId) {
+        pendingSessions--;
+        await closeRecord(record);
       }
     }
   });
 
-  // SSE endpoint — web app connects here to receive live state updates
-  app.get('/live', (req: Request, res: Response) => {
+  const previewRoutes = [
+    '/live',
+    '/p/:previewId/live',
+    '/p/:previewId/:accessKey/live',
+  ];
+  app.get(previewRoutes, (req: Request, res: Response) => {
+    const record = findPreview(req);
+    if (!record || record.closing) {
+      sendProtocolError(req, res, 404, -32000, 'Preview session not found');
+      return;
+    }
+    if (!authorizePreview(req, record)) {
+      sendProtocolError(req, res, 401, -32000, 'Authentication required');
+      return;
+    }
+    if (sseClientCount >= options.maxSseClients) {
+      sendProtocolError(req, res, 503, -32000, 'SSE client limit reached');
+      return;
+    }
+
+    record.lastActivity = Date.now();
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
+      'Cache-Control': 'no-cache, no-store',
       Connection: 'keep-alive',
-      'Access-Control-Allow-Origin': '*',
+      'X-Accel-Buffering': 'no',
     });
-    res.write('data: {"type":"connected"}\n\n');
-    sseClients.add(res);
-    req.on('close', () => sseClients.delete(res));
-  });
-
-  // Current state endpoint — serves cached JSON to avoid re-serialization
-  app.get('/state', (_req: Request, res: Response) => {
-    res.setHeader('Content-Type', 'application/json');
-    res.send(getSharedStateJSON());
-  });
-
-  const httpServer = app.listen(port, () => {
-    console.log(`Excalimate MCP server listening on http://localhost:${port}/mcp`);
-    console.log(`Live preview SSE at http://localhost:${port}/live`);
-  });
-
-  let shuttingDown = false;
-  const shutdown = async () => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log('\nGraceful shutdown started...');
-
-    // 1. Stop accepting new connections
-    httpServer.close();
-
-    // 2. Stop the session cleanup timer
-    clearInterval(sessionCleanupTimer);
-
-    // 3. Close all SSE clients
-    for (const client of sseClients) {
-      try { client.end(); } catch { /* best-effort */ }
+    const snapshotPath = `${previewPath(record)}/state`;
+    const accepted = res.write(`data: ${JSON.stringify({
+      type: 'connected',
+      revision: record.server.stateContext.getRevision(),
+      sequence: record.server.stateContext.getSequence(),
+      snapshot: snapshotPath,
+    })}\n\n`);
+    if (!accepted) {
+      res.end();
+      return;
     }
-    sseClients.clear();
+    record.sseClients.add(res);
+    sseClientCount++;
 
-    // 4. Clear MCP sessions
-    sessions.clear();
+    req.on('close', () => {
+      if (record.sseClients.delete(res)) sseClientCount--;
+    });
+  });
 
-    console.log('Shutdown complete.');
-    process.exit(0);
+  const stateRoutes = [
+    '/state',
+    '/p/:previewId/state',
+    '/p/:previewId/:accessKey/state',
+  ];
+  app.get(stateRoutes, (req: Request, res: Response) => {
+    const record = findPreview(req);
+    if (!record || record.closing) {
+      sendProtocolError(req, res, 404, -32000, 'Preview session not found');
+      return;
+    }
+    if (!authorizePreview(req, record)) {
+      sendProtocolError(req, res, 401, -32000, 'Authentication required');
+      return;
+    }
+    record.lastActivity = Date.now();
+    res.type('application/json').send(record.server.stateContext.getStateJSON());
+  });
+
+  app.use((
+    error: unknown,
+    req: Request,
+    res: Response,
+    _next: NextFunction,
+  ) => {
+    const typed = error as { type?: string; status?: number };
+    if (typed.type === 'entity.too.large' || typed.status === 413) {
+      sendProtocolError(req, res, 413, -32600, 'JSON request body is too large');
+      return;
+    }
+    if (typed.type === 'entity.parse.failed' || typed.status === 400) {
+      sendProtocolError(req, res, 400, -32700, 'Invalid JSON request body');
+      return;
+    }
+    sendProtocolError(req, res, 500, -32603, 'Internal HTTP server error');
+  });
+
+  const httpServer = createNodeServer(app);
+  httpServer.requestTimeout = options.requestTimeoutMs;
+  httpServer.headersTimeout = Math.max(options.requestTimeoutMs + 1_000, 5_000);
+
+  const cleanupTimer = setInterval(() => {
+    const staleBefore = Date.now() - options.sessionTtlMs;
+    for (const record of [...sessions.values()]) {
+      if (record.lastActivity < staleBefore) void closeRecord(record);
+    }
+  }, options.cleanupIntervalMs);
+  cleanupTimer.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    httpServer.once('error', onError);
+    httpServer.listen(options.port, options.host, () => {
+      httpServer.off('error', onError);
+      resolve();
+    });
+  });
+
+  const address = httpServer.address();
+  const actualPort = typeof address === 'object' && address ? address.port : options.port;
+  console.log(`[excalimate] MCP server listening on http://${options.host}:${actualPort}/mcp`);
+  console.log(`[excalimate] Allowed browser origins: ${options.allowedOrigins.join(', ')}`);
+
+  let signalShutdown: (() => void) | undefined;
+  const close = async (): Promise<void> => {
+    if (closing) return;
+    closing = true;
+    clearInterval(cleanupTimer);
+    if (signalShutdown) {
+      process.off('SIGINT', signalShutdown);
+      process.off('SIGTERM', signalShutdown);
+    }
+    await Promise.all([...records].map((record) => closeRecord(record)));
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+      httpServer.closeAllConnections();
+    });
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+
+  if (options.installSignalHandlers) {
+    signalShutdown = () => {
+      void close().catch(() => {
+        const requestId = createRequestId();
+        console.error(`[excalimate] Graceful shutdown failed (request ID: ${requestId})`);
+        process.exitCode = 1;
+      });
+    };
+    process.on('SIGINT', signalShutdown);
+    process.on('SIGTERM', signalShutdown);
+  }
+
+  return {
+    server: httpServer,
+    host: options.host,
+    port: actualPort,
+    close,
+    getStats: () => ({
+      sessions: sessions.size,
+      pendingSessions,
+      sseClients: sseClientCount,
+    }),
+  };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,63 +1,125 @@
 #!/usr/bin/env node
-import { FileCheckpointStore } from './checkpoint-store.js';
+import { FileCheckpointStore, MemoryCheckpointStore } from './checkpoint-store.js';
+import { startHTTPServer } from './httpServer.js';
+import type { HTTPServerOptions } from './httpServer.js';
+import { createRequestId } from './requestContext.js';
 import { createServer } from './server.js';
 import { startStdioServer } from './stdioServer.js';
-import { startHTTPServer } from './httpServer.js';
-import { gzip } from 'node:zlib';
-import { promisify } from 'node:util';
 
-const gzipAsync = promisify(gzip);
-
-/** Parse --port=NNNN or --port NNNN from argv */
-function parsePort(): number | undefined {
-  for (let i = 0; i < process.argv.length; i++) {
-    const arg = process.argv[i];
-    if (arg.startsWith('--port=')) {
-      return parseInt(arg.slice('--port='.length), 10);
-    }
-    if (arg === '--port' && process.argv[i + 1]) {
-      return parseInt(process.argv[i + 1], 10);
-    }
-    if (arg === '-p' && process.argv[i + 1]) {
-      return parseInt(process.argv[i + 1], 10);
-    }
-  }
-  return undefined;
+interface CLIOptions extends HTTPServerOptions {
+  stdio: boolean;
+  help: boolean;
 }
 
-async function main() {
-  process.on('unhandledRejection', (reason) => {
-    console.error('Unhandled rejection:', reason);
-  });
-  process.on('uncaughtException', (err) => {
-    console.error('Uncaught exception:', err);
-  });
+const HELP = `Excalimate MCP server
 
-  const store = new FileCheckpointStore();
-  const cliPort = parsePort();
+Usage:
+  excalimate-mcp [options]
 
-  if (process.argv.includes('--stdio')) {
-    await startStdioServer(() => createServer(store));
-  } else {
-    await startHTTPServer((_sseClients, broadcastSSE) => {
-      return createServer(store, (delta) => {
-        const json = JSON.stringify({ type: 'state', state: delta });
-        // Compress payloads >512 bytes with gzip+base64 to reduce SSE bandwidth.
-        // Small payloads aren't worth the overhead.
-        if (json.length > 512) {
-          gzipAsync(json).then(
-            (buf) => broadcastSSE(JSON.stringify({ type: 'gz', data: buf.toString('base64') })),
-            (err) => console.error('Failed to compress broadcast:', err),
-          );
-        } else {
-          broadcastSSE(json);
-        }
-      });
-    }, cliPort);
-  }
+Transport:
+  --stdio                      Use stdio instead of Streamable HTTP
+  -H, --host <host>            Bind host (default: 127.0.0.1)
+  -p, --port <port>            Bind port (default: 3001)
+
+HTTP security:
+  --auth-token <token>         Bearer token (required for non-loopback hosts)
+  --allowed-origins <list>     Comma-separated browser origins
+  --allowed-hosts <list>       Comma-separated Host values (required for wildcard binding)
+  -h, --help                   Show this help
+
+Environment:
+  EXCALIMATE_HOST, PORT, EXCALIMATE_AUTH_TOKEN,
+  EXCALIMATE_ALLOWED_ORIGINS (CORS_ORIGIN remains supported),
+  EXCALIMATE_ALLOWED_HOSTS, EXCALIMATE_BODY_LIMIT_BYTES,
+  EXCALIMATE_REQUEST_TIMEOUT_MS, EXCALIMATE_MAX_SESSIONS,
+  EXCALIMATE_MAX_SSE_CLIENTS, EXCALIMATE_SESSION_TTL_MS
+
+HTTP mode binds to loopback by default. Exposing it to a network requires an
+authentication token and strict allowed-host configuration for wildcard binds.`;
+
+function argumentValue(args: string[], index: number, name: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) throw new Error(`${name} requires a value`);
+  return value;
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+export function parseCLIOptions(args: string[]): CLIOptions {
+  const options: CLIOptions = { stdio: false, help: false };
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    const separatorIndex = argument.indexOf('=');
+    const name = separatorIndex === -1 ? argument : argument.slice(0, separatorIndex);
+    const inlineValue = separatorIndex === -1 ? undefined : argument.slice(separatorIndex + 1);
+    const readValue = () => inlineValue ?? argumentValue(args, index++, name);
+
+    switch (name) {
+      case '--stdio':
+        options.stdio = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--host':
+      case '-H':
+        options.host = readValue();
+        break;
+      case '--port':
+      case '-p':
+        options.port = Number(readValue());
+        break;
+      case '--auth-token':
+        options.authToken = readValue();
+        break;
+      case '--allowed-origins':
+        options.allowedOrigins = readValue().split(',').map((entry) => entry.trim()).filter(Boolean);
+        break;
+      case '--allowed-hosts':
+        options.allowedHosts = readValue().split(',').map((entry) => entry.trim()).filter(Boolean);
+        break;
+      default:
+        throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+  return options;
+}
+
+async function main(): Promise<void> {
+  const options = parseCLIOptions(process.argv.slice(2));
+  if (options.help) {
+    console.log(HELP);
+    return;
+  }
+
+  if (options.stdio) {
+    await startStdioServer(() => createServer(new FileCheckpointStore()));
+    return;
+  }
+
+  const {
+    stdio: _stdio,
+    help: _help,
+    ...httpOptions
+  } = options;
+  await startHTTPServer(
+    (onStateChange, resourceLimits) =>
+      createServer(new MemoryCheckpointStore(), onStateChange, { resourceLimits }),
+    httpOptions,
+  );
+}
+
+process.on('unhandledRejection', () => {
+  const requestId = createRequestId();
+  console.error(`[excalimate] Unhandled rejection (request ID: ${requestId})`);
+});
+process.on('uncaughtException', () => {
+  const requestId = createRequestId();
+  console.error(`[excalimate] Uncaught exception (request ID: ${requestId})`);
+  process.exitCode = 1;
+});
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : 'Unknown startup error';
+  console.error(`[excalimate] Startup failed: ${message}`);
+  process.exitCode = 1;
 });

--- a/mcp-server/src/requestContext.ts
+++ b/mcp-server/src/requestContext.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { nanoid } from 'nanoid';
+
+interface RequestContext {
+  requestId: string;
+  signal?: AbortSignal;
+}
+
+const requestContext = new AsyncLocalStorage<RequestContext>();
+
+export function createRequestId(): string {
+  return nanoid(16);
+}
+
+export function runWithRequestId<T>(
+  requestId: string,
+  callback: () => T,
+  signal?: AbortSignal,
+): T {
+  return requestContext.run({ requestId, signal }, callback);
+}
+
+export function getRequestId(): string {
+  return requestContext.getStore()?.requestId ?? createRequestId();
+}
+
+export function getRequestAbortSignal(): AbortSignal | undefined {
+  return requestContext.getStore()?.signal;
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { nanoid } from 'nanoid';
 import { createRequire } from 'node:module';
 import type { CheckpointStore } from './checkpoint-store.js';
 
@@ -15,27 +14,41 @@ import { registerQueryTools } from './server/queryTools.js';
 import { registerShareTools } from './server/shareTools.js';
 import { REFERENCE_TEXT, EXAMPLES_TEXT } from './server/referenceText.js';
 import { registerSceneTools } from './server/sceneTools.js';
-import { createStateContext, getSharedState, getSharedStateJSON, getSceneElementsJSON, getTimelineJSON } from './server/stateContext.js';
-import type { StateChangeListener } from './server/stateContext.js';
+import { createStateContext } from './server/stateContext.js';
+import type {
+  StateChangeListener,
+  StateContext,
+  StateContextOptions,
+} from './server/stateContext.js';
 
-export { getSharedState, getSharedStateJSON, getSceneElementsJSON, getTimelineJSON };
 export type { StateChangeListener } from './server/stateContext.js';
+
+export type ExcalimateMcpServer = McpServer & {
+  readonly stateContext: StateContext;
+};
 
 export function createServer(
   store: CheckpointStore,
   onStateChange?: StateChangeListener,
-): McpServer {
+  options: StateContextOptions = {},
+): ExcalimateMcpServer {
   const server = new McpServer({ name: 'excalimate', version: PKG_VERSION });
-  const ctx = createStateContext(nanoid(8), server, onStateChange);
+  const ctx = createStateContext(server, onStateChange, options);
+  Object.defineProperty(server, 'stateContext', {
+    value: ctx,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
 
-  server.tool(
+  ctx.tool(
     'read_me',
     'Returns the Excalidraw element format reference, animation property docs, easing types, and usage examples. Call this FIRST before creating scenes or animations.',
     {},
     async () => ({ content: [{ type: 'text', text: REFERENCE_TEXT }] }),
   );
 
-  server.tool(
+  ctx.tool(
     'get_examples',
     'Returns few-shot examples showing how to create elements and animate them. Call this to learn common patterns.',
     {},
@@ -49,5 +62,5 @@ export function createServer(
   registerCheckpointTools(server, ctx, store);
   registerShareTools(server, ctx);
 
-  return server;
+  return server as ExcalimateMcpServer;
 }

--- a/mcp-server/src/server/animationTools.ts
+++ b/mcp-server/src/server/animationTools.ts
@@ -6,25 +6,74 @@ import type { AnimatableProperty, EasingType } from '../types.js';
 import { ANIMATABLE_PROPERTIES, EASING_TYPES } from '../types.js';
 import { ORIGIN_MAP } from './geometry.js';
 import type { StateContext } from './stateContext.js';
-import { getTimelineJSON } from './stateContext.js';
+import {
+  assertAdditionalKeyframes,
+  boundedString,
+  boundedTime,
+  invalidInput,
+  legacyDeprecation,
+  parseLegacyArray,
+} from './limits.js';
 
 export function registerAnimationTools(
   server: McpServer,
   ctx: StateContext,
   getElementBounds: (el: any) => { minX: number; minY: number; maxX: number; maxY: number },
 ): void {
+  const propertySchema = z.enum(
+    ANIMATABLE_PROPERTIES as unknown as [AnimatableProperty, ...AnimatableProperty[]],
+  );
+  const easingSchema = z.enum(
+    EASING_TYPES as unknown as [EasingType, ...EasingType[]],
+  );
+  const scaleOriginSchema = z.enum([
+    'center', 'top-left', 'top-right', 'bottom-left', 'bottom-right',
+    'top', 'bottom', 'left', 'right',
+  ]);
+  const keyframeSchema = z.object({
+    targetId: boundedString(ctx.limits),
+    property: propertySchema,
+    time: boundedTime(ctx.limits),
+    value: z.number().finite(),
+    easing: easingSchema.optional(),
+    scaleOrigin: scaleOriginSchema.optional(),
+  }).strict();
+  const keyframesSchema = z.array(keyframeSchema).max(ctx.limits.maxBatchItems);
+  const scaleKeyframeSchema = z.object({
+    time: boundedTime(ctx.limits),
+    scaleX: z.number().finite().optional(),
+    scaleY: z.number().finite().optional(),
+    easing: easingSchema.optional(),
+  }).strict().refine(
+    (keyframe) => keyframe.scaleX !== undefined || keyframe.scaleY !== undefined,
+    'scaleX or scaleY is required',
+  );
+  const scaleKeyframesSchema = z.array(scaleKeyframeSchema).max(ctx.limits.maxBatchItems);
+  const cameraPropertySchema = z.enum([
+    'translateX', 'translateY', 'scaleX', 'scaleY',
+    'x', 'y', 'panX', 'panY', 'zoom', 'scale',
+  ]);
+  const cameraKeyframeSchema = z.object({
+    property: cameraPropertySchema,
+    time: boundedTime(ctx.limits),
+    value: z.number().finite(),
+    easing: easingSchema.optional(),
+  }).strict();
+  const cameraKeyframesSchema = z.array(cameraKeyframeSchema).max(ctx.limits.maxBatchItems);
+
   ctx.mutatingTool(
     'add_keyframe',
     'Add a keyframe to an animation track. Auto-creates the track if it doesn\'t exist.',
     {
-      targetId: z.string().describe('Element or group ID'),
-      property: z.enum(ANIMATABLE_PROPERTIES as unknown as [string, ...string[]]).describe('Animatable property'),
-      time: z.number().min(0).describe('Time in milliseconds'),
-      value: z.number().describe('Property value at this time'),
-      easing: z.enum(EASING_TYPES as unknown as [string, ...string[]]).optional().describe('Easing to next keyframe'),
+      targetId: boundedString(ctx.limits).describe('Element or group ID'),
+      property: propertySchema.describe('Animatable property'),
+      time: boundedTime(ctx.limits).describe('Time in milliseconds'),
+      value: z.number().finite().describe('Property value at this time'),
+      easing: easingSchema.optional().describe('Easing to next keyframe'),
     },
     async ({ targetId, property, time, value, easing }) => {
       const state = ctx.getState();
+      assertAdditionalKeyframes(state, 1, ctx.limits);
       ctx.updateState(addKeyframeToState(state, targetId, property as AnimatableProperty, time, value, (easing as EasingType) ?? 'linear'));
       return { content: [{ type: 'text', text: `Keyframe added: ${property} = ${value} at ${time}ms for ${targetId}` }] };
     },
@@ -34,59 +83,97 @@ export function registerAnimationTools(
     'add_keyframes_batch',
     'Add multiple keyframes at once. For scaleX/scaleY keyframes, include a "scaleOrigin" field per keyframe to control where scaling anchors from (auto-adds translate compensation). Origins: center, top-left, top-right, bottom-left, bottom-right, top, bottom, left, right.',
     {
-      keyframes: z.string().describe('JSON array of {targetId, property, time, value, easing?, scaleOrigin?}'),
+      keyframes: z.union([
+        keyframesSchema,
+        z.string().max(ctx.limits.maxStateBytes),
+      ]).describe('Array of {targetId, property, time, value, easing?, scaleOrigin?}; legacy JSON strings are deprecated'),
     },
     async ({ keyframes }) => {
-      try {
-        const parsed = JSON.parse(keyframes);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text', text: 'Error: must be array' }] };
+      const parsed = parseLegacyArray(
+        keyframes,
+        keyframesSchema,
+        'keyframes',
+        ctx.limits,
+      );
+      const batch: {
+        targetId: string;
+        property: AnimatableProperty;
+        time: number;
+        value: number;
+        easing?: EasingType;
+      }[] = [];
 
-        const validProperties = new Set<string>(ANIMATABLE_PROPERTIES);
-        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
-        let skipped = 0;
-
-        // Collect scale origin compensation data
-        const scaleCompensation = new Map<string, { targetId: string; time: number; sx: number; sy: number; origin: string; easing: string }>();
-        for (const kf of parsed) {
-          if ((kf.property === 'scaleX' || kf.property === 'scaleY') && kf.scaleOrigin && kf.scaleOrigin !== 'top-left') {
-            const key = `${kf.targetId}@${kf.time}`;
-            const existing = scaleCompensation.get(key) ?? { targetId: kf.targetId, time: kf.time, sx: 1, sy: 1, origin: kf.scaleOrigin, easing: kf.easing ?? 'linear' };
-            if (kf.property === 'scaleX') existing.sx = kf.value;
-            if (kf.property === 'scaleY') existing.sy = kf.value;
-            existing.origin = kf.scaleOrigin;
-            scaleCompensation.set(key, existing);
-          }
+      const scaleCompensation = new Map<string, {
+        targetId: string;
+        time: number;
+        sx: number;
+        sy: number;
+        origin: string;
+        easing: EasingType;
+      }>();
+      for (const keyframe of parsed.value) {
+        if (
+          (keyframe.property === 'scaleX' || keyframe.property === 'scaleY') &&
+          keyframe.scaleOrigin &&
+          keyframe.scaleOrigin !== 'top-left'
+        ) {
+          const key = `${keyframe.targetId}@${keyframe.time}`;
+          const existing = scaleCompensation.get(key) ?? {
+            targetId: keyframe.targetId,
+            time: keyframe.time,
+            sx: 1,
+            sy: 1,
+            origin: keyframe.scaleOrigin,
+            easing: keyframe.easing ?? 'linear',
+          };
+          if (keyframe.property === 'scaleX') existing.sx = keyframe.value;
+          if (keyframe.property === 'scaleY') existing.sy = keyframe.value;
+          existing.origin = keyframe.scaleOrigin;
+          scaleCompensation.set(key, existing);
         }
-
-        // Collect valid keyframes
-        for (const kf of parsed) {
-          if (!validProperties.has(kf.property)) { skipped++; continue; }
-          batch.push({ targetId: kf.targetId, property: kf.property, time: kf.time, value: kf.value, easing: kf.easing ?? 'linear' });
-        }
-
-        // Compute scale origin compensation keyframes
-        const state = ctx.getState();
-        for (const skf of scaleCompensation.values()) {
-          const [ox, oy] = ORIGIN_MAP[skf.origin] ?? [0.5, 0.5];
-          const el = state.scene.elements.find((e: any) => e.id === skf.targetId);
-          if (!el) continue;
-          const bounds = getElementBounds(el);
-          const w = bounds.maxX - bounds.minX;
-          const h = bounds.maxY - bounds.minY;
-          batch.push(
-            { targetId: skf.targetId, property: 'translateX', time: skf.time, value: -w * (skf.sx - 1) * ox, easing: skf.easing as EasingType },
-            { targetId: skf.targetId, property: 'translateY', time: skf.time, value: -h * (skf.sy - 1) * oy, easing: skf.easing as EasingType },
-          );
-        }
-
-        // Apply all keyframes in one pass
-        ctx.updateState(addKeyframesBatchToState(state, batch));
-
-        const count = batch.length;
-        return { content: [{ type: 'text', text: `Added ${count} keyframes.${skipped ? ` Skipped ${skipped} with invalid properties.` : ''}` }] };
-      } catch (e) {
-        return { content: [{ type: 'text', text: `Error: ${e}` }] };
+        batch.push({
+          targetId: keyframe.targetId,
+          property: keyframe.property,
+          time: keyframe.time,
+          value: keyframe.value,
+          easing: keyframe.easing ?? 'linear',
+        });
       }
+
+      const state = ctx.getState();
+      for (const scaleKeyframe of scaleCompensation.values()) {
+        const [originX, originY] = ORIGIN_MAP[scaleKeyframe.origin] ?? [0.5, 0.5];
+        const element = state.scene.elements.find((entry: any) => entry.id === scaleKeyframe.targetId);
+        if (!element) continue;
+        const bounds = getElementBounds(element);
+        const width = bounds.maxX - bounds.minX;
+        const height = bounds.maxY - bounds.minY;
+        batch.push(
+          {
+            targetId: scaleKeyframe.targetId,
+            property: 'translateX',
+            time: scaleKeyframe.time,
+            value: -width * (scaleKeyframe.sx - 1) * originX,
+            easing: scaleKeyframe.easing,
+          },
+          {
+            targetId: scaleKeyframe.targetId,
+            property: 'translateY',
+            time: scaleKeyframe.time,
+            value: -height * (scaleKeyframe.sy - 1) * originY,
+            easing: scaleKeyframe.easing,
+          },
+        );
+      }
+
+      assertAdditionalKeyframes(state, batch.length, ctx.limits);
+      ctx.updateState(addKeyframesBatchToState(state, batch));
+      return {
+        content: [{
+          type: 'text',
+          text: `Added ${batch.length} keyframes.${legacyDeprecation('keyframes', parsed.legacy)}`,
+        }],
+      };
     },
   );
 
@@ -94,8 +181,8 @@ export function registerAnimationTools(
     'remove_keyframe',
     'Remove a keyframe by track and keyframe ID.',
     {
-      trackId: z.string().describe('Track ID'),
-      keyframeId: z.string().describe('Keyframe ID'),
+      trackId: boundedString(ctx.limits).describe('Track ID'),
+      keyframeId: boundedString(ctx.limits).describe('Keyframe ID'),
     },
     async ({ trackId, keyframeId }) => {
       const state = ctx.getState();
@@ -111,11 +198,14 @@ export function registerAnimationTools(
     'create_sequence',
     'Create a reveal sequence — elements appear one after another with configurable timing.',
     {
-      elementIds: z.array(z.string()).describe('Element IDs in reveal order'),
+      elementIds: z.array(boundedString(ctx.limits))
+        .min(1)
+        .max(ctx.limits.maxBatchItems)
+        .describe('Element IDs in reveal order'),
       property: z.enum(['opacity', 'drawProgress']).default('opacity').describe('Property to animate'),
-      startTime: z.number().min(0).default(0).describe('When sequence starts (ms)'),
-      delay: z.number().min(0).default(300).describe('Delay between each reveal (ms)'),
-      duration: z.number().min(50).default(500).describe('Duration of each reveal (ms)'),
+      startTime: boundedTime(ctx.limits).default(0).describe('When sequence starts (ms)'),
+      delay: boundedTime(ctx.limits).default(300).describe('Delay between each reveal (ms)'),
+      duration: boundedTime(ctx.limits).min(50).default(500).describe('Duration of each reveal (ms)'),
     },
     async ({ elementIds, property, startTime, delay, duration }) => {
       const prop = property as AnimatableProperty;
@@ -132,6 +222,7 @@ export function registerAnimationTools(
       }
 
       const state = ctx.getState();
+      assertAdditionalKeyframes(state, batch.length, ctx.limits);
       ctx.updateState(addKeyframesBatchToState(state, batch));
 
       const totalDuration = startTime + (elementIds.length - 1) * delay + duration;
@@ -143,8 +234,8 @@ export function registerAnimationTools(
     'set_clip_range',
     'Set the export clip start and end times.',
     {
-      start: z.number().min(0).describe('Clip start time (ms)'),
-      end: z.number().min(100).describe('Clip end time (ms)'),
+      start: boundedTime(ctx.limits).describe('Clip start time (ms)'),
+      end: boundedTime(ctx.limits).min(100).describe('Clip end time (ms)'),
     },
     async ({ start, end }) => {
       const state = ctx.getState();
@@ -154,12 +245,12 @@ export function registerAnimationTools(
     },
   );
 
-  server.tool(
+  ctx.tool(
     'get_timeline',
     'Return the current animation timeline as JSON.',
     {},
     async () => ({
-      content: [{ type: 'text' as const, text: getTimelineJSON() }],
+      content: [{ type: 'text' as const, text: ctx.getTimelineJSON() }],
     }),
   );
 
@@ -178,50 +269,80 @@ export function registerAnimationTools(
     'add_scale_animation',
     'Add scale keyframes with a specific origin (edge/corner/center). Auto-computes translate compensation to keep the origin point fixed during scaling.',
     {
-      targetId: z.string().describe('Element ID'),
-      origin: z.enum(['center', 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top', 'bottom', 'left', 'right']).describe('Scale origin point'),
-      keyframes: z.string().describe('JSON array of {time, scaleX, scaleY, easing?}'),
+      targetId: boundedString(ctx.limits).describe('Element ID'),
+      origin: scaleOriginSchema.describe('Scale origin point'),
+      keyframes: z.union([
+        scaleKeyframesSchema,
+        z.string().max(ctx.limits.maxStateBytes),
+      ]).describe('Array of {time, scaleX, scaleY, easing?}; legacy JSON strings are deprecated'),
     },
     async ({ targetId, origin, keyframes }) => {
-      try {
-        const parsed = JSON.parse(keyframes);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text', text: 'Error: must be array' }] };
+      const parsed = parseLegacyArray(
+        keyframes,
+        scaleKeyframesSchema,
+        'scale keyframes',
+        ctx.limits,
+      );
+      const state = ctx.getState();
+      const element = state.scene.elements.find((entry: any) => entry.id === targetId);
+      if (!element) invalidInput(`Element "${targetId}" not found`);
 
-        const state = ctx.getState();
-        const el = state.scene.elements.find((e: any) => e.id === targetId);
-        if (!el) return { content: [{ type: 'text', text: `Element "${targetId}" not found.` }] };
+      const bounds = getElementBounds(element);
+      const width = bounds.maxX - bounds.minX;
+      const height = bounds.maxY - bounds.minY;
+      const [originX, originY] = ORIGIN_MAP[origin] ?? [0.5, 0.5];
+      const batch: {
+        targetId: string;
+        property: AnimatableProperty;
+        time: number;
+        value: number;
+        easing?: EasingType;
+      }[] = [];
 
-        const bounds = getElementBounds(el);
-        const w = bounds.maxX - bounds.minX;
-        const h = bounds.maxY - bounds.minY;
-        const [ox, oy] = ORIGIN_MAP[origin] ?? [0.5, 0.5];
+      for (const keyframe of parsed.value) {
+        const scaleX = keyframe.scaleX ?? 1;
+        const scaleY = keyframe.scaleY ?? 1;
+        const easing = keyframe.easing ?? 'linear';
+        batch.push(
+          { targetId, property: 'scaleX', time: keyframe.time, value: scaleX, easing },
+          { targetId, property: 'scaleY', time: keyframe.time, value: scaleY, easing },
+        );
 
-        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
-        for (const kf of parsed) {
-          const sx = kf.scaleX ?? 1;
-          const sy = kf.scaleY ?? 1;
-          const easing = (kf.easing ?? 'linear') as EasingType;
-
+        const translateX = -width * (scaleX - 1) * originX;
+        const translateY = -height * (scaleY - 1) * originY;
+        if (
+          Math.abs(translateX) > 0.1 ||
+          Math.abs(translateY) > 0.1 ||
+          originX !== 0 ||
+          originY !== 0
+        ) {
           batch.push(
-            { targetId, property: 'scaleX', time: kf.time, value: sx, easing },
-            { targetId, property: 'scaleY', time: kf.time, value: sy, easing },
+            {
+              targetId,
+              property: 'translateX',
+              time: keyframe.time,
+              value: translateX,
+              easing,
+            },
+            {
+              targetId,
+              property: 'translateY',
+              time: keyframe.time,
+              value: translateY,
+              easing,
+            },
           );
-
-          const tx = -w * (sx - 1) * ox;
-          const ty = -h * (sy - 1) * oy;
-          if (Math.abs(tx) > 0.1 || Math.abs(ty) > 0.1 || ox !== 0 || oy !== 0) {
-            batch.push(
-              { targetId, property: 'translateX', time: kf.time, value: tx, easing },
-              { targetId, property: 'translateY', time: kf.time, value: ty, easing },
-            );
-          }
         }
-
-        ctx.updateState(addKeyframesBatchToState(state, batch));
-        return { content: [{ type: 'text', text: `Added ${parsed.length} scale keyframes with origin "${origin}" for "${targetId}".` }] };
-      } catch (e) {
-        return { content: [{ type: 'text', text: `Error: ${e}` }] };
       }
+
+      assertAdditionalKeyframes(state, batch.length, ctx.limits);
+      ctx.updateState(addKeyframesBatchToState(state, batch));
+      return {
+        content: [{
+          type: 'text',
+          text: `Added ${parsed.value.length} scale keyframes with origin "${origin}" for "${targetId}".${legacyDeprecation('keyframes', parsed.legacy)}`,
+        }],
+      };
     },
   );
 
@@ -229,9 +350,9 @@ export function registerAnimationTools(
     'set_camera_frame',
     'Set the camera frame position, size, and aspect ratio. Also creates initial keyframes at time 0 for translateX, translateY, scaleX, scaleY so the camera starts at this position.',
     {
-      x: z.number().optional().describe('Camera center X (scene coords)'),
-      y: z.number().optional().describe('Camera center Y (scene coords)'),
-      width: z.number().optional().describe('Camera width (scene units)'),
+      x: z.number().finite().optional().describe('Camera center X (scene coords)'),
+      y: z.number().finite().optional().describe('Camera center Y (scene coords)'),
+      width: z.number().finite().positive().optional().describe('Camera width (scene units)'),
       aspectRatio: z.enum(['16:9', '4:3', '1:1', '3:2']).optional().describe('Aspect ratio'),
     },
     async ({ x, y, width, aspectRatio }) => {
@@ -242,6 +363,7 @@ export function registerAnimationTools(
       if (aspectRatio !== undefined) state.cameraFrame.aspectRatio = aspectRatio;
 
       const CAMERA_ID = '__camera_frame__';
+      assertAdditionalKeyframes(state, 4, ctx.limits);
       ctx.updateState(addKeyframesBatchToState(state, [
         { targetId: CAMERA_ID, property: 'translateX', time: 0, value: 0 },
         { targetId: CAMERA_ID, property: 'translateY', time: 0, value: 0 },
@@ -259,13 +381,14 @@ export function registerAnimationTools(
     'Add a keyframe for camera pan/zoom animation.',
     {
       property: z.enum(['translateX', 'translateY', 'scaleX', 'scaleY']).describe('Camera property'),
-      time: z.number().min(0).describe('Time in ms'),
-      value: z.number().describe('Value'),
-      easing: z.enum(EASING_TYPES as unknown as [string, ...string[]]).optional(),
+      time: boundedTime(ctx.limits).describe('Time in ms'),
+      value: z.number().finite().describe('Value'),
+      easing: easingSchema.optional(),
     },
     async ({ property, time, value, easing }) => {
       const CAMERA_ID = '__camera_frame__';
       const state = ctx.getState();
+      assertAdditionalKeyframes(state, 1, ctx.limits);
       ctx.updateState(addKeyframeToState(state, CAMERA_ID, property as AnimatableProperty, time, value, (easing as EasingType) ?? 'linear'));
       return { content: [{ type: 'text', text: `Camera keyframe: ${property} = ${value} at ${time}ms` }] };
     },
@@ -275,39 +398,48 @@ export function registerAnimationTools(
     'add_camera_keyframes_batch',
     'Add multiple camera keyframes at once. Properties: translateX, translateY, scaleX, scaleY.',
     {
-      keyframes: z.string().describe('JSON array of {property: "translateX"|"translateY"|"scaleX"|"scaleY", time, value, easing?}'),
+      keyframes: z.union([
+        cameraKeyframesSchema,
+        z.string().max(ctx.limits.maxStateBytes),
+      ]).describe('Array of camera keyframes; legacy JSON strings are deprecated'),
     },
     async ({ keyframes }) => {
-      try {
-        const parsed = JSON.parse(keyframes);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text', text: 'Error: must be array' }] };
-        const CAMERA_ID = '__camera_frame__';
-        const validCameraProps = new Set(['translateX', 'translateY', 'scaleX', 'scaleY']);
-        const propMap: Record<string, string> = {
-          x: 'translateX',
-          y: 'translateY',
-          panX: 'translateX',
-          panY: 'translateY',
-          zoom: 'scaleX',
-          scale: 'scaleX',
-        };
+      const parsed = parseLegacyArray(
+        keyframes,
+        cameraKeyframesSchema,
+        'camera keyframes',
+        ctx.limits,
+      );
+      const cameraId = '__camera_frame__';
+      const propertyMap: Record<string, AnimatableProperty> = {
+        translateX: 'translateX',
+        translateY: 'translateY',
+        scaleX: 'scaleX',
+        scaleY: 'scaleY',
+        x: 'translateX',
+        y: 'translateY',
+        panX: 'translateX',
+        panY: 'translateY',
+        zoom: 'scaleX',
+        scale: 'scaleX',
+      };
+      const batch = parsed.value.map((keyframe) => ({
+        targetId: cameraId,
+        property: propertyMap[keyframe.property],
+        time: keyframe.time,
+        value: keyframe.value,
+        easing: keyframe.easing ?? 'linear' as EasingType,
+      }));
 
-        const batch: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
-        let skipped = 0;
-        for (const kf of parsed) {
-          let prop = kf.property;
-          if (propMap[prop]) prop = propMap[prop];
-          if (!validCameraProps.has(prop)) { skipped++; continue; }
-          batch.push({ targetId: CAMERA_ID, property: prop as AnimatableProperty, time: kf.time, value: kf.value, easing: (kf.easing as EasingType) ?? 'linear' });
-        }
-
-        const state = ctx.getState();
-        ctx.updateState(addKeyframesBatchToState(state, batch));
-
-        return { content: [{ type: 'text', text: `Added ${batch.length} camera keyframes.${skipped ? ` Skipped ${skipped} with invalid properties (use translateX, translateY, scaleX, scaleY).` : ''}` }] };
-      } catch (e) {
-        return { content: [{ type: 'text', text: `Error: ${e}` }] };
-      }
+      const state = ctx.getState();
+      assertAdditionalKeyframes(state, batch.length, ctx.limits);
+      ctx.updateState(addKeyframesBatchToState(state, batch));
+      return {
+        content: [{
+          type: 'text',
+          text: `Added ${batch.length} camera keyframes.${legacyDeprecation('keyframes', parsed.legacy)}`,
+        }],
+      };
     },
   );
 }

--- a/mcp-server/src/server/checkpointTools.ts
+++ b/mcp-server/src/server/checkpointTools.ts
@@ -33,7 +33,7 @@ export function registerCheckpointTools(
     },
   );
 
-  server.tool(
+  ctx.tool(
     'list_checkpoints',
     'List all saved checkpoints.',
     {},

--- a/mcp-server/src/server/compositeTools.ts
+++ b/mcp-server/src/server/compositeTools.ts
@@ -6,6 +6,14 @@ import type { AnimatableProperty, EasingType } from '../types.js';
 import { ANIMATABLE_PROPERTIES, EASING_TYPES } from '../types.js';
 import { ORIGIN_MAP } from './geometry.js';
 import type { StateContext } from './stateContext.js';
+import {
+  assertAdditionalKeyframes,
+  boundedString,
+  boundedTime,
+  invalidInput,
+  legacyDeprecation,
+  parseLegacyArray,
+} from './limits.js';
 
 /**
  * Registers the `create_animated_scene` composite tool.
@@ -22,51 +30,86 @@ export function registerCompositeTools(
   normalizeElements: (elements: any[]) => any[],
   getElementBounds: (el: any) => { minX: number; minY: number; maxX: number; maxY: number },
 ): void {
+  const propertySchema = z.enum(
+    ANIMATABLE_PROPERTIES as unknown as [AnimatableProperty, ...AnimatableProperty[]],
+  );
+  const easingSchema = z.enum(
+    EASING_TYPES as unknown as [EasingType, ...EasingType[]],
+  );
+  const scaleOriginSchema = z.enum([
+    'center', 'top-left', 'top-right', 'bottom-left', 'bottom-right',
+    'top', 'bottom', 'left', 'right',
+  ]);
+  const keyframeSchema = z.object({
+    targetId: boundedString(ctx.limits),
+    property: propertySchema,
+    time: boundedTime(ctx.limits),
+    value: z.number().finite(),
+    easing: easingSchema.optional(),
+    scaleOrigin: scaleOriginSchema.optional(),
+  }).strict();
+  const keyframesSchema = z.array(keyframeSchema).max(ctx.limits.maxBatchItems);
+  const sequenceSchema = z.object({
+    elementIds: z.array(boundedString(ctx.limits))
+      .min(1)
+      .max(ctx.limits.maxBatchItems),
+    property: z.enum(['opacity', 'drawProgress']).optional(),
+    startTime: boundedTime(ctx.limits).optional(),
+    delay: boundedTime(ctx.limits).optional(),
+    duration: boundedTime(ctx.limits).min(50).optional(),
+  }).strict();
+  const sequencesSchema = z.array(sequenceSchema).max(ctx.limits.maxBatchItems);
+  const elementsSchema = z.array(z.record(z.unknown())).max(ctx.limits.maxElements);
+
   ctx.mutatingTool(
     'create_animated_scene',
     'Create a complete animated scene in one call: elements + keyframes + sequences + camera + clip range. ' +
     'Preferred over calling create_scene, add_keyframes_batch, create_sequence separately. ' +
     'Only elements is required — all other fields are optional.',
     {
-      elements: z.string().describe(
+      elements: z.string().max(ctx.limits.maxStateBytes).describe(
         'JSON string of Excalidraw elements array',
       ),
-      keyframes: z.string().optional().describe(
-        'JSON array of {targetId, property, time, value, easing?, scaleOrigin?}. ' +
-        'Properties: opacity, translateX, translateY, scaleX, scaleY, rotation, drawProgress.',
+      keyframes: z.union([
+        keyframesSchema,
+        z.string().max(ctx.limits.maxStateBytes),
+      ]).optional().describe(
+        'Array of {targetId, property, time, value, easing?, scaleOrigin?}; legacy JSON strings are deprecated.',
       ),
-      sequences: z.string().optional().describe(
-        'JSON array of {elementIds: string[], property?: "opacity"|"drawProgress", ' +
-        'startTime?: number, delay?: number, duration?: number}. Creates reveal sequences.',
+      sequences: z.union([
+        sequencesSchema,
+        z.string().max(ctx.limits.maxStateBytes),
+      ]).optional().describe(
+        'Array of reveal sequences; legacy JSON strings are deprecated.',
       ),
-      duration: z.number().optional().describe('Timeline duration in ms (default: 30000)'),
-      clipStart: z.number().optional().describe('Clip start time in ms (default: 0)'),
-      clipEnd: z.number().optional().describe('Clip end time in ms'),
+      duration: boundedTime(ctx.limits).optional().describe('Timeline duration in ms (default: 30000)'),
+      clipStart: boundedTime(ctx.limits).optional().describe('Clip start time in ms (default: 0)'),
+      clipEnd: boundedTime(ctx.limits).optional().describe('Clip end time in ms'),
       cameraFrame: z.object({
-        x: z.number().optional(),
-        y: z.number().optional(),
-        width: z.number().optional(),
+        x: z.number().finite().optional(),
+        y: z.number().finite().optional(),
+        width: z.number().finite().positive().optional(),
         aspectRatio: z.enum(['16:9', '4:3', '1:1', '3:2']).optional(),
-      }).optional().describe('Camera frame position and size'),
+      }).strict().optional().describe('Camera frame position and size'),
     },
     async ({ elements, keyframes, sequences, duration, clipStart, clipEnd, cameraFrame }) => {
-      const errors: string[] = [];
       const stats = { elements: 0, keyframes: 0, sequences: 0 };
+      let keyframesLegacy = false;
+      let sequencesLegacy = false;
 
       // ── 1. Parse and create scene elements ───────────────
-      let parsedElements: any[];
+      let rawElements: unknown;
       try {
-        parsedElements = JSON.parse(elements);
-        if (!Array.isArray(parsedElements)) {
-          return { content: [{ type: 'text' as const, text: 'Error: elements must be a JSON array' }] };
-        }
-      } catch (e) {
-        return { content: [{ type: 'text' as const, text: `Error parsing elements: ${e}` }] };
+        rawElements = JSON.parse(elements);
+      } catch {
+        invalidInput('elements must be valid JSON');
       }
+      const parsedElements = elementsSchema.safeParse(rawElements);
+      if (!parsedElements.success) invalidInput('elements must be a valid array');
 
       const state = ctx.getState();
-      state.scene.elements = normalizeElements(parsedElements);
-      stats.elements = parsedElements.length;
+      state.scene.elements = normalizeElements(parsedElements.data);
+      stats.elements = parsedElements.data.length;
 
       // ── 2. Set timeline duration ─────────────────────────
       if (duration !== undefined) {
@@ -83,8 +126,6 @@ export function registerCompositeTools(
 
       // ── 4. Collect all keyframes into a single batch ─────
       const allKeyframes: { targetId: string; property: AnimatableProperty; time: number; value: number; easing?: EasingType }[] = [];
-      const validProperties = new Set<string>(ANIMATABLE_PROPERTIES);
-      const validEasings = new Set<string>(EASING_TYPES);
 
       // 4a. Camera initial keyframes (always create at t=0 so camera starts correctly)
       if (cameraFrame) {
@@ -99,101 +140,138 @@ export function registerCompositeTools(
 
       // 4b. User-supplied keyframes
       if (keyframes) {
-        try {
-          const parsedKfs = JSON.parse(keyframes);
-          if (!Array.isArray(parsedKfs)) {
-            errors.push('keyframes must be a JSON array — skipped');
-          } else {
-            // Pre-process scale compensation (same logic as add_keyframes_batch)
-            const scaleCompensation = new Map<string, { targetId: string; time: number; sx: number; sy: number; origin: string; easing: string }>();
+        const parsed = parseLegacyArray(keyframes, keyframesSchema, 'keyframes', ctx.limits);
+        keyframesLegacy = parsed.legacy;
+        const scaleCompensation = new Map<string, {
+          targetId: string;
+          time: number;
+          scaleX: number;
+          scaleY: number;
+          origin: string;
+          easing: EasingType;
+        }>();
 
-            for (const kf of parsedKfs) {
-              if (!kf.targetId || !kf.property || kf.time === undefined || kf.value === undefined) continue;
-              if (!validProperties.has(kf.property)) continue;
-
-              // Collect scale origin compensation data
-              if ((kf.property === 'scaleX' || kf.property === 'scaleY') && kf.scaleOrigin && kf.scaleOrigin !== 'top-left') {
-                const key = `${kf.targetId}@${kf.time}`;
-                const existing = scaleCompensation.get(key) ?? {
-                  targetId: kf.targetId, time: kf.time, sx: 1, sy: 1,
-                  origin: kf.scaleOrigin, easing: kf.easing ?? 'linear',
-                };
-                if (kf.property === 'scaleX') existing.sx = kf.value;
-                if (kf.property === 'scaleY') existing.sy = kf.value;
-                existing.origin = kf.scaleOrigin;
-                scaleCompensation.set(key, existing);
-              }
-
-              const easing = (kf.easing && validEasings.has(kf.easing)) ? kf.easing : 'linear';
-              allKeyframes.push({
-                targetId: kf.targetId,
-                property: kf.property as AnimatableProperty,
-                time: kf.time,
-                value: kf.value,
-                easing: easing as EasingType,
-              });
-              stats.keyframes++;
-            }
-
-            // Compute scale origin translation compensation
-            for (const skf of scaleCompensation.values()) {
-              const [ox, oy] = ORIGIN_MAP[skf.origin] ?? [0.5, 0.5];
-              const el = state.scene.elements.find((e: any) => e.id === skf.targetId);
-              if (!el) continue;
-              const bounds = getElementBounds(el);
-              const w = bounds.maxX - bounds.minX;
-              const h = bounds.maxY - bounds.minY;
-              const tx = -w * (skf.sx - 1) * ox;
-              const ty = -h * (skf.sy - 1) * oy;
-              const easing = (validEasings.has(skf.easing) ? skf.easing : 'linear') as EasingType;
-              allKeyframes.push(
-                { targetId: skf.targetId, property: 'translateX', time: skf.time, value: tx, easing },
-                { targetId: skf.targetId, property: 'translateY', time: skf.time, value: ty, easing },
-              );
-              stats.keyframes += 2;
-            }
+        for (const keyframe of parsed.value) {
+          if (
+            (keyframe.property === 'scaleX' || keyframe.property === 'scaleY') &&
+            keyframe.scaleOrigin &&
+            keyframe.scaleOrigin !== 'top-left'
+          ) {
+            const key = `${keyframe.targetId}@${keyframe.time}`;
+            const existing = scaleCompensation.get(key) ?? {
+              targetId: keyframe.targetId,
+              time: keyframe.time,
+              scaleX: 1,
+              scaleY: 1,
+              origin: keyframe.scaleOrigin,
+              easing: keyframe.easing ?? 'linear',
+            };
+            if (keyframe.property === 'scaleX') existing.scaleX = keyframe.value;
+            if (keyframe.property === 'scaleY') existing.scaleY = keyframe.value;
+            existing.origin = keyframe.scaleOrigin;
+            scaleCompensation.set(key, existing);
           }
-        } catch (e) {
-          errors.push(`Error parsing keyframes: ${e}`);
+
+          allKeyframes.push({
+            targetId: keyframe.targetId,
+            property: keyframe.property,
+            time: keyframe.time,
+            value: keyframe.value,
+            easing: keyframe.easing ?? 'linear',
+          });
+          stats.keyframes++;
+        }
+
+        for (const scaleKeyframe of scaleCompensation.values()) {
+          const [originX, originY] = ORIGIN_MAP[scaleKeyframe.origin] ?? [0.5, 0.5];
+          const element = state.scene.elements.find(
+            (entry: any) => entry.id === scaleKeyframe.targetId,
+          );
+          if (!element) continue;
+          const bounds = getElementBounds(element);
+          const width = bounds.maxX - bounds.minX;
+          const height = bounds.maxY - bounds.minY;
+          allKeyframes.push(
+            {
+              targetId: scaleKeyframe.targetId,
+              property: 'translateX',
+              time: scaleKeyframe.time,
+              value: -width * (scaleKeyframe.scaleX - 1) * originX,
+              easing: scaleKeyframe.easing,
+            },
+            {
+              targetId: scaleKeyframe.targetId,
+              property: 'translateY',
+              time: scaleKeyframe.time,
+              value: -height * (scaleKeyframe.scaleY - 1) * originY,
+              easing: scaleKeyframe.easing,
+            },
+          );
+          stats.keyframes += 2;
         }
       }
 
       // 4c. Sequence reveals → expand into keyframes
       if (sequences) {
-        try {
-          const parsedSeqs = JSON.parse(sequences);
-          if (!Array.isArray(parsedSeqs)) {
-            errors.push('sequences must be a JSON array — skipped');
-          } else {
-            for (const seq of parsedSeqs) {
-              const ids = seq.elementIds;
-              if (!Array.isArray(ids) || ids.length === 0) continue;
-
-              const prop: AnimatableProperty = (seq.property === 'drawProgress') ? 'drawProgress' : 'opacity';
-              const startTime = seq.startTime ?? 0;
-              const delay = seq.delay ?? 300;
-              const dur = seq.duration ?? 500;
-
-              for (let i = 0; i < ids.length; i++) {
-                const revealStart = startTime + i * delay;
-                const revealEnd = revealStart + dur;
-                const targetId = ids[i];
-
-                if (revealStart > 0) {
-                  allKeyframes.push({ targetId, property: prop, time: 0, value: 0 });
-                }
-                if (revealStart > 10) {
-                  allKeyframes.push({ targetId, property: prop, time: revealStart, value: 0 });
-                }
-                allKeyframes.push({ targetId, property: prop, time: revealEnd, value: 1, easing: 'easeOut' });
-                stats.keyframes += (revealStart > 0 ? 1 : 0) + (revealStart > 10 ? 1 : 0) + 1;
-              }
-              stats.sequences++;
-            }
+        const parsed = parseLegacyArray(sequences, sequencesSchema, 'sequences', ctx.limits);
+        sequencesLegacy = parsed.legacy;
+        let expandedKeyframeCount = 0;
+        for (const sequence of parsed.value) {
+          const itemCount = sequence.elementIds.length;
+          const startTime = sequence.startTime ?? 0;
+          const delay = sequence.delay ?? 300;
+          const sequenceDuration = sequence.duration ?? 500;
+          const finalTime = startTime + Math.max(0, itemCount - 1) * delay + sequenceDuration;
+          if (!Number.isFinite(finalTime) || finalTime > ctx.limits.maxTimeMs) {
+            invalidInput(`Sequence times must not exceed ${ctx.limits.maxTimeMs}ms`);
           }
-        } catch (e) {
-          errors.push(`Error parsing sequences: ${e}`);
+
+          const countAfter = (threshold: number): number => {
+            if (delay === 0) return startTime > threshold ? itemCount : 0;
+            const firstIndex = Math.max(0, Math.floor((threshold - startTime) / delay) + 1);
+            return Math.max(0, itemCount - firstIndex);
+          };
+          expandedKeyframeCount +=
+            itemCount +
+            countAfter(0) +
+            countAfter(10);
         }
+        assertAdditionalKeyframes(
+          state,
+          allKeyframes.length + expandedKeyframeCount,
+          ctx.limits,
+        );
+
+        for (const sequence of parsed.value) {
+          const property: AnimatableProperty =
+            sequence.property === 'drawProgress' ? 'drawProgress' : 'opacity';
+          const startTime = sequence.startTime ?? 0;
+          const delay = sequence.delay ?? 300;
+          const sequenceDuration = sequence.duration ?? 500;
+
+          for (let index = 0; index < sequence.elementIds.length; index++) {
+            const revealStart = startTime + index * delay;
+            const revealEnd = revealStart + sequenceDuration;
+            const targetId = sequence.elementIds[index];
+            if (revealStart > 0) {
+              allKeyframes.push({ targetId, property, time: 0, value: 0 });
+            }
+            if (revealStart > 10) {
+              allKeyframes.push({ targetId, property, time: revealStart, value: 0 });
+            }
+            allKeyframes.push({
+              targetId,
+              property,
+              time: revealEnd,
+              value: 1,
+              easing: 'easeOut',
+            });
+            stats.keyframes += (revealStart > 0 ? 1 : 0) + (revealStart > 10 ? 1 : 0) + 1;
+          }
+          stats.sequences++;
+        }
+      } else {
+        assertAdditionalKeyframes(state, allKeyframes.length, ctx.limits);
       }
 
       // ── 5. Apply all keyframes in one batched pass ───────
@@ -227,9 +305,7 @@ export function registerCompositeTools(
         `clip: ${finalState.clipStart}ms–${finalState.clipEnd}ms`,
       ].filter(Boolean).join(', ');
 
-      const msg = errors.length > 0
-        ? `${parts}\nWarnings: ${errors.join('; ')}`
-        : parts;
+      const msg = `${parts}${legacyDeprecation('keyframes', keyframesLegacy)}${legacyDeprecation('sequences', sequencesLegacy)}`;
 
       return { content: [{ type: 'text' as const, text: msg }] };
     },

--- a/mcp-server/src/server/limits.ts
+++ b/mcp-server/src/server/limits.ts
@@ -1,0 +1,180 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { ServerState } from '../types.js';
+
+export interface ResourceLimits {
+  maxElements: number;
+  maxTracks: number;
+  maxKeyframesPerTrack: number;
+  maxTotalKeyframes: number;
+  maxBatchItems: number;
+  maxStringLength: number;
+  maxTimeMs: number;
+  maxStateBytes: number;
+  maxObjectDepth: number;
+  maxMutationsPerWindow: number;
+  mutationWindowMs: number;
+}
+
+export const DEFAULT_RESOURCE_LIMITS: Readonly<ResourceLimits> = {
+  maxElements: 2_000,
+  maxTracks: 2_000,
+  maxKeyframesPerTrack: 1_000,
+  maxTotalKeyframes: 20_000,
+  maxBatchItems: 2_000,
+  maxStringLength: 100_000,
+  maxTimeMs: 24 * 60 * 60 * 1_000,
+  maxStateBytes: 10 * 1024 * 1024,
+  maxObjectDepth: 32,
+  maxMutationsPerWindow: 240,
+  mutationWindowMs: 60_000,
+};
+
+export function mergeResourceLimits(overrides: Partial<ResourceLimits> = {}): ResourceLimits {
+  const limits = { ...DEFAULT_RESOURCE_LIMITS, ...overrides };
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`Invalid resource limit: ${name}`);
+    }
+  }
+  return limits;
+}
+
+export function invalidInput(message: string): never {
+  throw new McpError(ErrorCode.InvalidParams, message);
+}
+
+function assertNestedValue(
+  value: unknown,
+  limits: ResourceLimits,
+  path: string,
+  depth: number,
+): void {
+  if (depth > limits.maxObjectDepth) {
+    invalidInput(`${path} exceeds the maximum nesting depth`);
+  }
+  if (typeof value === 'string' && value.length > limits.maxStringLength) {
+    invalidInput(`${path} exceeds the maximum string length`);
+  }
+  if (Array.isArray(value)) {
+    if (value.length > limits.maxBatchItems) {
+      invalidInput(`${path} exceeds the maximum array length`);
+    }
+    value.forEach((entry, index) => assertNestedValue(entry, limits, `${path}[${index}]`, depth + 1));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value)) {
+      assertNestedValue(entry, limits, `${path}.${key}`, depth + 1);
+    }
+  }
+}
+
+export function assertInputWithinLimits(input: unknown, limits: ResourceLimits): void {
+  assertNestedValue(input, limits, 'input', 0);
+}
+
+export function countTotalKeyframes(state: ServerState): number {
+  return state.timeline.tracks.reduce(
+    (total, track) => total + track.keyframes.length,
+    0,
+  );
+}
+
+export function assertAdditionalKeyframes(
+  state: ServerState,
+  additionalCount: number,
+  limits: ResourceLimits,
+): void {
+  if (
+    !Number.isSafeInteger(additionalCount) ||
+    additionalCount < 0 ||
+    countTotalKeyframes(state) + additionalCount > limits.maxTotalKeyframes
+  ) {
+    invalidInput(`Timeline exceeds the ${limits.maxTotalKeyframes} total keyframe limit`);
+  }
+}
+
+export function assertStateWithinLimits(state: ServerState, limits: ResourceLimits): void {
+  if (state.scene.elements.length > limits.maxElements) {
+    invalidInput(`Scene exceeds the ${limits.maxElements} element limit`);
+  }
+  if (state.timeline.tracks.length > limits.maxTracks) {
+    invalidInput(`Timeline exceeds the ${limits.maxTracks} track limit`);
+  }
+
+  let totalKeyframes = 0;
+  for (const track of state.timeline.tracks) {
+    if (track.keyframes.length > limits.maxKeyframesPerTrack) {
+      invalidInput(`Track "${track.id}" exceeds the keyframe limit`);
+    }
+    totalKeyframes += track.keyframes.length;
+    for (const keyframe of track.keyframes) {
+      if (!Number.isFinite(keyframe.time) || keyframe.time < 0 || keyframe.time > limits.maxTimeMs) {
+        invalidInput(`Keyframe time must be between 0 and ${limits.maxTimeMs}ms`);
+      }
+      if (!Number.isFinite(keyframe.value)) {
+        invalidInput('Keyframe values must be finite numbers');
+      }
+    }
+  }
+  if (totalKeyframes > limits.maxTotalKeyframes) {
+    invalidInput(`Timeline exceeds the ${limits.maxTotalKeyframes} total keyframe limit`);
+  }
+
+  const timeValues = [
+    state.timeline.duration,
+    state.clipStart,
+    state.clipEnd,
+  ];
+  if (timeValues.some((value) => !Number.isFinite(value) || value < 0 || value > limits.maxTimeMs)) {
+    invalidInput(`Timeline times must be between 0 and ${limits.maxTimeMs}ms`);
+  }
+
+  assertNestedValue(state, limits, 'state', 0);
+  if (Buffer.byteLength(JSON.stringify(state), 'utf8') > limits.maxStateBytes) {
+    invalidInput(`Project state exceeds the ${limits.maxStateBytes} byte limit`);
+  }
+}
+
+export function parseLegacyArray<T>(
+  value: string | T[],
+  schema: z.ZodType<T[]>,
+  label: string,
+  limits: ResourceLimits,
+): { value: T[]; legacy: boolean } {
+  if (Array.isArray(value)) {
+    return { value, legacy: false };
+  }
+  if (Buffer.byteLength(value, 'utf8') > limits.maxStateBytes) {
+    invalidInput(`${label} JSON exceeds the input size limit`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    invalidInput(`${label} must be valid JSON`);
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue.path.length > 0 ? ` at ${issue.path.join('.')}` : '';
+    invalidInput(`Invalid ${label}${path}: ${issue.message}`);
+  }
+  return { value: result.data, legacy: true };
+}
+
+export function legacyDeprecation(label: string, legacy: boolean): string {
+  return legacy
+    ? ` Deprecated: pass ${label} as a nested array instead of a JSON-encoded string.`
+    : '';
+}
+
+export function boundedString(limits: ResourceLimits) {
+  return z.string().min(1).max(limits.maxStringLength);
+}
+
+export function boundedTime(limits: ResourceLimits) {
+  return z.number().finite().min(0).max(limits.maxTimeMs);
+}

--- a/mcp-server/src/server/queryTools.ts
+++ b/mcp-server/src/server/queryTools.ts
@@ -22,7 +22,7 @@ export function registerQueryTools(
   ctx: StateContext,
   geometry: Geometry,
 ): void {
-  server.tool(
+  ctx.tool(
     'are_items_in_line',
     'Check if the given items are aligned horizontally or vertically (within a tolerance).',
     {
@@ -48,7 +48,7 @@ export function registerQueryTools(
     },
   );
 
-  server.tool(
+  ctx.tool(
     'is_camera_centered',
     'Check if the camera is centered on the scene content (horizontally, vertically, or both).',
     {
@@ -74,7 +74,7 @@ export function registerQueryTools(
     },
   );
 
-  server.tool(
+  ctx.tool(
     'items_visible_in_camera',
     'Check what percentage of items are visible in the camera frame at a given time.',
     {
@@ -101,7 +101,7 @@ export function registerQueryTools(
     },
   );
 
-  server.tool(
+  ctx.tool(
     'animations_of_item',
     'Returns a timeline description of all animations an item goes through.',
     {

--- a/mcp-server/src/server/sceneTools.ts
+++ b/mcp-server/src/server/sceneTools.ts
@@ -2,51 +2,64 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { StateContext } from './stateContext.js';
-import { getSceneElementsJSON } from './stateContext.js';
+import { boundedString, invalidInput } from './limits.js';
 
 export function registerSceneTools(
   server: McpServer,
   ctx: StateContext,
   normalizeElements: (elements: any[]) => any[],
 ): void {
+  const elementSchema = z.record(z.unknown());
+  const elementsSchema = z.array(elementSchema).max(ctx.limits.maxElements);
+  const updateSchema = z.object({
+    id: boundedString(ctx.limits),
+  }).passthrough();
+  const updatesSchema = z.array(updateSchema).max(ctx.limits.maxBatchItems);
+
+  function parseArray<T>(input: string, schema: z.ZodType<T>, label: string): T {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      invalidInput(`${label} must be valid JSON`);
+    }
+    const result = schema.safeParse(parsed);
+    if (!result.success) invalidInput(`${label} must be a valid array`);
+    return result.data;
+  }
+
   ctx.mutatingTool(
     'create_scene',
     'Create or replace the Excalidraw scene with the given elements.',
-    { elements: z.string().describe('JSON string of Excalidraw elements array') },
+    { elements: z.string().max(ctx.limits.maxStateBytes).describe('JSON string of Excalidraw elements array') },
     async ({ elements }) => {
-      try {
-        const parsed = JSON.parse(elements);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text' as const, text: 'Error: elements must be a JSON array' }] };
-        const state = ctx.getState();
-        state.scene.elements = normalizeElements(parsed);
-        return { content: [{ type: 'text' as const, text: `Scene created with ${parsed.length} elements.` }] };
-      } catch (e) {
-        return { content: [{ type: 'text' as const, text: `Error parsing elements: ${e}` }] };
-      }
+      const parsed = parseArray(elements, elementsSchema, 'elements');
+      const state = ctx.getState();
+      state.scene.elements = normalizeElements(parsed);
+      return { content: [{ type: 'text' as const, text: `Scene created with ${parsed.length} elements.` }] };
     },
   );
 
   ctx.mutatingTool(
     'add_elements',
     'Add elements to the existing scene.',
-    { elements: z.string().describe('JSON string of elements to add') },
+    { elements: z.string().max(ctx.limits.maxStateBytes).describe('JSON string of elements to add') },
     async ({ elements }) => {
-      try {
-        const parsed = JSON.parse(elements);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text' as const, text: 'Error: must be array' }] };
-        const state = ctx.getState();
-        state.scene.elements.push(...normalizeElements(parsed));
-        return { content: [{ type: 'text' as const, text: `Added ${parsed.length} elements. Total: ${state.scene.elements.length}.` }] };
-      } catch (e) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e}` }] };
-      }
+      const parsed = parseArray(elements, elementsSchema, 'elements');
+      const state = ctx.getState();
+      state.scene.elements.push(...normalizeElements(parsed));
+      return { content: [{ type: 'text' as const, text: `Added ${parsed.length} elements. Total: ${state.scene.elements.length}.` }] };
     },
   );
 
   ctx.mutatingTool(
     'remove_elements',
     'Remove elements by their IDs.',
-    { ids: z.array(z.string()).describe('Array of element IDs to remove') },
+    {
+      ids: z.array(boundedString(ctx.limits))
+        .max(ctx.limits.maxBatchItems)
+        .describe('Array of element IDs to remove'),
+    },
     async ({ ids }) => {
       const state = ctx.getState();
       const idSet = new Set(ids);
@@ -60,38 +73,37 @@ export function registerSceneTools(
   ctx.mutatingTool(
     'update_elements',
     'Update properties of existing elements.',
-    { updates: z.string().describe('JSON string of array [{id, ...properties}]') },
+    {
+      updates: z.string()
+        .max(ctx.limits.maxStateBytes)
+        .describe('JSON string of array [{id, ...properties}]'),
+    },
     async ({ updates }) => {
-      try {
-        const parsed = JSON.parse(updates);
-        if (!Array.isArray(parsed)) return { content: [{ type: 'text' as const, text: 'Error: must be array' }] };
-        const state = ctx.getState();
-        // Build id→index map for O(1) lookups instead of O(n) findIndex per update
-        const indexById = new Map<string, number>();
-        for (let i = 0; i < state.scene.elements.length; i++) {
-          indexById.set((state.scene.elements[i] as any).id, i);
-        }
-        let updated = 0;
-        for (const upd of parsed) {
-          const idx = indexById.get(upd.id);
-          if (idx !== undefined) {
-            state.scene.elements[idx] = { ...state.scene.elements[idx], ...upd };
-            updated++;
-          }
-        }
-        return { content: [{ type: 'text' as const, text: `Updated ${updated} elements.` }] };
-      } catch (e) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e}` }] };
+      const parsed = parseArray(updates, updatesSchema, 'updates');
+      const state = ctx.getState();
+      // Build id→index map for O(1) lookups instead of O(n) findIndex per update
+      const indexById = new Map<string, number>();
+      for (let i = 0; i < state.scene.elements.length; i++) {
+        indexById.set((state.scene.elements[i] as any).id, i);
       }
+      let updated = 0;
+      for (const upd of parsed) {
+        const idx = indexById.get(upd.id);
+        if (idx !== undefined) {
+          state.scene.elements[idx] = { ...state.scene.elements[idx], ...upd };
+          updated++;
+        }
+      }
+      return { content: [{ type: 'text' as const, text: `Updated ${updated} elements.` }] };
     },
   );
 
-  server.tool(
+  ctx.tool(
     'get_scene',
     'Return the current scene elements as JSON.',
     {},
     async () => ({
-      content: [{ type: 'text' as const, text: getSceneElementsJSON() }],
+      content: [{ type: 'text' as const, text: ctx.getSceneElementsJSON() }],
     }),
   );
 
@@ -112,7 +124,9 @@ export function registerSceneTools(
     'delete_items',
     'Delete specific elements and all their animation tracks. Batch operation.',
     {
-      ids: z.array(z.string()).describe('Element IDs to delete'),
+      ids: z.array(boundedString(ctx.limits))
+        .max(ctx.limits.maxBatchItems)
+        .describe('Element IDs to delete'),
     },
     async ({ ids }) => {
       const state = ctx.getState();

--- a/mcp-server/src/server/shareTools.ts
+++ b/mcp-server/src/server/shareTools.ts
@@ -14,7 +14,9 @@ import crypto from 'node:crypto';
 import { z } from 'zod';
 import { promisify } from 'node:util';
 import { gzip } from 'node:zlib';
+import { getRequestAbortSignal } from '../requestContext.js';
 import type { StateContext } from './stateContext.js';
+import { invalidInput } from './limits.js';
 
 const gzipAsync = promisify(gzip);
 
@@ -39,62 +41,58 @@ export function registerShareTools(
   server: McpServer,
   ctx: StateContext,
 ): void {
-  server.tool(
+  ctx.tool(
     'share_project',
     'Create an E2E encrypted share URL for the current project. Uploads to the Excalimate cloud share service so links persist permanently (30 days). The encryption key is in the URL hash fragment (never sent to any server). Returns the shareable URL.',
     {
-      baseUrl: z.string().optional().describe('Base URL for the share link (default: https://app.excalimate.com)'),
-      shareApi: z.string().optional().describe('Share service API URL (default: https://share.excalimate.com)'),
+      baseUrl: z.string().url().max(2_048).optional().describe('Base URL for the share link (default: https://app.excalimate.com)'),
+      shareApi: z.string().url().max(2_048).optional().describe('Share service API URL (default: https://share.excalimate.com)'),
     },
     async ({ baseUrl, shareApi }) => {
       const state = ctx.getState();
       if (!state.scene.elements || state.scene.elements.length === 0) {
-        return { content: [{ type: 'text', text: 'Error: No elements in the scene. Create a scene first.' }] };
+        invalidInput('No elements in the scene; create a scene first');
       }
 
-      try {
-        const payload = JSON.stringify({
-          scene: state.scene,
-          timeline: state.timeline,
-          clipStart: state.clipStart,
-          clipEnd: state.clipEnd,
-          cameraFrame: state.cameraFrame,
-        });
+      const payload = JSON.stringify({
+        scene: state.scene,
+        timeline: state.timeline,
+        clipStart: state.clipStart,
+        clipEnd: state.clipEnd,
+        cameraFrame: state.cameraFrame,
+      });
 
-        const compressed = await gzipAsync(Buffer.from(payload, 'utf-8'));
-        const { encrypted, keyBase64url } = encrypt(compressed);
+      const compressed = await gzipAsync(Buffer.from(payload, 'utf-8'));
+      const { encrypted, keyBase64url } = encrypt(compressed);
 
-        // Upload to the cloud share service (persists across MCP server restarts)
-        const apiUrl = shareApi ?? process.env.EXCALIMATE_SHARE_API ?? DEFAULT_SHARE_API;
-        const response = await fetch(`${apiUrl}/share`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/octet-stream' },
-          body: new Uint8Array(encrypted),
-        });
+      // Upload to the cloud share service (persists across MCP server restarts)
+      const apiUrl = shareApi ?? process.env.EXCALIMATE_SHARE_API ?? DEFAULT_SHARE_API;
+      const response = await fetch(`${apiUrl}/share`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: new Uint8Array(encrypted),
+        signal: getRequestAbortSignal(),
+      });
 
-        if (!response.ok) {
-          const err = await response.text();
-          return { content: [{ type: 'text', text: `Error uploading share: ${err}` }] };
-        }
-
-        const { id } = await response.json() as { id: string };
-
-        const appBase = baseUrl ?? 'https://app.excalimate.com';
-        const fullUrl = `${appBase}/#share=${id},${keyBase64url}`;
-
-        return {
-          content: [{
-            type: 'text',
-            text: `Share URL created:\n${fullUrl}\n\n` +
-              `Elements: ${state.scene.elements.length}, ` +
-              `Tracks: ${state.timeline.tracks.length}, ` +
-              `Encrypted size: ${(encrypted.length / 1024).toFixed(1)} KB\n\n` +
-              `Link is valid for 30 days. The encryption key is in the URL hash — no server can read the content.`,
-          }],
-        };
-      } catch (e) {
-        return { content: [{ type: 'text', text: `Error creating share: ${e}` }] };
+      if (!response.ok) {
+        throw new Error('Share service request failed');
       }
+
+      const { id } = await response.json() as { id: string };
+
+      const appBase = baseUrl ?? 'https://app.excalimate.com';
+      const fullUrl = `${appBase}/#share=${id},${keyBase64url}`;
+
+      return {
+        content: [{
+          type: 'text',
+          text: `Share URL created:\n${fullUrl}\n\n` +
+            `Elements: ${state.scene.elements.length}, ` +
+            `Tracks: ${state.timeline.tracks.length}, ` +
+            `Encrypted size: ${(encrypted.length / 1024).toFixed(1)} KB\n\n` +
+            `Link is valid for 30 days. The encryption key is in the URL hash — no server can read the content.`,
+        }],
+      };
     },
   );
 }

--- a/mcp-server/src/server/stateContext.ts
+++ b/mcp-server/src/server/stateContext.ts
@@ -1,28 +1,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { createDefaultState } from '../state.js';
 import type { ServerState } from '../types.js';
+import { getRequestId } from '../requestContext.js';
+import {
+  assertInputWithinLimits,
+  assertStateWithinLimits,
+  mergeResourceLimits,
+} from './limits.js';
+import type { ResourceLimits } from './limits.js';
 
-/**
- * Delta message format sent over SSE.
- * Instead of full state areas, we send fine-grained changes:
- * - Scene: only added/updated/removed elements
- * - Timeline: only upserted/removed tracks
- * - Clip and cameraFrame: sent as-is (small payloads)
- */
+type DirtyArea = 'scene' | 'timeline' | 'clip' | 'cameraFrame';
+
 export interface StateDelta {
+  revision: number;
+  sequence: number;
+  baseRevision: number;
   scene?: {
-    /** Elements that were added or have changed properties */
     upsert: any[];
-    /** Element IDs that were removed */
     removed: string[];
   };
   timeline?: {
-    /** Tracks that were added or have changed keyframes */
     upsertedTracks: any[];
-    /** Track IDs that were removed */
     removedTrackIds: string[];
-    /** Timeline metadata (duration, fps) — only sent if changed */
     meta?: { duration: number; fps: number };
   };
   clipStart?: number;
@@ -32,94 +33,43 @@ export interface StateDelta {
 
 export type StateChangeListener = (delta: StateDelta) => void;
 
-let _activeState: ServerState = createDefaultState();
-let _activeServerId: string | null = null;
-let _stateVersion = 0;
-
-export function getSharedState(): ServerState { return _activeState; }
-
-/**
- * Cached JSON serialization of state areas.
- * Invalidated by version counter — avoids re-serializing unchanged state
- * on repeated get_scene / get_timeline / /state calls.
- */
-const _jsonCache = {
-  fullState: { version: -1, json: '' },
-  sceneElements: { version: -1, json: '' },
-  timeline: { version: -1, json: '' },
-};
-
-/** Get the full state as a JSON string, using cache when unchanged. */
-export function getSharedStateJSON(): string {
-  if (_jsonCache.fullState.version === _stateVersion) return _jsonCache.fullState.json;
-  const json = JSON.stringify(_activeState);
-  _jsonCache.fullState = { version: _stateVersion, json };
-  return json;
+export interface StateSnapshot extends ServerState {
+  revision: number;
+  sequence: number;
 }
 
-/** Get scene elements as a pretty JSON string, using cache when unchanged. */
-export function getSceneElementsJSON(): string {
-  if (_jsonCache.sceneElements.version === _stateVersion) return _jsonCache.sceneElements.json;
-  const json = JSON.stringify(_activeState.scene.elements, null, 2);
-  _jsonCache.sceneElements = { version: _stateVersion, json };
-  return json;
-}
-
-/** Get timeline + clip + camera as a pretty JSON string, using cache when unchanged. */
-export function getTimelineJSON(): string {
-  if (_jsonCache.timeline.version === _stateVersion) return _jsonCache.timeline.json;
-  const json = JSON.stringify({
-    timeline: _activeState.timeline,
-    clipStart: _activeState.clipStart,
-    clipEnd: _activeState.clipEnd,
-    cameraFrame: _activeState.cameraFrame,
-  }, null, 2);
-  _jsonCache.timeline = { version: _stateVersion, json };
-  return json;
+export interface StateContextOptions {
+  resourceLimits?: Partial<ResourceLimits>;
 }
 
 export interface StateContext {
+  readonly limits: ResourceLimits;
   getState: () => ServerState;
+  getRevision: () => number;
+  getSequence: () => number;
+  getSnapshot: () => StateSnapshot;
+  getStateJSON: () => string;
+  getSceneElementsJSON: () => string;
+  getTimelineJSON: () => string;
   updateState: (newState: ServerState) => void;
   emitChange: () => void;
-  /** Mark a state area as dirty for delta broadcasting. */
-  markDirty: (area: 'scene' | 'timeline' | 'clip' | 'cameraFrame' | 'all') => void;
+  close: () => void;
+  markDirty: (area: DirtyArea | 'all') => void;
+  tool: (
+    name: string,
+    description: string,
+    schema: any,
+    handler: (args: any) => Promise<any>,
+  ) => void;
   mutatingTool: (
     name: string,
     description: string,
     schema: any,
-    handler: (args: any) => Promise<{ content: { type: 'text'; text: string }[] }>,
-    /** Which state areas this tool modifies (for delta broadcasting). Defaults to 'all'. */
-    dirtyAreas?: Array<'scene' | 'timeline' | 'clip' | 'cameraFrame'>,
+    handler: (args: any) => Promise<any>,
+    dirtyAreas?: DirtyArea[],
   ) => void;
 }
 
-// ── Delta computation helpers ──────────────────────────────────
-
-/** Snapshot the minimal data needed to compute scene deltas. */
-function snapshotElementIds(state: ServerState): Map<string, number> {
-  const map = new Map<string, number>();
-  for (const el of state.scene.elements) {
-    // Use version (or versionNonce) as a change indicator
-    map.set(el.id, el.version ?? 0);
-  }
-  return map;
-}
-
-/** Snapshot track IDs and their keyframe counts for change detection. */
-function snapshotTracks(state: ServerState): Map<string, number> {
-  const map = new Map<string, number>();
-  for (const t of state.timeline.tracks) {
-    map.set(t.id, t.keyframes.length);
-  }
-  return map;
-}
-
-/**
- * Properties stripped from elements in SSE deltas to reduce payload size.
- * These are non-visual metadata that the client can re-fetch on reconnect
- * via the /state endpoint (which sends full elements).
- */
 const STRIP_ELEMENT_KEYS = new Set([
   'seed', 'versionNonce', 'updated', 'link', 'locked',
   'roundness', 'boundElements', 'lastCommittedPoint',
@@ -134,178 +84,283 @@ function stripElement(el: any): any {
   return stripped;
 }
 
+function fingerprint(value: unknown): string {
+  return JSON.stringify(value);
+}
+
 function computeSceneDelta(
-  prevElements: Map<string, number>,
+  previous: ServerState,
   current: ServerState,
 ): StateDelta['scene'] | undefined {
-  const upsert: any[] = [];
+  const previousElements = new Map(
+    previous.scene.elements.map((element: any) => [element.id as string, fingerprint(element)]),
+  );
   const currentIds = new Set<string>();
+  const upsert: any[] = [];
 
-  for (const el of current.scene.elements) {
-    currentIds.add(el.id);
-    const prevVersion = prevElements.get(el.id);
-    if (prevVersion === undefined || prevVersion !== (el.version ?? 0)) {
-      upsert.push(stripElement(el));
+  for (const element of current.scene.elements) {
+    currentIds.add(element.id);
+    if (previousElements.get(element.id) !== fingerprint(element)) {
+      upsert.push(stripElement(element));
     }
   }
 
-  const removed: string[] = [];
-  for (const id of prevElements.keys()) {
-    if (!currentIds.has(id)) removed.push(id);
-  }
-
-  if (upsert.length === 0 && removed.length === 0) return undefined;
-  return { upsert, removed };
+  const removed = [...previousElements.keys()].filter((id) => !currentIds.has(id));
+  return upsert.length > 0 || removed.length > 0 ? { upsert, removed } : undefined;
 }
 
 function computeTimelineDelta(
-  prevTracks: Map<string, number>,
-  prevDuration: number,
-  prevFps: number,
+  previous: ServerState,
   current: ServerState,
 ): StateDelta['timeline'] | undefined {
-  const upsertedTracks: any[] = [];
+  const previousTracks = new Map(
+    previous.timeline.tracks.map((track) => [track.id, fingerprint(track)]),
+  );
   const currentTrackIds = new Set<string>();
+  const upsertedTracks = [];
 
   for (const track of current.timeline.tracks) {
     currentTrackIds.add(track.id);
-    const prevKfCount = prevTracks.get(track.id);
-    if (prevKfCount === undefined || prevKfCount !== track.keyframes.length) {
+    if (previousTracks.get(track.id) !== fingerprint(track)) {
       upsertedTracks.push(track);
     }
   }
 
-  const removedTrackIds: string[] = [];
-  for (const id of prevTracks.keys()) {
-    if (!currentTrackIds.has(id)) removedTrackIds.push(id);
+  const removedTrackIds = [...previousTracks.keys()].filter((id) => !currentTrackIds.has(id));
+  const metaChanged =
+    previous.timeline.duration !== current.timeline.duration ||
+    previous.timeline.fps !== current.timeline.fps;
+
+  if (upsertedTracks.length === 0 && removedTrackIds.length === 0 && !metaChanged) {
+    return undefined;
   }
-
-  const metaChanged = current.timeline.duration !== prevDuration || current.timeline.fps !== prevFps;
-
-  if (upsertedTracks.length === 0 && removedTrackIds.length === 0 && !metaChanged) return undefined;
-
-  const result: StateDelta['timeline'] = { upsertedTracks, removedTrackIds };
-  if (metaChanged) {
-    result.meta = { duration: current.timeline.duration, fps: current.timeline.fps };
-  }
-  return result;
+  return {
+    upsertedTracks,
+    removedTrackIds,
+    ...(metaChanged
+      ? { meta: { duration: current.timeline.duration, fps: current.timeline.fps } }
+      : {}),
+  };
 }
 
-// ── State context factory ──────────────────────────────────────
+export function computeStateDelta(
+  previous: ServerState,
+  current: ServerState,
+  metadata: Pick<StateDelta, 'revision' | 'sequence' | 'baseRevision'>,
+  areas: ReadonlySet<DirtyArea> = new Set(['scene', 'timeline', 'clip', 'cameraFrame']),
+): StateDelta | null {
+  const delta: StateDelta = { ...metadata };
+  if (areas.has('scene')) delta.scene = computeSceneDelta(previous, current);
+  if (areas.has('timeline')) delta.timeline = computeTimelineDelta(previous, current);
+  if (
+    areas.has('clip') &&
+    (previous.clipStart !== current.clipStart || previous.clipEnd !== current.clipEnd)
+  ) {
+    delta.clipStart = current.clipStart;
+    delta.clipEnd = current.clipEnd;
+  }
+  if (areas.has('cameraFrame') && fingerprint(previous.cameraFrame) !== fingerprint(current.cameraFrame)) {
+    delta.cameraFrame = current.cameraFrame;
+  }
+
+  return delta.scene || delta.timeline || delta.clipStart !== undefined || delta.cameraFrame
+    ? delta
+    : null;
+}
+
+function cloneState(state: ServerState): ServerState {
+  return structuredClone(state);
+}
+
+function isMcpError(error: unknown): error is McpError {
+  return error instanceof McpError;
+}
 
 export function createStateContext(
-  serverId: string,
   server: McpServer,
   onStateChange?: StateChangeListener,
+  options: StateContextOptions = {},
 ): StateContext {
-  if (_activeServerId !== null) {
-    console.warn(
-      `[excalimate] New server ${serverId} replacing active server ${_activeServerId}. ` +
-      'Concurrent MCP sessions share the same state (single-tenant design).',
-    );
-  }
-  _activeServerId = serverId;
+  const limits = mergeResourceLimits(options.resourceLimits);
+  let state = createDefaultState();
+  let lastPublishedState = cloneState(state);
+  let revision = 0;
+  let sequence = 0;
+  let closed = false;
+  let pendingDirtyAreas = new Set<DirtyArea>();
+  const mutationTimestamps: number[] = [];
+  let stateJsonCache: { revision: number; sequence: number; json: string } | null = null;
+  let mutationQueue: Promise<void> = Promise.resolve();
 
-  // ── Delta broadcasting with debounce ───────────────────────────
-  let _emitTimer: ReturnType<typeof setTimeout> | null = null;
-  const _dirty = { scene: false, timeline: false, clip: false, cameraFrame: false };
+  assertStateWithinLimits(state, limits);
 
-  // Snapshots taken before each tool call for delta computation
-  let _prevElementSnapshot: Map<string, number> = snapshotElementIds(_activeState);
-  let _prevTrackSnapshot: Map<string, number> = snapshotTracks(_activeState);
-  let _prevDuration: number = _activeState.timeline.duration;
-  let _prevFps: number = _activeState.timeline.fps;
-
-  function markDirty(area: 'scene' | 'timeline' | 'clip' | 'cameraFrame' | 'all') {
+  function markDirty(area: DirtyArea | 'all'): void {
     if (area === 'all') {
-      _dirty.scene = _dirty.timeline = _dirty.clip = _dirty.cameraFrame = true;
+      pendingDirtyAreas = new Set(['scene', 'timeline', 'clip', 'cameraFrame']);
     } else {
-      _dirty[area] = true;
+      pendingDirtyAreas.add(area);
     }
   }
 
-  const emitChange = () => {
-    if (!_dirty.scene && !_dirty.timeline && !_dirty.clip && !_dirty.cameraFrame) {
-      markDirty('all');
+  function publishChange(previous: ServerState, areas: ReadonlySet<DirtyArea>): void {
+    const nextRevision = revision + 1;
+    const nextSequence = sequence + 1;
+    const delta = computeStateDelta(previous, state, {
+      revision: nextRevision,
+      sequence: nextSequence,
+      baseRevision: revision,
+    }, areas);
+    if (!delta) return;
+
+    revision = nextRevision;
+    sequence = nextSequence;
+    stateJsonCache = null;
+    lastPublishedState = cloneState(state);
+    try {
+      onStateChange?.(structuredClone(delta));
+    } catch {
+      const requestId = getRequestId();
+      console.error(`[excalimate] State listener failed (request ID: ${requestId})`);
     }
+  }
 
-    if (_emitTimer) clearTimeout(_emitTimer);
-    _emitTimer = setTimeout(() => {
-      _emitTimer = null;
-      try {
-        if (!onStateChange) return;
+  function emitChange(): void {
+    assertStateWithinLimits(state, limits);
+    const areas = pendingDirtyAreas.size > 0
+      ? new Set(pendingDirtyAreas)
+      : new Set<DirtyArea>(['scene', 'timeline', 'clip', 'cameraFrame']);
+    pendingDirtyAreas.clear();
+    publishChange(lastPublishedState, areas);
+  }
 
-        const delta: StateDelta = {};
-        let hasContent = false;
+  function assertMutationAllowed(): void {
+    const now = Date.now();
+    while (
+      mutationTimestamps.length > 0 &&
+      mutationTimestamps[0] <= now - limits.mutationWindowMs
+    ) {
+      mutationTimestamps.shift();
+    }
+    if (mutationTimestamps.length >= limits.maxMutationsPerWindow) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Mutation rate limit exceeded; retry after ${limits.mutationWindowMs}ms`,
+      );
+    }
+    mutationTimestamps.push(now);
+  }
 
-        if (_dirty.scene) {
-          delta.scene = computeSceneDelta(_prevElementSnapshot, _activeState);
-          _prevElementSnapshot = snapshotElementIds(_activeState);
-          if (delta.scene) hasContent = true;
-        }
-        if (_dirty.timeline) {
-          delta.timeline = computeTimelineDelta(_prevTrackSnapshot, _prevDuration, _prevFps, _activeState);
-          _prevTrackSnapshot = snapshotTracks(_activeState);
-          _prevDuration = _activeState.timeline.duration;
-          _prevFps = _activeState.timeline.fps;
-          if (delta.timeline) hasContent = true;
-        }
-        if (_dirty.clip) {
-          delta.clipStart = _activeState.clipStart;
-          delta.clipEnd = _activeState.clipEnd;
-          hasContent = true;
-        }
-        if (_dirty.cameraFrame) {
-          delta.cameraFrame = _activeState.cameraFrame;
-          hasContent = true;
-        }
+  async function runSafely<T>(name: string, handler: () => Promise<T>): Promise<T> {
+    if (closed) {
+      throw new McpError(ErrorCode.ConnectionClosed, 'MCP session is closed');
+    }
+    try {
+      return await handler();
+    } catch (error) {
+      if (isMcpError(error)) throw error;
+      const requestId = getRequestId();
+      console.error(`[excalimate] Tool "${name}" failed (request ID: ${requestId})`);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Internal tool error (request ID: ${requestId})`,
+      );
+    }
+  }
 
-        // Reset dirty flags
-        _dirty.scene = _dirty.timeline = _dirty.clip = _dirty.cameraFrame = false;
-
-        if (!hasContent) return;
-        onStateChange(delta);
-      } catch (err) {
-        console.error('emitChange failed:', err);
-      }
-    }, 50);
+  const tool: StateContext['tool'] = (name, description, schema, handler) => {
+    server.tool(name, description, schema, async (args: any) => runSafely(name, async () => {
+      assertInputWithinLimits(args, limits);
+      return handler(args);
+    }));
   };
 
-  (server as any).__getState = () => _activeState;
-
-  const updateState = (newState: ServerState) => {
-    _activeState = newState;
-    _stateVersion++;
-  };
-
-  const mutatingTool: StateContext['mutatingTool'] = (name, description, schema, handler, dirtyAreas) => {
+  const mutatingTool: StateContext['mutatingTool'] = (
+    name,
+    description,
+    schema,
+    handler,
+    dirtyAreas,
+  ) => {
     server.tool(name, description, schema, async (args: any) => {
-      // Snapshot before the tool mutates state
-      if (!dirtyAreas || dirtyAreas.includes('scene')) {
-        _prevElementSnapshot = snapshotElementIds(_activeState);
-      }
-      if (!dirtyAreas || dirtyAreas.includes('timeline')) {
-        _prevTrackSnapshot = snapshotTracks(_activeState);
-        _prevDuration = _activeState.timeline.duration;
-        _prevFps = _activeState.timeline.fps;
-      }
+      const operation = mutationQueue.then(() => runSafely(name, async () => {
+        assertMutationAllowed();
+        assertInputWithinLimits(args, limits);
+        const previous = cloneState(state);
+        const previousJson = JSON.stringify(previous);
+        pendingDirtyAreas.clear();
 
-      const result = await handler(args);
-      // Bump version after mutation — invalidates JSON cache
-      _stateVersion++;
-      if (dirtyAreas) {
-        for (const area of dirtyAreas) markDirty(area);
-      }
-      emitChange();
-      return result;
+        try {
+          const result = await handler(args);
+          if (closed) {
+            throw new McpError(ErrorCode.ConnectionClosed, 'MCP session is closed');
+          }
+          assertStateWithinLimits(state, limits);
+          if (JSON.stringify(state) !== previousJson) {
+            const areas = dirtyAreas
+              ? new Set(dirtyAreas)
+              : pendingDirtyAreas.size > 0
+                ? new Set(pendingDirtyAreas)
+                : new Set<DirtyArea>(['scene', 'timeline', 'clip', 'cameraFrame']);
+            publishChange(previous, areas);
+          }
+          pendingDirtyAreas.clear();
+          return result;
+        } catch (error) {
+          state = previous;
+          pendingDirtyAreas.clear();
+          throw error;
+        }
+      }));
+      mutationQueue = operation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return operation;
     });
   };
 
   return {
-    getState: () => _activeState,
-    updateState,
+    limits,
+    getState: () => state,
+    getRevision: () => revision,
+    getSequence: () => sequence,
+    getSnapshot: () => ({
+      ...cloneState(state),
+      revision,
+      sequence,
+    }),
+    getStateJSON: () => {
+      if (
+        stateJsonCache &&
+        stateJsonCache.revision === revision &&
+        stateJsonCache.sequence === sequence
+      ) {
+        return stateJsonCache.json;
+      }
+      const json = JSON.stringify({ ...state, revision, sequence });
+      stateJsonCache = { revision, sequence, json };
+      return json;
+    },
+    getSceneElementsJSON: () => JSON.stringify(state.scene.elements, null, 2),
+    getTimelineJSON: () => JSON.stringify({
+      timeline: state.timeline,
+      clipStart: state.clipStart,
+      clipEnd: state.clipEnd,
+      cameraFrame: state.cameraFrame,
+      revision,
+      sequence,
+    }, null, 2),
+    updateState: (newState) => {
+      state = newState;
+    },
     emitChange,
+    close: () => {
+      closed = true;
+      mutationTimestamps.length = 0;
+      pendingDirtyAreas.clear();
+    },
     markDirty,
+    tool,
     mutatingTool,
   };
 }

--- a/mcp-server/test/mcp.test.ts
+++ b/mcp-server/test/mcp.test.ts
@@ -1,0 +1,809 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { request as httpRequest } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import test from 'node:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { CheckpointStore } from '../src/checkpoint-store.js';
+import { MemoryCheckpointStore } from '../src/checkpoint-store.js';
+import {
+  resolveHTTPServerOptions,
+  startHTTPServer,
+} from '../src/httpServer.js';
+import type { HTTPServerHandle, HTTPServerOptions } from '../src/httpServer.js';
+import { createServer } from '../src/server.js';
+import type { ExcalimateMcpServer } from '../src/server.js';
+import type { StateDelta } from '../src/server/stateContext.js';
+import type { ServerState } from '../src/types.js';
+
+const ALLOWED_ORIGIN = 'https://app.excalimate.com';
+const MCP_HEADERS = {
+  Accept: 'application/json, text/event-stream',
+  'Content-Type': 'application/json',
+};
+
+interface RawSession {
+  sessionId: string;
+  previewUrl: string;
+}
+
+async function startTestServer(
+  options: HTTPServerOptions = {},
+  configure?: (server: ExcalimateMcpServer) => void,
+): Promise<HTTPServerHandle> {
+  return startHTTPServer((listener, resourceLimits) => {
+    const server = createServer(new MemoryCheckpointStore(), listener, { resourceLimits });
+    configure?.(server);
+    return server;
+  }, {
+    host: '127.0.0.1',
+    port: 0,
+    installSignalHandlers: false,
+    cleanupIntervalMs: 10,
+    ...options,
+  });
+}
+
+function serverBase(handle: HTTPServerHandle): string {
+  return `http://127.0.0.1:${handle.port}`;
+}
+
+function parseMcpResponse(text: string): Record<string, unknown> {
+  const dataLines = text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => line.slice(6));
+  return JSON.parse(dataLines.at(-1) ?? text) as Record<string, unknown>;
+}
+
+async function initialize(
+  handle: HTTPServerHandle,
+  extraHeaders: Record<string, string> = {},
+): Promise<RawSession> {
+  const response = await fetch(`${serverBase(handle)}/mcp`, {
+    method: 'POST',
+    headers: { ...MCP_HEADERS, ...extraHeaders },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'excalimate-test', version: '1.0.0' },
+      },
+    }),
+  });
+  const initializationBody = await response.text();
+  assert.equal(response.status, 200, initializationBody);
+  const sessionId = response.headers.get('mcp-session-id');
+  const previewUrl = response.headers.get('x-excalimate-preview-url');
+  assert.ok(sessionId);
+  assert.ok(previewUrl);
+  const initialized = await fetch(`${serverBase(handle)}/mcp`, {
+    method: 'POST',
+    headers: {
+      ...MCP_HEADERS,
+      ...extraHeaders,
+      'mcp-session-id': sessionId,
+      'mcp-protocol-version': '2025-06-18',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  });
+  const initializedBody = await initialized.text();
+  assert.ok(initialized.ok, initializedBody);
+  return { sessionId, previewUrl };
+}
+
+async function rawStatus(
+  url: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; requestId?: string }> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(url, { headers }, (response) => {
+      response.resume();
+      response.on('end', () => resolve({
+        status: response.statusCode ?? 0,
+        requestId: typeof response.headers['x-request-id'] === 'string'
+          ? response.headers['x-request-id']
+          : undefined,
+      }));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function callRawTool(
+  handle: HTTPServerHandle,
+  session: RawSession,
+  name: string,
+  args: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {},
+): Promise<Record<string, unknown>> {
+  const response = await fetch(`${serverBase(handle)}/mcp`, {
+    method: 'POST',
+    headers: {
+      ...MCP_HEADERS,
+      ...extraHeaders,
+      'mcp-session-id': session.sessionId,
+      'mcp-protocol-version': '2025-06-18',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Math.floor(Math.random() * 100_000),
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+  const text = await response.text();
+  assert.equal(response.status, 200, text);
+  return parseMcpResponse(text);
+}
+
+async function createInMemoryClient(
+  store: CheckpointStore,
+  deltas: StateDelta[] = [],
+  resourceLimits: Parameters<typeof createServer>[2]['resourceLimits'] = {},
+) {
+  const server = createServer(store, (delta) => deltas.push(delta), { resourceLimits });
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    server,
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function toolText(result: Awaited<ReturnType<Client['callTool']>>): string {
+  return result.content
+    .filter((entry) => entry.type === 'text')
+    .map((entry) => 'text' in entry ? entry.text : '')
+    .join('\n');
+}
+
+function rawToolText(message: Record<string, unknown>): string {
+  const result = message.result as {
+    content?: Array<{ type?: string; text?: string }>;
+  } | undefined;
+  return result?.content
+    ?.filter((entry) => entry.type === 'text')
+    .map((entry) => entry.text ?? '')
+    .join('\n') ?? '';
+}
+
+test('HTTP defaults to loopback and enforces Host, Origin, and browser context', async () => {
+  const resolved = resolveHTTPServerOptions({
+    host: '127.0.0.1',
+    port: 0,
+    installSignalHandlers: false,
+  });
+  assert.equal(resolved.host, '127.0.0.1');
+  assert.equal(resolved.loopback, true);
+  assert.throws(
+    () => resolveHTTPServerOptions({ host: '0.0.0.0', allowedHosts: ['example.test'] }),
+    /authentication token/,
+  );
+  assert.throws(
+    () => resolveHTTPServerOptions({
+      host: '0.0.0.0',
+      authToken: 'a-secure-token-123',
+    }),
+    /allowed hosts/,
+  );
+
+  const handle = await startTestServer();
+  try {
+    const address = handle.server.address();
+    assert.equal(typeof address === 'object' && address?.address, '127.0.0.1');
+
+    const badHost = await rawStatus(`${serverBase(handle)}/state`, {
+      Host: `evil.example:${handle.port}`,
+    });
+    assert.equal(badHost.status, 421);
+    assert.match(badHost.requestId ?? '', /^[A-Za-z0-9_-]{16}$/);
+
+    const badOrigin = await fetch(`${serverBase(handle)}/state?preview=missing`, {
+      headers: { Origin: 'https://evil.example' },
+    });
+    assert.equal(badOrigin.status, 403);
+
+    const fetchMetadataWithoutOrigin = await fetch(`${serverBase(handle)}/state?preview=missing`, {
+      headers: { 'Sec-Fetch-Site': 'cross-site' },
+    });
+    assert.equal(fetchMetadataWithoutOrigin.status, 403);
+
+    const allowed = await fetch(`${serverBase(handle)}/state?preview=missing`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+    });
+    assert.equal(allowed.status, 404);
+    assert.equal(allowed.headers.get('access-control-allow-origin'), ALLOWED_ORIGIN);
+  } finally {
+    await handle.close();
+  }
+});
+
+test('auth, body, session, and SSE limits return sanitized protocol errors', async () => {
+  const token = 'test-auth-token-12345';
+  const handle = await startTestServer({
+    authToken: token,
+    bodyLimitBytes: 512,
+    maxSessions: 1,
+    maxSseClients: 1,
+  });
+  try {
+    const unauthorized = await fetch(`${serverBase(handle)}/mcp`, {
+      method: 'POST',
+      headers: MCP_HEADERS,
+      body: '{}',
+    });
+    assert.equal(unauthorized.status, 401);
+
+    const oversized = await fetch(`${serverBase(handle)}/mcp`, {
+      method: 'POST',
+      headers: {
+        ...MCP_HEADERS,
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ payload: 'x'.repeat(1_000) }),
+    });
+    assert.equal(oversized.status, 413);
+    const oversizedBody = await oversized.text();
+    assert.doesNotMatch(oversizedBody, /stack|SyntaxError/i);
+    assert.match(oversizedBody, /requestId/);
+
+    const authHeaders = { Authorization: `Bearer ${token}` };
+    const session = await initialize(handle, authHeaders);
+    assert.match(session.previewUrl, /\/p\/[A-Za-z0-9_-]{32}\/[A-Za-z0-9_-]{43}$/);
+    const previewId = new URL(session.previewUrl).pathname.split('/')[2];
+    const leakedMasterToken = await fetch(
+      `${serverBase(handle)}/state?preview=${previewId}&token=${encodeURIComponent(token)}`,
+    );
+    assert.equal(leakedMasterToken.status, 401);
+
+    const secondSession = await fetch(`${serverBase(handle)}/mcp`, {
+      method: 'POST',
+      headers: { ...MCP_HEADERS, ...authHeaders },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'second', version: '1.0.0' },
+        },
+      }),
+    });
+    assert.equal(secondSession.status, 503);
+
+    const firstAbort = new AbortController();
+    const firstSse = await fetch(`${session.previewUrl}/live`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+      signal: firstAbort.signal,
+    });
+    assert.equal(firstSse.status, 200);
+    assert.equal(firstSse.headers.get('access-control-allow-origin'), ALLOWED_ORIGIN);
+    assert.notEqual(firstSse.headers.get('access-control-allow-origin'), '*');
+    const firstEvent = await firstSse.body?.getReader().read();
+    assert.match(new TextDecoder().decode(firstEvent?.value), /"snapshot":".*\/state"/);
+
+    const secondSse = await fetch(`${session.previewUrl}/live`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+    });
+    assert.equal(secondSse.status, 503);
+    firstAbort.abort();
+  } finally {
+    await handle.close();
+  }
+});
+
+test('preview IDs isolate sessions and snapshots carry monotonic metadata', async () => {
+  const handle = await startTestServer({ maxSessions: 2 });
+  try {
+    const first = await initialize(handle);
+    const second = await initialize(handle);
+    assert.notEqual(first.previewUrl, second.previewUrl);
+
+    await callRawTool(handle, first, 'create_scene', {
+      elements: JSON.stringify([{ id: 'first', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 }]),
+    });
+    await callRawTool(handle, second, 'create_scene', {
+      elements: JSON.stringify([{ id: 'second', type: 'ellipse', x: 0, y: 0, width: 10, height: 10 }]),
+    });
+    await callRawTool(handle, first, 'save_checkpoint', { id: 'private' });
+    const secondCheckpoints = await callRawTool(handle, second, 'list_checkpoints', {});
+    assert.equal(rawToolText(secondCheckpoints), 'No checkpoints saved.');
+    const crossSessionLoad = await callRawTool(handle, second, 'load_checkpoint', {
+      id: 'private',
+    });
+    assert.match(rawToolText(crossSessionLoad), /not found/);
+    await callRawTool(handle, first, 'add_keyframes_batch', {
+      keyframes: [{
+        targetId: 'first',
+        property: 'opacity',
+        time: 100,
+        value: 0.5,
+      }],
+    });
+
+    const firstState = await (await fetch(`${first.previewUrl}/state`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+    })).json() as ServerState & { revision: number; sequence: number };
+    const secondState = await (await fetch(`${second.previewUrl}/state`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+    })).json() as ServerState & { revision: number; sequence: number };
+    assert.deepEqual(firstState.scene.elements.map((entry) => entry.id), ['first']);
+    assert.deepEqual(secondState.scene.elements.map((entry) => entry.id), ['second']);
+    assert.equal(firstState.revision, 2);
+    assert.equal(firstState.sequence, 2);
+    assert.equal(secondState.revision, 1);
+    assert.equal(secondState.sequence, 1);
+  } finally {
+    await handle.close();
+  }
+});
+
+test('revisioned deltas detect same-count keyframe edits and legacy arrays remain compatible', async () => {
+  class EditableStore implements CheckpointStore {
+    state: ServerState | null = null;
+    async save(_id: string, state: ServerState): Promise<void> {
+      this.state = structuredClone(state);
+    }
+    async load(): Promise<ServerState | null> {
+      return this.state ? structuredClone(this.state) : null;
+    }
+    async list(): Promise<string[]> {
+      return this.state ? ['editable'] : [];
+    }
+  }
+
+  const store = new EditableStore();
+  const deltas: StateDelta[] = [];
+  const connection = await createInMemoryClient(store, deltas);
+  try {
+    const tools = await connection.client.listTools();
+    assert.equal(tools.tools.length, 29);
+    await connection.client.callTool({
+      name: 'create_scene',
+      arguments: {
+        elements: JSON.stringify([{ id: 'box', type: 'rectangle', x: 0, y: 0, width: 10, height: 10 }]),
+      },
+    });
+    const legacy = await connection.client.callTool({
+      name: 'add_keyframes_batch',
+      arguments: {
+        keyframes: JSON.stringify([{
+          targetId: 'box',
+          property: 'opacity',
+          time: 100,
+          value: 0.5,
+        }]),
+      },
+    });
+    assert.match(toolText(legacy), /Deprecated/);
+    const capturedAddDelta = deltas.at(-1);
+    const capturedTrack = connection.server.stateContext.getState().timeline.tracks[0];
+    await connection.client.callTool({
+      name: 'remove_keyframe',
+      arguments: {
+        trackId: capturedTrack.id,
+        keyframeId: capturedTrack.keyframes[0].id,
+      },
+    });
+    assert.equal(capturedAddDelta?.timeline?.upsertedTracks[0].keyframes.length, 1);
+    await connection.client.callTool({
+      name: 'add_keyframe',
+      arguments: {
+        targetId: 'box',
+        property: 'opacity',
+        time: 100,
+        value: 0.5,
+      },
+    });
+    await connection.client.callTool({
+      name: 'save_checkpoint',
+      arguments: { id: 'editable' },
+    });
+    assert.ok(store.state);
+    store.state.timeline.tracks[0].keyframes[0].value = 0.75;
+    await connection.client.callTool({
+      name: 'load_checkpoint',
+      arguments: { id: 'editable' },
+    });
+
+    const lastDelta = deltas.at(-1);
+    assert.ok(lastDelta?.timeline);
+    assert.equal(lastDelta.timeline.upsertedTracks.length, 1);
+    assert.equal(lastDelta.timeline.upsertedTracks[0].keyframes.length, 1);
+    assert.equal(lastDelta.timeline.upsertedTracks[0].keyframes[0].value, 0.75);
+    assert.equal(lastDelta.baseRevision + 1, lastDelta.revision);
+    assert.equal(lastDelta.sequence, lastDelta.revision);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('mutations are serialized and expanded sequences are rejected before allocation', async () => {
+  const delayedFailureStore: CheckpointStore = {
+    async save() {
+      await delay(30);
+      throw new Error('delayed failure');
+    },
+    async load() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+  };
+  const serialized = await createInMemoryClient(delayedFailureStore);
+  try {
+    const save = serialized.client.callTool({
+      name: 'save_checkpoint',
+      arguments: { id: 'delayed' },
+    });
+    const create = serialized.client.callTool({
+      name: 'create_scene',
+      arguments: {
+        elements: JSON.stringify([{
+          id: 'survives',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+        }]),
+      },
+    });
+    const [saveResult, createResult] = await Promise.all([save, create]);
+    assert.equal(saveResult.isError, true);
+    assert.notEqual(createResult.isError, true);
+    assert.deepEqual(
+      serialized.server.stateContext.getState().scene.elements.map((element) => element.id),
+      ['survives'],
+    );
+  } finally {
+    await serialized.close();
+  }
+
+  const bounded = await createInMemoryClient(new MemoryCheckpointStore(), [], {
+    maxTotalKeyframes: 10,
+  });
+  try {
+    const result = await bounded.client.callTool({
+      name: 'create_animated_scene',
+      arguments: {
+        elements: '[]',
+        sequences: [{
+          elementIds: ['a', 'b', 'c', 'd', 'e'],
+          startTime: 100,
+          delay: 100,
+          duration: 100,
+        }],
+      },
+    });
+    assert.equal(result.isError, true);
+    assert.match(toolText(result), /total keyframe limit/);
+    assert.equal(bounded.server.stateContext.getState().timeline.tracks.length, 0);
+  } finally {
+    await bounded.close();
+  }
+
+  const throwingServer = createServer(
+    new MemoryCheckpointStore(),
+    () => {
+      throw new Error('listener failure');
+    },
+  );
+  const throwingClient = new Client({ name: 'listener-test', version: '1.0.0' });
+  const [throwingClientTransport, throwingServerTransport] =
+    InMemoryTransport.createLinkedPair();
+  await throwingServer.connect(throwingServerTransport);
+  await throwingClient.connect(throwingClientTransport);
+  try {
+    const result = await throwingClient.callTool({
+      name: 'create_scene',
+      arguments: {
+        elements: JSON.stringify([{
+          id: 'committed',
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+        }]),
+      },
+    });
+    assert.notEqual(result.isError, true);
+    assert.equal(throwingServer.stateContext.getRevision(), 1);
+    assert.deepEqual(
+      throwingServer.stateContext.getState().scene.elements.map((element) => element.id),
+      ['committed'],
+    );
+  } finally {
+    await throwingClient.close();
+    await throwingServer.close();
+  }
+});
+
+test('SSE broadcasts preserve revision order across large and small deltas', async () => {
+  const handle = await startTestServer();
+  try {
+    const session = await initialize(handle);
+    const controller = new AbortController();
+    const response = await fetch(`${session.previewUrl}/live`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+      signal: controller.signal,
+    });
+    assert.equal(response.status, 200);
+    const reader = response.body?.getReader();
+    assert.ok(reader);
+    let buffered = '';
+    const nextEvent = async (): Promise<string> => {
+      while (!buffered.includes('\n\n')) {
+        const chunk = await reader.read();
+        assert.equal(chunk.done, false);
+        buffered += new TextDecoder().decode(chunk.value);
+      }
+      const separator = buffered.indexOf('\n\n');
+      const event = buffered.slice(0, separator);
+      buffered = buffered.slice(separator + 2);
+      return event;
+    };
+
+    await nextEvent();
+    await callRawTool(handle, session, 'create_scene', {
+      elements: JSON.stringify([{
+        id: 'large',
+        type: 'text',
+        text: 'x'.repeat(5_000),
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 20,
+      }]),
+    });
+    await callRawTool(handle, session, 'set_clip_range', { start: 0, end: 1_000 });
+
+    const revisions: number[] = [];
+    while (revisions.length < 2) {
+      const event = await nextEvent();
+      const data = event.split('\n').find((line) => line.startsWith('data: '));
+      assert.ok(data);
+      const payload = JSON.parse(data.slice(6)) as {
+        revision?: number;
+        state?: { revision?: number };
+      };
+      revisions.push(payload.revision ?? payload.state?.revision ?? -1);
+    }
+    assert.deepEqual(revisions, [1, 2]);
+    controller.abort();
+  } finally {
+    await handle.close();
+  }
+});
+
+test('nested validation, mutation rates, resource rollback, and errors are safe', async () => {
+  const failingStore: CheckpointStore = {
+    async save() {
+      throw new Error('SECRET_INTERNAL_STACK_TEXT');
+    },
+    async load() {
+      return null;
+    },
+    async list() {
+      return [];
+    },
+  };
+  const connection = await createInMemoryClient(failingStore, [], {
+    maxMutationsPerWindow: 2,
+    maxTotalKeyframes: 1,
+  });
+  try {
+    const invalid = await connection.client.callTool({
+      name: 'add_keyframes_batch',
+      arguments: {
+        keyframes: [{
+          targetId: 'box',
+          property: 'opacity',
+          time: -1,
+          value: 1,
+        }],
+      },
+    });
+    assert.equal(invalid.isError, true);
+
+    const overLimit = await connection.client.callTool({
+      name: 'add_keyframes_batch',
+      arguments: {
+        keyframes: [
+          { targetId: 'box', property: 'opacity', time: 0, value: 0 },
+          { targetId: 'box', property: 'opacity', time: 100, value: 1 },
+        ],
+      },
+    });
+    assert.equal(overLimit.isError, true);
+    assert.equal(connection.server.stateContext.getState().timeline.tracks.length, 0);
+
+    const internal = await connection.client.callTool({
+      name: 'save_checkpoint',
+      arguments: { id: 'safe-error' },
+    });
+    assert.equal(internal.isError, true);
+    const text = toolText(internal);
+    assert.doesNotMatch(text, /SECRET_INTERNAL_STACK_TEXT/);
+    assert.match(text, /Internal tool error \(request ID: [A-Za-z0-9_-]{16}\)/);
+
+    const rateLimited = await connection.client.callTool({
+      name: 'clear_animation',
+      arguments: {},
+    });
+    assert.equal(rateLimited.isError, true);
+    assert.match(toolText(rateLimited), /Mutation rate limit/);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('request timeout and stale cleanup close transports and preview SSE clients', async () => {
+  let closeCalls = 0;
+  const handle = await startTestServer({
+    requestTimeoutMs: 25,
+    sessionTtlMs: 40,
+    maxSessions: 1,
+  }, (server) => {
+    const originalClose = server.close.bind(server);
+    server.close = async () => {
+      closeCalls++;
+      await originalClose();
+    };
+    server.stateContext.tool('slow_test_tool', 'Test-only slow tool', {}, async () => {
+      await delay(100);
+      return { content: [{ type: 'text', text: 'done' }] };
+    });
+  });
+  try {
+    const session = await initialize(handle);
+    const timeoutResponse = await fetch(`${serverBase(handle)}/mcp`, {
+      method: 'POST',
+      headers: {
+        ...MCP_HEADERS,
+        'mcp-session-id': session.sessionId,
+        'mcp-protocol-version': '2025-06-18',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 8,
+        method: 'tools/call',
+        params: { name: 'slow_test_tool', arguments: {} },
+      }),
+    });
+    assert.equal(timeoutResponse.status, 504);
+    assert.match(await timeoutResponse.text(), /requestId/);
+    const blockedWhileRunning = await fetch(`${serverBase(handle)}/mcp`, {
+      method: 'POST',
+      headers: MCP_HEADERS,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 9,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'blocked', version: '1.0.0' },
+        },
+      }),
+    });
+    assert.equal(blockedWhileRunning.status, 503);
+    await delay(100);
+    assert.ok(closeCalls >= 1);
+
+    const cleanupSession = await initialize(handle);
+    const controller = new AbortController();
+    const sse = await fetch(`${cleanupSession.previewUrl}/live`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+      signal: controller.signal,
+    });
+    assert.equal(sse.status, 200);
+    await delay(100);
+    const staleState = await fetch(`${cleanupSession.previewUrl}/state`, {
+      headers: { Origin: ALLOWED_ORIGIN },
+    });
+    assert.equal(staleState.status, 404);
+    assert.equal(handle.getStats().sessions, 0);
+    assert.equal(handle.getStats().sseClients, 0);
+    controller.abort();
+  } finally {
+    await handle.close();
+  }
+});
+
+test('built CLI help and stdio initialization remain compatible', async () => {
+  const cwd = new URL('..', import.meta.url);
+  const help = await new Promise<{ code: number | null; stdout: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, ['dist/index.js', '--help'], { cwd });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout }));
+  });
+  assert.equal(help.code, 0);
+  assert.match(help.stdout, /default: 127\.0\.0\.1/);
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      'dist/index.js',
+      '--host=127.0.0.1',
+      '--port=0',
+      '--auth-token=short=1234567890123456',
+    ], { cwd });
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('inline token test timed out'));
+    }, 3_000);
+    let output = '';
+    const inspect = (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.includes('MCP server listening')) {
+        clearTimeout(timer);
+        child.kill();
+        resolve();
+      } else if (output.includes('Startup failed')) {
+        clearTimeout(timer);
+        child.kill();
+        reject(new Error(output));
+      }
+    };
+    child.stdout.on('data', inspect);
+    child.stderr.on('data', inspect);
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+
+  const stdioResult = await new Promise<Record<string, unknown>>((resolve, reject) => {
+    const child = spawn(process.execPath, ['dist/index.js', '--stdio'], { cwd });
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('stdio test timed out'));
+    }, 3_000);
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      const line = stdout.split(/\r?\n/).find(Boolean);
+      if (!line) return;
+      clearTimeout(timer);
+      child.kill();
+      resolve(JSON.parse(line) as Record<string, unknown>);
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'stdio-test', version: '1.0.0' },
+      },
+    })}\n`);
+  });
+  assert.equal(stdioResult.jsonrpc, '2.0');
+  assert.equal(stdioResult.id, 1);
+  assert.ok(stdioResult.result);
+});


### PR DESCRIPTION
## Summary

- bind HTTP mode to `127.0.0.1` by default and require token authentication for non-loopback hosts, with strict Host, Origin, Fetch Metadata, and CORS handling on `/mcp`, `/live`, and `/state`
- add bounded request/session/SSE/mutation/project resources, request deadlines with cancellation, sanitized request-ID errors, ordered SSE backpressure handling, and transport-aware stale cleanup
- replace process-global project state with per-transport state and checkpoints, add unguessable preview pairing URLs, and publish revision/sequence/base-revision metadata with full-snapshot recovery
- accept nested bounded animation arrays while retaining JSON-string inputs on the same tool names with deprecation messages
- add MCP coverage for security policy, limits, session/checkpoint isolation, revisions and same-count edits, cleanup, concurrency, sanitized errors, stdio, CLI parsing, and all 29 existing registered tools
- update CLI help, README pairing/security guidance, and benchmark harnesses

## Compatibility decisions

- stdio behavior and file-backed checkpoints are preserved
- HTTP checkpoints are intentionally scoped to the active transport to prevent cross-session access
- all 29 tools currently registered by the server are preserved (the README previously reported 23)
- legacy JSON-string animation arrays remain accepted; nested arrays are preferred
- live deltas use ordered plain JSON instead of asynchronous gzip payloads so existing web clients apply revisions in wire order

## Validation

- `npm --prefix mcp-server test`
- changed-file ESLint
- `npm test`
- `npm run build`
- small MCP benchmark smoke test