### PR TITLE
Add V2 Magic workspace and local Auto Animate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ VITE_MCP_SERVER_URL=http://localhost:3001
 # PostHog Analytics (optional — leave empty to disable analytics)
 VITE_PUBLIC_POSTHOG_KEY=
 VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# Emergency rollback: render the legacy Studio shell for every project
+# VITE_FORCE_STUDIO_SHELL=true

--- a/packages/animation-core/benchmarks/auto-animate.mjs
+++ b/packages/animation-core/benchmarks/auto-animate.mjs
@@ -1,0 +1,49 @@
+import { analyzeAutoAnimate } from '../dist/index.js';
+
+const sizes = [25, 100, 500];
+
+console.log('\nAuto-animate analyzer benchmark');
+for (const size of sizes) {
+  const elements = [];
+  for (let index = 0; index < size; index += 1) {
+    elements.push({
+      id: `node-${index}`,
+      type: 'rectangle',
+      x: (index % 20) * 140,
+      y: Math.floor(index / 20) * 100,
+      width: 100,
+      height: 60,
+      zIndex: index,
+    });
+    if (index > 0) {
+      elements.push({
+        id: `arrow-${index - 1}-${index}`,
+        type: 'arrow',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 10,
+        zIndex: size + index,
+        startBinding: { elementId: `node-${index - 1}` },
+        endBinding: { elementId: `node-${index}` },
+      });
+    }
+  }
+
+  const iterations = Math.max(5, Math.floor(2_000 / size));
+  const start = performance.now();
+  let recipeCount = 0;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    recipeCount += analyzeAutoAnimate({ elements, scope: 'diagram' }).recipes.length;
+  }
+  const elapsed = performance.now() - start;
+  console.log(
+    JSON.stringify({
+      nodes: size,
+      elements: elements.length,
+      iterations,
+      analysesPerSecond: Math.round((iterations / elapsed) * 1_000),
+      averageRecipes: Math.round(recipeCount / iterations),
+    }),
+  );
+}

--- a/packages/animation-core/package.json
+++ b/packages/animation-core/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "benchmark": "node ./benchmarks/playback.mjs"
+    "benchmark": "node ./benchmarks/playback.mjs && node ./benchmarks/auto-animate.mjs"
   },
   "dependencies": {
     "@excalimate/project-schema": "*"

--- a/packages/animation-core/src/autoAnimate.test.ts
+++ b/packages/animation-core/src/autoAnimate.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  analyzeAutoAnimate,
+  normalizeSemanticTargets,
+  type AutoAnimateElement,
+} from './autoAnimate';
+
+function node(
+  id: string,
+  x: number,
+  y: number,
+  zIndex: number,
+): AutoAnimateElement {
+  return { id, type: 'rectangle', x, y, width: 100, height: 60, zIndex };
+}
+
+function arrow(
+  id: string,
+  sourceId: string,
+  destinationId: string,
+  zIndex: number,
+): AutoAnimateElement {
+  return {
+    id,
+    type: 'arrow',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 10,
+    zIndex,
+    startBinding: { elementId: sourceId },
+    endBinding: { elementId: destinationId },
+  };
+}
+
+describe('auto animate analysis', () => {
+  it('selects a deterministic hierarchy and reveals nodes before outbound arrows', () => {
+    const elements = [
+      node('a', 0, 0, 0),
+      node('b', 200, 0, 1),
+      node('c', 400, 0, 2),
+      arrow('ab', 'a', 'b', 3),
+      arrow('bc', 'b', 'c', 4),
+    ];
+
+    const first = analyzeAutoAnimate({ elements, scope: 'diagram' });
+    const second = analyzeAutoAnimate({
+      elements: [...elements].reverse(),
+      scope: 'diagram',
+    });
+
+    expect(first).toEqual(second);
+    expect(first.strategy).toBe('hierarchical');
+    expect(first.orderedTargetIds.slice(0, 3)).toEqual(['a', 'b', 'c']);
+    expect(first.recipes.map((recipe) => recipe.targetIds[0])).toEqual([
+      'a',
+      'ab',
+      'b',
+      'bc',
+      'c',
+    ]);
+  });
+
+  it('groups bound labels and Excalidraw groups into semantic targets', () => {
+    const elements = [
+      {
+        ...node('shape', 0, 0, 0),
+        boundElements: [{ id: 'label', type: 'text' }],
+      },
+      {
+        id: 'label',
+        type: 'text',
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 20,
+        zIndex: 1,
+        containerId: 'shape',
+      },
+      { ...node('group-a', 200, 0, 2), groupIds: ['group-1'] },
+      { ...node('group-b', 220, 80, 3), groupIds: ['group-1'] },
+    ];
+    const targets = normalizeSemanticTargets(elements);
+    const analysis = analyzeAutoAnimate({ elements, scope: 'diagram' });
+
+    expect(targets).toEqual([
+      expect.objectContaining({
+        id: 'shape',
+        elementIds: ['label', 'shape'],
+      }),
+      expect.objectContaining({
+        id: 'group-1',
+        elementIds: ['group-a', 'group-b'],
+      }),
+    ]);
+    expect(analysis.recipes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetIds: ['label', 'shape'],
+          staggerMs: 0,
+        }),
+        expect.objectContaining({
+          targetIds: ['group-1'],
+          staggerMs: 0,
+        }),
+      ]),
+    );
+  });
+
+  it('does not claim hierarchy for cycles and reports ambiguity for sparse input', () => {
+    const cycle = analyzeAutoAnimate({
+      elements: [
+        node('a', 0, 0, 0),
+        node('b', 100, 100, 1),
+        node('c', 0, 200, 2),
+        arrow('ab', 'a', 'b', 3),
+        arrow('bc', 'b', 'c', 4),
+        arrow('ca', 'c', 'a', 5),
+      ],
+      scope: 'diagram',
+    });
+    const sparse = analyzeAutoAnimate({
+      elements: [node('only', 0, 0, 0)],
+      scope: 'diagram',
+    });
+
+    expect(cycle.strategy).not.toBe('hierarchical');
+    expect(cycle.reasons.some((reason) => reason.code === 'cycle-fallback')).toBe(
+      true,
+    );
+    expect(sparse).toMatchObject({
+      strategy: 'stable-z-order',
+      confidenceBand: 'low',
+      ambiguous: true,
+    });
+  });
+
+  it('limits selected analysis to selected semantic groups', () => {
+    const analysis = analyzeAutoAnimate({
+      elements: [node('a', 0, 0, 0), node('b', 200, 0, 1)],
+      scope: 'selection',
+      selectedElementIds: ['b'],
+    });
+
+    expect(analysis.semanticTargets.map((target) => target.id)).toEqual(['b']);
+    expect(analysis.reasons[0]?.code).toBe('selection-scope');
+  });
+
+  it('performs no network calls', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    analyzeAutoAnimate({
+      elements: [node('a', 0, 0, 0), node('b', 200, 0, 1)],
+      scope: 'diagram',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/animation-core/src/autoAnimate.ts
+++ b/packages/animation-core/src/autoAnimate.ts
@@ -1,0 +1,608 @@
+export type AutoAnimateScope = 'selection' | 'diagram';
+
+export type AutoAnimateStrategy =
+  | 'hierarchical'
+  | 'radial'
+  | 'timeline'
+  | 'linear-left-to-right'
+  | 'linear-top-to-bottom'
+  | 'stable-z-order';
+
+export type AutoAnimateConfidenceBand = 'low' | 'medium' | 'high';
+
+export interface AutoAnimateElement {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  isDeleted?: boolean;
+  groupIds?: readonly string[];
+  containerId?: string | null;
+  boundElements?: readonly { id: string; type: string }[];
+  startBinding?: { elementId: string } | null;
+  endBinding?: { elementId: string } | null;
+}
+
+export interface AutoAnimateRequest {
+  elements: readonly AutoAnimateElement[];
+  scope: AutoAnimateScope;
+  selectedElementIds?: readonly string[];
+}
+
+export interface AutoAnimateReason {
+  code:
+    | 'directed-graph'
+    | 'network-center'
+    | 'horizontal-flow'
+    | 'vertical-flow'
+    | 'sparse-layout'
+    | 'selection-scope'
+    | 'cycle-fallback'
+    | 'stable-fallback';
+  message: string;
+}
+
+export interface SemanticTarget {
+  id: string;
+  type: 'node' | 'connector';
+  elementIds: readonly string[];
+  centerX: number;
+  centerY: number;
+  zIndex: number;
+  sourceId?: string;
+  destinationId?: string;
+}
+
+export interface AutoAnimateRecipe {
+  targetIds: readonly string[];
+  preset: 'fade' | 'draw' | 'pop';
+  startMs: number;
+  durationMs: number;
+  staggerMs: number;
+}
+
+export interface AutoAnimateAnalysis {
+  scope: AutoAnimateScope;
+  strategy: AutoAnimateStrategy;
+  confidence: number;
+  confidenceBand: AutoAnimateConfidenceBand;
+  ambiguous: boolean;
+  reasons: readonly AutoAnimateReason[];
+  semanticTargets: readonly SemanticTarget[];
+  orderedTargetIds: readonly string[];
+  recipes: readonly AutoAnimateRecipe[];
+}
+
+interface MutableSemanticTarget {
+  id: string;
+  type: 'node' | 'connector';
+  elementIds: string[];
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+  zIndex: number;
+  sourceId?: string;
+  destinationId?: string;
+}
+
+interface GraphData {
+  nodes: SemanticTarget[];
+  connectors: SemanticTarget[];
+  outgoing: Map<string, SemanticTarget[]>;
+  incomingCount: Map<string, number>;
+  edgeCount: number;
+  hasCycle: boolean;
+}
+
+interface ScoredStrategy {
+  strategy: AutoAnimateStrategy;
+  score: number;
+}
+
+const STRATEGY_ORDER: readonly AutoAnimateStrategy[] = [
+  'hierarchical',
+  'radial',
+  'timeline',
+  'linear-left-to-right',
+  'linear-top-to-bottom',
+  'stable-z-order',
+];
+
+function compareStable(left: SemanticTarget, right: SemanticTarget): number {
+  return left.zIndex - right.zIndex || left.id.localeCompare(right.id);
+}
+
+function confidenceBand(confidence: number): AutoAnimateConfidenceBand {
+  if (confidence >= 0.8) return 'high';
+  if (confidence >= 0.6) return 'medium';
+  return 'low';
+}
+
+function isConnector(type: string): boolean {
+  return type === 'arrow' || type === 'line';
+}
+
+function addElementBounds(
+  target: MutableSemanticTarget,
+  element: AutoAnimateElement,
+): void {
+  target.minX = Math.min(target.minX, element.x, element.x + element.width);
+  target.minY = Math.min(target.minY, element.y, element.y + element.height);
+  target.maxX = Math.max(target.maxX, element.x, element.x + element.width);
+  target.maxY = Math.max(target.maxY, element.y, element.y + element.height);
+  target.zIndex = Math.min(target.zIndex, element.zIndex);
+  if (!target.elementIds.includes(element.id)) target.elementIds.push(element.id);
+}
+
+export function normalizeSemanticTargets(
+  elements: readonly AutoAnimateElement[],
+): SemanticTarget[] {
+  const active = elements
+    .filter((element) => !element.isDeleted)
+    .slice()
+    .sort((left, right) => left.zIndex - right.zIndex || left.id.localeCompare(right.id));
+  const byId = new Map(active.map((element) => [element.id, element]));
+  const elementToTarget = new Map<string, string>();
+  const targets = new Map<string, MutableSemanticTarget>();
+
+  for (const element of active) {
+    if (element.containerId && byId.has(element.containerId)) continue;
+    const targetId = element.groupIds?.[0] ?? element.id;
+    const targetType = isConnector(element.type) ? 'connector' : 'node';
+    const existing = targets.get(targetId);
+    const target =
+      existing ??
+      {
+        id: targetId,
+        type: targetType,
+        elementIds: [],
+        minX: Number.POSITIVE_INFINITY,
+        minY: Number.POSITIVE_INFINITY,
+        maxX: Number.NEGATIVE_INFINITY,
+        maxY: Number.NEGATIVE_INFINITY,
+        zIndex: Number.POSITIVE_INFINITY,
+      };
+    if (existing && existing.type !== targetType) target.type = 'node';
+    addElementBounds(target, element);
+    targets.set(targetId, target);
+    elementToTarget.set(element.id, targetId);
+  }
+
+  for (const element of active) {
+    if (!element.containerId) continue;
+    const containerTargetId = elementToTarget.get(element.containerId);
+    const target = containerTargetId ? targets.get(containerTargetId) : undefined;
+    if (!target) continue;
+    addElementBounds(target, element);
+    elementToTarget.set(element.id, target.id);
+  }
+
+  for (const element of active) {
+    const target = targets.get(elementToTarget.get(element.id) ?? '');
+    if (!target || target.type !== 'connector') continue;
+    const sourceId = element.startBinding?.elementId;
+    const destinationId = element.endBinding?.elementId;
+    const semanticSource = sourceId ? elementToTarget.get(sourceId) : undefined;
+    const semanticDestination = destinationId
+      ? elementToTarget.get(destinationId)
+      : undefined;
+    if (semanticSource && semanticSource !== target.id) {
+      target.sourceId = semanticSource;
+    }
+    if (semanticDestination && semanticDestination !== target.id) {
+      target.destinationId = semanticDestination;
+    }
+  }
+
+  return [...targets.values()]
+    .map((target) => ({
+      id: target.id,
+      type: target.type,
+      elementIds: [...target.elementIds].sort(),
+      centerX: (target.minX + target.maxX) / 2,
+      centerY: (target.minY + target.maxY) / 2,
+      zIndex: target.zIndex,
+      ...(target.sourceId ? { sourceId: target.sourceId } : {}),
+      ...(target.destinationId ? { destinationId: target.destinationId } : {}),
+    }))
+    .sort(compareStable);
+}
+
+function buildGraph(targets: readonly SemanticTarget[]): GraphData {
+  const nodes = targets.filter((target) => target.type === 'node');
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const connectors = targets.filter((target) => target.type === 'connector');
+  const outgoing = new Map<string, SemanticTarget[]>();
+  const incomingCount = new Map(nodes.map((node) => [node.id, 0]));
+  let edgeCount = 0;
+
+  for (const connector of connectors) {
+    if (
+      !connector.sourceId ||
+      !connector.destinationId ||
+      !nodeIds.has(connector.sourceId) ||
+      !nodeIds.has(connector.destinationId)
+    ) {
+      continue;
+    }
+    edgeCount += 1;
+    const sourceConnectors = outgoing.get(connector.sourceId) ?? [];
+    sourceConnectors.push(connector);
+    sourceConnectors.sort(compareStable);
+    outgoing.set(connector.sourceId, sourceConnectors);
+    incomingCount.set(
+      connector.destinationId,
+      (incomingCount.get(connector.destinationId) ?? 0) + 1,
+    );
+  }
+
+  const remainingIncoming = new Map(incomingCount);
+  const ready = nodes
+    .filter((node) => (remainingIncoming.get(node.id) ?? 0) === 0)
+    .sort(compareStable);
+  let visited = 0;
+  while (ready.length > 0) {
+    const node = ready.shift()!;
+    visited += 1;
+    for (const connector of outgoing.get(node.id) ?? []) {
+      const destinationId = connector.destinationId!;
+      const nextCount = (remainingIncoming.get(destinationId) ?? 0) - 1;
+      remainingIncoming.set(destinationId, nextCount);
+      if (nextCount === 0) {
+        const destination = nodes.find((candidate) => candidate.id === destinationId);
+        if (destination) {
+          ready.push(destination);
+          ready.sort(compareStable);
+        }
+      }
+    }
+  }
+
+  return {
+    nodes,
+    connectors,
+    outgoing,
+    incomingCount,
+    edgeCount,
+    hasCycle: visited !== nodes.length && edgeCount > 0,
+  };
+}
+
+function spread(
+  nodes: readonly SemanticTarget[],
+  coordinate: 'centerX' | 'centerY',
+): number {
+  if (nodes.length < 2) return 0;
+  const values = nodes.map((node) => node[coordinate]);
+  return Math.max(...values) - Math.min(...values);
+}
+
+function scoreStrategies(graph: GraphData): ScoredStrategy[] {
+  const { nodes, edgeCount, hasCycle, outgoing, incomingCount } = graph;
+  const xSpread = spread(nodes, 'centerX');
+  const ySpread = spread(nodes, 'centerY');
+  const totalSpread = Math.max(1, xSpread + ySpread);
+  const xShare = xSpread / totalSpread;
+  const yShare = ySpread / totalSpread;
+  const edgeDensity =
+    nodes.length > 1 ? edgeCount / Math.max(1, nodes.length - 1) : 0;
+  const degrees = nodes.map(
+    (node) =>
+      (outgoing.get(node.id)?.length ?? 0) + (incomingCount.get(node.id) ?? 0),
+  );
+  const maxDegree = degrees.length > 0 ? Math.max(...degrees) : 0;
+  const centralization =
+    edgeCount > 0 ? maxDegree / Math.max(1, edgeCount * 2) : 0;
+  const scores: ScoredStrategy[] = [];
+
+  if (edgeCount > 0 && !hasCycle) {
+    scores.push({
+      strategy: 'hierarchical',
+      score: Math.min(0.95, 0.72 + Math.min(0.23, edgeDensity * 0.2)),
+    });
+  }
+  if (nodes.length >= 4 && edgeCount >= nodes.length - 1 && centralization >= 0.3) {
+    scores.push({
+      strategy: 'radial',
+      score: Math.min(0.9, 0.61 + centralization * 0.32),
+    });
+  }
+  if (nodes.length >= 3 && xShare >= 0.72 && edgeDensity <= 1.1) {
+    scores.push({
+      strategy: 'timeline',
+      score: Math.min(0.88, 0.61 + xShare * 0.25),
+    });
+  }
+  if (nodes.length >= 2 && xShare >= 0.55) {
+    scores.push({
+      strategy: 'linear-left-to-right',
+      score: Math.min(0.79, 0.48 + xShare * 0.31),
+    });
+  }
+  if (nodes.length >= 2 && yShare >= 0.55) {
+    scores.push({
+      strategy: 'linear-top-to-bottom',
+      score: Math.min(0.79, 0.48 + yShare * 0.31),
+    });
+  }
+  scores.push({
+    strategy: 'stable-z-order',
+    score: nodes.length <= 1 ? 0.34 : hasCycle ? 0.48 : 0.43,
+  });
+
+  return scores.sort(
+    (left, right) =>
+      right.score - left.score ||
+      STRATEGY_ORDER.indexOf(left.strategy) -
+        STRATEGY_ORDER.indexOf(right.strategy),
+  );
+}
+
+function topologicalOrder(graph: GraphData): SemanticTarget[] {
+  const remainingIncoming = new Map(graph.incomingCount);
+  const byId = new Map(graph.nodes.map((node) => [node.id, node]));
+  const ready = graph.nodes
+    .filter((node) => (remainingIncoming.get(node.id) ?? 0) === 0)
+    .sort(
+      (left, right) =>
+        left.centerY - right.centerY ||
+        left.centerX - right.centerX ||
+        compareStable(left, right),
+    );
+  const ordered: SemanticTarget[] = [];
+  while (ready.length > 0) {
+    const node = ready.shift()!;
+    ordered.push(node);
+    for (const connector of graph.outgoing.get(node.id) ?? []) {
+      const destinationId = connector.destinationId!;
+      const nextCount = (remainingIncoming.get(destinationId) ?? 0) - 1;
+      remainingIncoming.set(destinationId, nextCount);
+      if (nextCount === 0) {
+        const destination = byId.get(destinationId);
+        if (destination) {
+          ready.push(destination);
+          ready.sort(
+            (left, right) =>
+              left.centerY - right.centerY ||
+              left.centerX - right.centerX ||
+              compareStable(left, right),
+          );
+        }
+      }
+    }
+  }
+  return ordered.length === graph.nodes.length
+    ? ordered
+    : graph.nodes.slice().sort(compareStable);
+}
+
+function radialOrder(graph: GraphData): SemanticTarget[] {
+  const degree = (node: SemanticTarget) =>
+    (graph.outgoing.get(node.id)?.length ?? 0) +
+    (graph.incomingCount.get(node.id) ?? 0);
+  const center =
+    graph.nodes
+      .slice()
+      .sort(
+        (left, right) =>
+          degree(right) - degree(left) || compareStable(left, right),
+      )[0] ?? null;
+  if (!center) return [];
+  return graph.nodes.slice().sort((left, right) => {
+    if (left.id === center.id) return -1;
+    if (right.id === center.id) return 1;
+    const leftDistance = Math.hypot(
+      left.centerX - center.centerX,
+      left.centerY - center.centerY,
+    );
+    const rightDistance = Math.hypot(
+      right.centerX - center.centerX,
+      right.centerY - center.centerY,
+    );
+    const leftAngle = Math.atan2(
+      left.centerY - center.centerY,
+      left.centerX - center.centerX,
+    );
+    const rightAngle = Math.atan2(
+      right.centerY - center.centerY,
+      right.centerX - center.centerX,
+    );
+    return (
+      leftDistance - rightDistance ||
+      leftAngle - rightAngle ||
+      compareStable(left, right)
+    );
+  });
+}
+
+function orderNodes(
+  strategy: AutoAnimateStrategy,
+  graph: GraphData,
+): SemanticTarget[] {
+  if (strategy === 'hierarchical') return topologicalOrder(graph);
+  if (strategy === 'radial') return radialOrder(graph);
+  if (
+    strategy === 'timeline' ||
+    strategy === 'linear-left-to-right'
+  ) {
+    return graph.nodes
+      .slice()
+      .sort(
+        (left, right) =>
+          left.centerX - right.centerX ||
+          left.centerY - right.centerY ||
+          compareStable(left, right),
+      );
+  }
+  if (strategy === 'linear-top-to-bottom') {
+    return graph.nodes
+      .slice()
+      .sort(
+        (left, right) =>
+          left.centerY - right.centerY ||
+          left.centerX - right.centerX ||
+          compareStable(left, right),
+      );
+  }
+  return graph.nodes.slice().sort(compareStable);
+}
+
+function reasonsFor(
+  strategy: AutoAnimateStrategy,
+  scope: AutoAnimateScope,
+  hasCycle: boolean,
+): AutoAnimateReason[] {
+  const reasons: AutoAnimateReason[] = [];
+  if (scope === 'selection') {
+    reasons.push({
+      code: 'selection-scope',
+      message: 'Only the selected semantic groups were analyzed.',
+    });
+  }
+  if (hasCycle && strategy !== 'radial') {
+    reasons.push({
+      code: 'cycle-fallback',
+      message: 'The connector graph contains a cycle, so a stable spatial order is used.',
+    });
+  }
+  if (strategy === 'hierarchical') {
+    reasons.push({
+      code: 'directed-graph',
+      message: 'Connector direction forms an acyclic hierarchy.',
+    });
+  } else if (strategy === 'radial') {
+    reasons.push({
+      code: 'network-center',
+      message: 'A well-connected center supports a center-out reveal.',
+    });
+  } else if (
+    strategy === 'timeline' ||
+    strategy === 'linear-left-to-right'
+  ) {
+    reasons.push({
+      code: 'horizontal-flow',
+      message: 'The layout has a stable left-to-right reading order.',
+    });
+  } else if (strategy === 'linear-top-to-bottom') {
+    reasons.push({
+      code: 'vertical-flow',
+      message: 'The layout has a stable top-to-bottom reading order.',
+    });
+  } else {
+    reasons.push({
+      code: 'stable-fallback',
+      message: 'No strong structure was detected, so canvas stacking order is used.',
+    });
+  }
+  return reasons;
+}
+
+function createRecipes(
+  strategy: AutoAnimateStrategy,
+  orderedNodes: readonly SemanticTarget[],
+  graph: GraphData,
+): AutoAnimateRecipe[] {
+  const recipes: AutoAnimateRecipe[] = [];
+  const emittedConnectors = new Set<string>();
+  let startMs = 0;
+  for (const node of orderedNodes) {
+    const nodeTargetIds = node.elementIds.includes(node.id)
+      ? node.elementIds
+      : [node.id];
+    recipes.push({
+      targetIds: nodeTargetIds,
+      preset: strategy === 'radial' ? 'pop' : 'fade',
+      startMs,
+      durationMs: 420,
+      staggerMs: 0,
+    });
+    startMs += 220;
+    for (const connector of graph.outgoing.get(node.id) ?? []) {
+      if (emittedConnectors.has(connector.id)) continue;
+      emittedConnectors.add(connector.id);
+      const connectorTargetIds = connector.elementIds.includes(connector.id)
+        ? connector.elementIds
+        : [connector.id];
+      recipes.push({
+        targetIds: connectorTargetIds,
+        preset: 'draw',
+        startMs,
+        durationMs: 520,
+        staggerMs: 0,
+      });
+      startMs += 160;
+    }
+  }
+  for (const connector of graph.connectors.slice().sort(compareStable)) {
+    if (emittedConnectors.has(connector.id)) continue;
+    const connectorTargetIds = connector.elementIds.includes(connector.id)
+      ? connector.elementIds
+      : [connector.id];
+    recipes.push({
+      targetIds: connectorTargetIds,
+      preset: 'draw',
+      startMs,
+      durationMs: 520,
+      staggerMs: 0,
+    });
+    startMs += 160;
+  }
+  return recipes;
+}
+
+export function analyzeAutoAnimate(
+  request: AutoAnimateRequest,
+): AutoAnimateAnalysis {
+  const normalized = normalizeSemanticTargets(request.elements);
+  const selectedIds = new Set(request.selectedElementIds ?? []);
+  const scoped =
+    request.scope === 'selection'
+      ? normalized.filter(
+          (target) =>
+            selectedIds.has(target.id) ||
+            target.elementIds.some((id) => selectedIds.has(id)),
+        )
+      : normalized;
+  const selectedSemanticIds = new Set(scoped.map((target) => target.id));
+  const targets = scoped.map((target) => ({
+    ...target,
+    ...(target.sourceId && selectedSemanticIds.has(target.sourceId)
+      ? { sourceId: target.sourceId }
+      : { sourceId: undefined }),
+    ...(target.destinationId && selectedSemanticIds.has(target.destinationId)
+      ? { destinationId: target.destinationId }
+      : { destinationId: undefined }),
+  }));
+  const graph = buildGraph(targets);
+  const scored = scoreStrategies(graph);
+  const winner = scored[0]!;
+  const runnerUp = scored[1];
+  const confidence = Number(winner.score.toFixed(2));
+  const ambiguous =
+    confidence < 0.6 ||
+    (runnerUp !== undefined && winner.score - runnerUp.score < 0.06);
+  const orderedNodes = orderNodes(winner.strategy, graph);
+  const orderedConnectors = graph.connectors
+    .slice()
+    .sort(compareStable)
+    .map((connector) => connector.id);
+
+  return {
+    scope: request.scope,
+    strategy: winner.strategy,
+    confidence,
+    confidenceBand: confidenceBand(confidence),
+    ambiguous,
+    reasons: reasonsFor(winner.strategy, request.scope, graph.hasCycle),
+    semanticTargets: targets,
+    orderedTargetIds: [
+      ...orderedNodes.map((node) => node.id),
+      ...orderedConnectors,
+    ],
+    recipes: createRecipes(winner.strategy, orderedNodes, graph),
+  };
+}

--- a/packages/animation-core/src/index.ts
+++ b/packages/animation-core/src/index.ts
@@ -5,3 +5,4 @@ export * from './interpolation.js';
 export * from './models.js';
 export * from './runtime.js';
 export * from './compiler.js';
+export * from './autoAnimate.js';

--- a/packages/project-schema/src/index.ts
+++ b/packages/project-schema/src/index.ts
@@ -55,7 +55,7 @@ export const ANIMATABLE_PROPERTIES = [
 ] as const;
 
 export const ASPECT_RATIOS = ['16:9', '4:3', '1:1', '3:2'] as const;
-export const PREFERRED_WORKSPACES = ['magic', 'sequence'] as const;
+export const PREFERRED_WORKSPACES = ['magic', 'sequence', 'studio'] as const;
 export const ANIMATION_ACTION_TYPES = [
   'fade',
   'slide',
@@ -550,6 +550,8 @@ export function migrateV1Project(input: unknown): ProjectDocument {
       clipEnd,
       cameraFrame: legacy.cameraFrame ?? createDefaultCameraFrame(),
     },
+    preferredWorkspace:
+      legacy.timeline.tracks.length > 0 ? 'studio' : 'magic',
   };
 
   return parseWithSchema(

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,278 +1,79 @@
-import { Suspense, lazy, useEffect, useCallback } from 'react';
-import { MantineProvider, CloseButton, ActionIcon, Tooltip } from '@mantine/core';
-import { IconLayoutSidebarLeftExpand, IconChevronUp } from '@tabler/icons-react';
+import { useEffect, useMemo } from 'react';
+import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { ModalsProvider } from '@mantine/modals';
 import { NavigationProgress } from '@mantine/nprogress';
-import { Toolbar } from '../Toolbar';
-import { LayersPanel } from '../Layers/LayersPanel';
-import { SequenceRevealPanel } from '../SequenceReveal/SequenceRevealPanel';
-import { WelcomeOverlay } from '../Onboarding/WelcomeOverlay';
-import { ToolbarHints } from '../Onboarding/ToolbarHints';
-import { ErrorBoundary } from '../common/ErrorBoundary';
 import { McpSetupGuide } from '../Pages/McpSetupGuide';
-import { useAnimationStore } from '../../stores/animationStore';
-import { useProjectStore } from '../../stores/projectStore';
+import { ConsentBanner } from '../ConsentBanner';
+import { MagicWorkspace } from '../Workspace/MagicWorkspace';
+import { StudioWorkspace } from '../Workspace/StudioWorkspace';
 import { useUIStore } from '../../stores/uiStore';
 import { useAppHotkeys } from '../../hooks/useAppHotkeys';
 import { useAutoSave } from '../../hooks/useAutoSave';
-import { ConsentBanner } from '../ConsentBanner';
 import { getPlaybackController } from '../../core/engine/playbackSingleton';
 import { useShareLoader } from './useShareLoader';
-import { useSceneChangeSync } from './useSceneChangeSync';
-import { useSelectionDerivedState } from './useSelectionDerivedState';
-import { useKeyframeActions } from './useKeyframeActions';
-import { TimelinePanelWrapper } from './TimelinePanelWrapper';
-import { PropertyPanelWrapper } from './PropertyPanelWrapper';
-
-// Lazy-load heavy editor components — each pulls in @excalidraw/excalidraw (~2MB).
-// Only the active mode's editor is loaded, reducing initial bundle size.
-const ExcalidrawEditor = lazy(() =>
-  import('../Canvas/ExcalidrawEditor').then((m) => ({ default: m.ExcalidrawEditor })),
-);
-const AnimateCanvasWrapper = lazy(() =>
-  import('./AnimateCanvasWrapper').then((m) => ({ default: m.AnimateCanvasWrapper })),
-);
+import { getWorkspaceShellFlags } from '../../core/workspace/workspaceFlags';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
 
 export function App() {
   useAppHotkeys();
-
   getPlaybackController();
+
+  const shellFlags = useMemo(() => getWorkspaceShellFlags(), []);
   const shareLoadState = useShareLoader();
   const recoveryReady = useAutoSave({
     restoreLocal: shareLoadState === 'idle',
     enabled: shareLoadState !== 'loading',
   });
   const startupReady = shareLoadState !== 'loading' && recoveryReady;
+  const theme = useUIStore((state) => state.theme);
+  const workspace = useUIStore((state) => state.workspace);
+  const activePage = useUIStore((state) => state.activePage);
 
-  // Prevent browser zoom on Ctrl+Scroll anywhere in the app.
-  // The Excalidraw canvas handles its own zoom internally.
   useEffect(() => {
-    const handler = (e: WheelEvent) => {
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault();
-      }
+    const handler = (event: WheelEvent) => {
+      if (event.ctrlKey || event.metaKey) event.preventDefault();
     };
     document.addEventListener('wheel', handler, { passive: false });
     return () => document.removeEventListener('wheel', handler);
   }, []);
 
-  // Apply theme to the document element and Mantine color scheme
-  const theme = useUIStore((s) => s.theme);
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
 
-  const mantineColorScheme = theme === 'dark' ? 'dark' : 'light';
+  useEffect(() => {
+    if (!startupReady || !shellFlags.workspaceOverride) return;
+    useUIStore.getState().hydrateWorkspace(shellFlags.workspaceOverride);
+    trackCreatorEvent('creator_workspace_changed', {
+      workspace: shellFlags.workspaceOverride,
+      source: 'query',
+    });
+  }, [shellFlags.workspaceOverride, startupReady]);
 
-  // Page navigation — render a full-screen page instead of the main app
-  const activePage = useUIStore((s) => s.activePage);
-
-  // Use selectors to avoid over-subscription
-  const mode = useUIStore((s) => s.mode);
-  const selectedElementIds = useUIStore((s) => s.selectedElementIds);
-  const sequenceRevealOpen = useUIStore((s) => s.sequenceRevealOpen);
-  const layersPanelOpen = useUIStore((s) => s.layersPanelOpen);
-  const timelinePanelOpen = useUIStore((s) => s.timelinePanelOpen);
-  const targets = useProjectStore((s) => s.targets);
-  const project = useProjectStore((s) => s.project);
-  const cameraFrame = useProjectStore((s) => s.cameraFrame);
-  const timeline = useAnimationStore((s) => s.timeline);
-  const selectedTrackId = useAnimationStore((s) => s.selectedTrackId);
-  const selectedKeyframeIds = useAnimationStore((s) => s.selectedKeyframeIds);
-  const clipStart = useAnimationStore((s) => s.clipStart);
-  const clipEnd = useAnimationStore((s) => s.clipEnd);
-
-  const { handleSceneChange, handleElementsSelected } = useSceneChangeSync();
-  const {
-    targetLabels,
-    targetOrder,
-    targetParents,
-    selectedTargets,
-    selectedTargetTracks,
-    selectedKeyframeDetails,
-  } = useSelectionDerivedState({
-    targets,
-    timeline,
-    selectedElementIds,
-    selectedKeyframeIds,
-  });
-  const {
-    handleScrub,
-    handleSelectTrack,
-    handleSelectKeyframes,
-    handleAddKeyframe,
-    handleMoveKeyframe,
-    handleRemoveKeyframe,
-    handleToggleTrackEnabled,
-    handleRemoveTrack,
-    handleUpdateKeyframe,
-    handleSelectTarget,
-    handleSelectElements,
-    handleAddOrUpdateKeyframe,
-    handleDragElement,
-    handleAddTrackProp,
-    handleResizeElement,
-    handleRotateElement,
-  } = useKeyframeActions();
-
-  const closePropertyPanel = useCallback(() => {
-    useUIStore.getState().setSelectedElements([]);
-    useAnimationStore.getState().clearKeyframeSelection();
-  }, []);
+  const content = activePage === 'mcp-guide' ? (
+    <McpSetupGuide />
+  ) : startupReady ? (
+    shellFlags.forceStudioShell ? (
+      <StudioWorkspace legacyShell />
+    ) : workspace === 'magic' ? (
+      <MagicWorkspace />
+    ) : (
+      <StudioWorkspace />
+    )
+  ) : null;
 
   return (
-    <MantineProvider forceColorScheme={mantineColorScheme}>
+    <MantineProvider
+      forceColorScheme={theme}
+      theme={{ respectReducedMotion: true }}
+    >
       <ModalsProvider>
         <Notifications position="bottom-right" />
         <NavigationProgress />
-        {activePage === 'mcp-guide' ? (
-          <McpSetupGuide />
-        ) : startupReady ? (
-        <div className="flex flex-col h-screen w-screen bg-surface text-text">
-          {/* Top toolbar */}
-          <Toolbar />
-          <ToolbarHints />
-
-      {/* Main content area */}
-      <div className="flex flex-1 overflow-hidden px-2 pb-2 gap-2">
-        {/* Left: Layers panel (animate mode only) */}
-        {mode === 'animate' && layersPanelOpen && (
-          <aside data-hint="layers" className="w-[200px] border border-border bg-surface rounded-lg shadow-float overflow-y-auto shrink-0">
-            <LayersPanel
-              targets={targets}
-              tracks={timeline.tracks}
-              selectedElementIds={selectedElementIds}
-              onSelectElements={handleSelectElements}
-            />
-          </aside>
-        )}
-
-        {/* Center: Canvas area */}
-        <main className="flex-1 relative overflow-hidden bg-surface rounded-lg border border-border shadow-float">
-          <ErrorBoundary fallback={<div className="flex items-center justify-center h-full text-sm text-danger">Canvas error</div>}>
-            <Suspense fallback={<div className="flex items-center justify-center h-full text-sm text-text-muted">Loading editor…</div>}>
-            {mode === 'edit' ? (
-              <ExcalidrawEditor
-                key={project?.id ?? 'empty'}
-                onSceneChange={handleSceneChange}
-                onElementsSelected={handleElementsSelected}
-                initialData={project?.scene}
-              />
-            ) : (
-              <AnimateCanvasWrapper
-                scene={project?.scene ?? null}
-                targets={targets}
-                selectedElementIds={selectedElementIds}
-                cameraFrame={cameraFrame}
-                onSelectElements={handleSelectElements}
-                onDragElement={handleDragElement}
-                onResizeElement={handleResizeElement}
-                onRotateElement={handleRotateElement}
-              />
-            )}
-            </Suspense>
-          </ErrorBoundary>
-          {/* Onboarding hints for empty projects */}
-          <WelcomeOverlay />
-          {/* Sequence Reveal Panel (floating) */}
-          {mode === 'animate' && sequenceRevealOpen && (
-            <SequenceRevealPanel
-              targets={targets}
-              selectedElementIds={selectedElementIds}
-            />
-          )}
-          {/* Layers toggle (floating, animate mode only, visible when panel is closed) */}
-          {mode === 'animate' && !layersPanelOpen && (
-            <div className="absolute top-2 left-2 z-20">
-              <Tooltip label="Show layers" position="right">
-                <ActionIcon
-                  variant="filled"
-                  color="indigo"
-                  size="md"
-                  onClick={() => useUIStore.getState().toggleLayersPanel()}
-                >
-                  <IconLayoutSidebarLeftExpand size={18} />
-                </ActionIcon>
-              </Tooltip>
-            </div>
-          )}
-          {/* Timeline toggle (floating, visible when the timeline is collapsed) */}
-          {!timelinePanelOpen && (
-            <div className="absolute bottom-2 right-2 z-20">
-              <Tooltip label="Show timeline" position="left">
-                <ActionIcon
-                  variant="filled"
-                  color="indigo"
-                  size="md"
-                  onClick={() => useUIStore.getState().toggleTimelinePanel()}
-                >
-                  <IconChevronUp size={18} />
-                </ActionIcon>
-              </Tooltip>
-            </div>
-          )}
-        </main>
-
-        {/* Right: Property panel (visible when elements or keyframes selected) */}
-        {(selectedTargets.length > 0 || selectedKeyframeIds.length > 0) && (
-        <aside className="w-[280px] border border-border bg-surface rounded-lg shadow-float overflow-hidden shrink-0 flex flex-col">
-          <div className="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0">
-            <span className="text-[10px] text-text-muted uppercase tracking-wider font-semibold">Properties</span>
-            <CloseButton size="sm" onClick={closePropertyPanel} />
-          </div>
-          <div className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={<div className="flex items-center justify-center h-full text-sm text-danger">Property panel error</div>}>
-            <PropertyPanelWrapper
-              selectedTargets={selectedTargets}
-              allTargets={targets}
-              tracks={selectedTargetTracks}
-              selectedKeyframes={selectedKeyframeDetails}
-              onAddTrack={handleAddTrackProp}
-              onAddOrUpdateKeyframe={handleAddOrUpdateKeyframe}
-              onUpdateKeyframe={handleUpdateKeyframe}
-              onDeleteKeyframe={handleRemoveKeyframe}
-              onSelectTarget={handleSelectTarget}
-            />
-          </ErrorBoundary>
-          </div>
-        </aside>
-        )}
-      </div>
-
-      {/* Bottom: Timeline panel */}
-      {timelinePanelOpen && (
-      <div data-hint="timeline" className="h-[250px] mx-2 mb-2 border border-border bg-surface-alt rounded-lg shadow-float overflow-hidden">
-        <ErrorBoundary fallback={<div className="flex items-center justify-center h-full text-sm text-danger">Timeline error</div>}>
-        <TimelinePanelWrapper
-          tracks={timeline.tracks}
-          duration={timeline.duration}
-          selectedTrackId={selectedTrackId}
-          rawSelectedKeyframeIds={selectedKeyframeIds}
-          clipStart={clipStart}
-          clipEnd={clipEnd}
-          onSelectTrack={handleSelectTrack}
-          onSelectKeyframes={handleSelectKeyframes}
-          onAddKeyframe={handleAddKeyframe}
-          onMoveKeyframe={handleMoveKeyframe}
-          onDeleteKeyframe={handleRemoveKeyframe}
-          onScrub={handleScrub}
-          onToggleTrackEnabled={handleToggleTrackEnabled}
-          onRemoveTrack={handleRemoveTrack}
-          onClipRangeChange={(start, end) => useAnimationStore.getState().setClipRange(start, end)}
-          targetLabels={targetLabels}
-          targetOrder={targetOrder}
-          targetParents={targetParents}
-          selectedElementIds={selectedElementIds}
-          onCollapse={() => useUIStore.getState().toggleTimelinePanel()}
-        />
-        </ErrorBoundary>
-      </div>
-      )}
-    </div>
-        ) : null}
+        {content}
         <ConsentBanner />
-        </ModalsProvider>
-      </MantineProvider>
+      </ModalsProvider>
+    </MantineProvider>
   );
 }

--- a/src/components/Onboarding/WelcomeOverlay.test.tsx
+++ b/src/components/Onboarding/WelcomeOverlay.test.tsx
@@ -1,0 +1,117 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import { WelcomeOverlay } from './WelcomeOverlay';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  importFile: vi.fn(async () => undefined),
+  openProject: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../hooks/useMcpLive', () => ({
+  useMcpLive: () => ({
+    connected: false,
+    connect: mocks.connect,
+  }),
+}));
+
+vi.mock('../Toolbar/useFileOperations', () => ({
+  useFileOperations: () => ({
+    handleImportFile: mocks.importFile,
+    handleLoadProjectFile: mocks.openProject,
+  }),
+}));
+
+describe('WelcomeOverlay', () => {
+  beforeEach(() => {
+    mocks.connect.mockClear();
+    mocks.importFile.mockClear();
+    mocks.openProject.mockClear();
+    useProjectStore.setState({
+      project: null,
+      targets: [],
+      isDirty: false,
+    });
+    useUIStore.setState({
+      workspace: 'magic',
+      canvasMode: 'design',
+      mode: 'edit',
+      startSurfaceDismissed: false,
+    });
+  });
+
+  function renderOverlay() {
+    return render(
+      <MantineProvider>
+        <WelcomeOverlay />
+      </MantineProvider>,
+    );
+  }
+
+  it('exposes labeled, keyboard-operable Magic start actions', () => {
+    renderOverlay();
+
+    expect(
+      screen.getByRole('heading', { name: 'Start with the canvas' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Drop an Excalidraw or Excalimate file'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Start from a template' }),
+    ).toBeDisabled();
+
+    const startDrawing = screen.getByRole('button', {
+      name: 'Start drawing',
+    });
+    startDrawing.focus();
+    fireEvent.keyDown(startDrawing, { key: 'Enter' });
+    fireEvent.click(startDrawing);
+
+    expect(useUIStore.getState().startSurfaceDismissed).toBe(true);
+  });
+
+  it('routes import, open, and MCP actions through existing services', async () => {
+    const { container } = renderOverlay();
+    const importInput = container.querySelector<HTMLInputElement>(
+      'input[accept^=".excalidraw"]',
+    );
+    const importFile = new File(['{}'], 'scene.excalidraw', {
+      type: 'application/json',
+    });
+    const projectFile = new File(['{}'], 'project.excanim', {
+      type: 'application/json',
+    });
+
+    fireEvent.change(importInput!, { target: { files: [importFile] } });
+    await waitFor(() => expect(mocks.importFile).toHaveBeenCalledWith(importFile));
+
+    act(() => useUIStore.getState().setStartSurfaceDismissed(false));
+    let openInput: HTMLInputElement | null = null;
+    await waitFor(() => {
+      openInput = container.querySelector<HTMLInputElement>(
+        'input[accept^=".excanim"]',
+      );
+      expect(openInput).not.toBeNull();
+    });
+    fireEvent.change(openInput!, {
+      target: { files: [projectFile] },
+    });
+    await waitFor(() =>
+      expect(mocks.openProject).toHaveBeenCalledWith(projectFile),
+    );
+
+    act(() => useUIStore.getState().setStartSurfaceDismissed(false));
+    fireEvent.click(screen.getByRole('button', { name: 'Connect MCP' }));
+    expect(mocks.connect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Onboarding/WelcomeOverlay.tsx
+++ b/src/components/Onboarding/WelcomeOverlay.tsx
@@ -1,127 +1,257 @@
-import { Stack, Text } from '@mantine/core';
+import { useState } from 'react';
 import {
-  IconFolderOpen,
-  IconFileImport,
+  Box,
+  Button,
+  FileButton,
+  Group,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { Dropzone } from '@mantine/dropzone';
+import { notifications } from '@mantine/notifications';
+import {
   IconBroadcast,
-  IconServer,
+  IconFileImport,
+  IconFolderOpen,
+  IconPencil,
+  IconSparkles,
 } from '@tabler/icons-react';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
-import { useAnimationStore } from '../../stores/animationStore';
+import { useFileOperations } from '../Toolbar/useFileOperations';
+import { useMcpLive } from '../../hooks/useMcpLive';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
 
-/**
- * Non-intrusive onboarding content shown on the canvas for empty projects.
- * Styled after Excalidraw's welcome screen — centered logo, helpful message,
- * and quick action links. Disappears automatically when user starts working.
- */
 export function WelcomeOverlay() {
-  const mode = useUIStore((s) => s.mode);
-  const drawToolActive = useUIStore((s) => s.drawToolActive);
-  const hasSelection = useUIStore((s) => s.selectedElementIds.length > 0);
-  const theme = useUIStore((s) => s.theme);
-  const targets = useProjectStore((s) => s.targets);
-  const tracks = useAnimationStore((s) => s.timeline.tracks);
+  const [loading, setLoading] = useState(false);
+  const project = useProjectStore((state) => state.project);
+  const workspace = useUIStore((state) => state.workspace);
+  const canvasMode = useUIStore((state) => state.canvasMode);
+  const dismissed = useUIStore((state) => state.startSurfaceDismissed);
+  const theme = useUIStore((state) => state.theme);
+  const { handleImportFile, handleLoadProjectFile } = useFileOperations();
+  const { connected, connect } = useMcpLive();
+  const hasElements =
+    project?.scene.elements.some((element) => !element.isDeleted) ?? false;
 
-  const hasElements = targets.length > 1;
-  const hasTracks = tracks.length > 0;
+  if (
+    workspace !== 'magic' ||
+    canvasMode !== 'design' ||
+    hasElements ||
+    dismissed
+  ) {
+    return null;
+  }
 
-  // Hide when the user has content or is actively interacting
-  if (mode === 'edit' && (hasElements || drawToolActive)) return null;
-  if (mode === 'animate' && (hasTracks || hasSelection)) return null;
+  const finishStart = (
+    path:
+      | 'draw'
+      | 'import-excalidraw'
+      | 'open-project'
+      | 'mcp'
+      | 'template-teaser',
+  ) => {
+    if (path === 'draw' || path === 'mcp' || path === 'template-teaser') {
+      trackCreatorEvent('creator_project_started', { path });
+    }
+    useUIStore.getState().setStartSurfaceDismissed(true);
+  };
+
+  const runFileAction = async (
+    file: File | null,
+    kind: 'import' | 'open',
+  ) => {
+    if (!file) return;
+    try {
+      setLoading(true);
+      if (kind === 'open') {
+        await handleLoadProjectFile(file);
+        finishStart('open-project');
+      } else {
+        await handleImportFile(file);
+        finishStart('import-excalidraw');
+      }
+    } catch (error) {
+      notifications.show({
+        title: kind === 'open' ? 'Could not open project' : 'Could not import file',
+        message:
+          error instanceof Error ? error.message : 'The selected file is invalid.',
+        color: 'red',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
-    <div className="absolute inset-0 z-10 pointer-events-none flex items-center justify-center">
-      <Stack gap="md" align="center" className="pointer-events-none">
-        {/* Logo */}
-        <img
-          src={theme === 'dark' ? '/excalimate_logo_dark.svg' : '/excalimate_logo.svg'}
-          alt="Excalimate"
-          className="h-12 opacity-80"
-        />
-
-        {/* Helpful message */}
-        <Text
-          ta="center"
-          style={{
-            fontFamily: '"Virgil", "Segoe Print", "Comic Sans MS", cursive',
-            fontSize: '18px',
-            lineHeight: 1.6,
-            color: 'var(--color-text-muted)',
-            opacity: 0.55,
-            whiteSpace: 'pre-line',
-          }}
-        >
-          {mode === 'edit'
-            ? 'Draw something on the canvas,\nor use the actions below to get started.'
-            : hasElements
-              ? 'Select an element, then add\nkeyframes in the Properties panel.'
-              : 'Switch to Edit mode and\ndraw some shapes first.'
-          }
-        </Text>
-
-        {/* Quick action links */}
-        {mode === 'edit' && (
-          <Stack gap={4} className="pointer-events-auto" mt="xs">
-            <ActionLink
-              icon={<IconFolderOpen size={16} />}
-              label="Open"
-              onClick={() => {
-                document.querySelector<HTMLButtonElement>('[data-hint="file"] button')?.click();
-              }}
-            />
-            <ActionLink
-              icon={<IconFileImport size={16} />}
-              label="Import Excalidraw"
-              onClick={() => {
-                document.querySelector<HTMLButtonElement>('[data-hint="file"] button')?.click();
-              }}
-            />
-            <ActionLink
-              icon={<IconBroadcast size={16} />}
-              label="Connect to MCP server"
-              onClick={() => {
-                document.querySelector<HTMLButtonElement>('[data-hint="live"] button')?.click();
-              }}
-            />
-            <ActionLink
-              icon={<IconServer size={16} />}
-              label="MCP Setup Guide"
-              onClick={() => useUIStore.getState().setActivePage('mcp-guide')}
-            />
-          </Stack>
-        )}
-      </Stack>
-    </div>
-  );
-}
-
-function ActionLink({
-  icon,
-  label,
-  onClick,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex items-center gap-3 px-3 py-1.5 rounded-md hover:bg-accent-muted transition-colors text-left cursor-pointer"
-      style={{ minWidth: 200 }}
+    <Box
+      pos="absolute"
+      inset={0}
+      style={{
+        zIndex: 20,
+        pointerEvents: 'none',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 'clamp(12px, 4vw, 40px)',
+      }}
     >
-      <span className="text-text-muted opacity-60">{icon}</span>
-      <span
-        className="flex-1 text-text-muted"
-        style={{
-          fontFamily: '"Virgil", "Segoe Print", "Comic Sans MS", cursive',
-          fontSize: '15px',
-          opacity: 0.6,
-        }}
+      <Paper
+        component="section"
+        aria-labelledby="magic-start-title"
+        withBorder
+        shadow="xl"
+        radius="lg"
+        p={{ base: 'md', sm: 'xl' }}
+        maw={720}
+        w="100%"
+        style={{ pointerEvents: 'auto' }}
       >
-        {label}
-      </span>
-    </button>
+        <Stack gap="lg">
+          <Stack gap={6} align="center">
+            <img
+              src={
+                theme === 'dark'
+                  ? '/excalimate_logo_dark.svg'
+                  : '/excalimate_logo.svg'
+              }
+              alt="Excalimate"
+              style={{ height: 38, maxWidth: '70%' }}
+            />
+            <Title id="magic-start-title" order={2} ta="center">
+              Start with the canvas
+            </Title>
+            <Text c="dimmed" ta="center" maw={520}>
+              Draw freely, bring in an Excalidraw scene, or open an Excalimate
+              project. Animation controls appear as soon as the canvas has content.
+            </Text>
+          </Stack>
+
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+            <Button
+              size="lg"
+              leftSection={<IconPencil size={20} aria-hidden="true" />}
+              onClick={() => {
+                finishStart('draw');
+                requestAnimationFrame(() =>
+                  document.querySelector<HTMLElement>('.excalidraw')?.focus(),
+                );
+              }}
+            >
+              Start drawing
+            </Button>
+            <FileButton
+              onChange={(file) => void runFileAction(file, 'import')}
+              accept=".excalidraw,.json,application/json"
+            >
+              {(props) => (
+                <Button
+                  {...props}
+                  size="lg"
+                  variant="light"
+                  loading={loading}
+                  leftSection={<IconFileImport size={20} aria-hidden="true" />}
+                >
+                  Import Excalidraw
+                </Button>
+              )}
+            </FileButton>
+            <FileButton
+              onChange={(file) => void runFileAction(file, 'open')}
+              accept=".excanim,.json,application/json"
+            >
+              {(props) => (
+                <Button
+                  {...props}
+                  size="lg"
+                  variant="light"
+                  loading={loading}
+                  leftSection={<IconFolderOpen size={20} aria-hidden="true" />}
+                >
+                  Open Excalimate
+                </Button>
+              )}
+            </FileButton>
+            <Button
+              size="lg"
+              variant="light"
+              color={connected ? 'green' : 'indigo'}
+              leftSection={<IconBroadcast size={20} aria-hidden="true" />}
+              onClick={() => {
+                try {
+                  connect();
+                  finishStart('mcp');
+                  notifications.show({
+                    title: 'Connecting to MCP',
+                    message: 'The local live connection is starting.',
+                    color: 'indigo',
+                  });
+                } catch (error) {
+                  notifications.show({
+                    title: 'MCP connection failed',
+                    message:
+                      error instanceof Error
+                        ? error.message
+                        : 'Check the MCP server settings.',
+                    color: 'red',
+                  });
+                }
+              }}
+            >
+              {connected ? 'MCP connected' : 'Connect MCP'}
+            </Button>
+          </SimpleGrid>
+
+          <Dropzone
+            aria-label="Drop an Excalidraw or Excalimate file"
+            loading={loading}
+            multiple={false}
+            onDrop={(files) => {
+              const file = files[0];
+              if (!file) return;
+              const isProject = file.name.toLowerCase().endsWith('.excanim');
+              void runFileAction(file, isProject ? 'open' : 'import');
+            }}
+            onReject={() =>
+              notifications.show({
+                title: 'Unsupported file',
+                message: 'Drop an Excalidraw JSON or .excanim project.',
+                color: 'yellow',
+              })
+            }
+          >
+            <Group justify="center" gap="xs" mih={54}>
+              <IconFileImport
+                size={22}
+                color="var(--mantine-color-dimmed)"
+                aria-hidden="true"
+              />
+              <Text size="sm" c="dimmed" ta="center">
+                Drop an Excalidraw or Excalimate file here
+              </Text>
+            </Group>
+          </Dropzone>
+
+          <Button
+            variant="subtle"
+            disabled
+            leftSection={<IconSparkles size={18} aria-hidden="true" />}
+            aria-describedby="template-teaser-description"
+          >
+            Start from a template
+          </Button>
+          <Text
+            id="template-teaser-description"
+            size="xs"
+            c="dimmed"
+            ta="center"
+          >
+            Templates are coming in a later release.
+          </Text>
+        </Stack>
+      </Paper>
+    </Box>
   );
 }

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -18,8 +18,9 @@ import { ExportControls } from './ExportControls';
 import { InfoLinks } from './InfoLinks';
 import { useUIStore } from '../../stores/uiStore';
 import { useMcpLive, getMcpUrl } from '../../hooks/useMcpLive';
+import { WorkspaceSwitcher } from '../Workspace/WorkspaceSwitcher';
 
-export function Toolbar() {
+export function Toolbar({ legacyShell = false }: { legacyShell?: boolean }) {
   const ghostMode = useUIStore((s) => s.ghostMode);
   const sequenceRevealOpen = useUIStore((s) => s.sequenceRevealOpen);
   const theme = useUIStore((s) => s.theme);
@@ -128,7 +129,8 @@ export function Toolbar() {
       </div>
 
       {/* Center section: Mode switcher */}
-      <div className="flex-1 flex justify-center" data-hint="mode">
+      <div className="flex-1 flex justify-center items-center gap-3" data-hint="mode">
+        {!legacyShell && <WorkspaceSwitcher />}
         <ModeSwitcher />
       </div>
 

--- a/src/components/Toolbar/useFileOperations.ts
+++ b/src/components/Toolbar/useFileOperations.ts
@@ -17,7 +17,14 @@ import {
   captureProjectDocument,
   loadProjectDocumentIntoStores,
 } from '../../services/ProjectDocumentService';
-import { trackNewProject, trackSaveProject, trackLoadProject, trackImport } from '../../services/analytics/posthog';
+import {
+  trackCreatorEvent,
+  trackImport,
+  trackLoadProject,
+  trackNewProject,
+  trackSaveProject,
+} from '../../services/analytics/posthog';
+import { useUIStore } from '../../stores/uiStore';
 
 function resetTimeline() {
   const timeline = createTimeline();
@@ -32,6 +39,7 @@ function importScene(name: string, scene: ExcalidrawSceneData) {
   const targets = extractTargets(scene.elements);
   useProjectStore.getState().setTargets(targets);
   resetTimeline();
+  useUIStore.getState().hydrateWorkspace('magic');
 }
 
 export function useFileOperations() {
@@ -44,6 +52,8 @@ export function useFileOperations() {
     useProjectStore.getState().setTargets([]);
     useProjectStore.getState().setCameraAspectRatio(aspectRatio);
     resetTimeline();
+    useUIStore.getState().hydrateWorkspace('magic');
+    trackCreatorEvent('creator_project_started', { path: 'draw' });
     trackNewProject(aspectRatio);
   };
 
@@ -68,6 +78,9 @@ export function useFileOperations() {
   const handleImportFile = async (file: File) => {
     const scene = await parseExcalidrawFileBlob(file);
     importScene('Imported Animation', scene);
+    trackCreatorEvent('creator_project_started', {
+      path: 'import-excalidraw',
+    });
     trackImport('file');
   };
 
@@ -81,6 +94,7 @@ export function useFileOperations() {
   const handleLoadProjectFile = async (file: File) => {
     const project = await parseProjectFileBlob(file);
     loadProjectDocumentIntoStores(project);
+    trackCreatorEvent('creator_project_started', { path: 'open-project' });
     trackLoadProject('file');
   };
 

--- a/src/components/Workspace/MagicControls.tsx
+++ b/src/components/Workspace/MagicControls.tsx
@@ -1,0 +1,419 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Divider,
+  Group,
+  Modal,
+  SegmentedControl,
+  Select,
+  Slider,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconArrowRight,
+  IconChartDots,
+  IconCircleCheck,
+  IconLayoutBoard,
+  IconListDetails,
+  IconPlayerPlay,
+  IconSparkles,
+} from '@tabler/icons-react';
+import type {
+  AutoAnimateAnalysis,
+  EasingType,
+} from '@excalimate/animation-core';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import {
+  applyPreset,
+  applyPresetBatch,
+} from '../../services/AnimationCommandService';
+import { analyzeAutoAnimateInWorker } from '../../services/AutoAnimateService';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
+
+type Preset = 'fade' | 'slide' | 'draw' | 'pop';
+type Direction = 'left' | 'right' | 'up' | 'down';
+
+const EASING_OPTIONS: { value: EasingType; label: string }[] = [
+  { value: 'easeOut', label: 'Gentle' },
+  { value: 'easeInOut', label: 'Smooth' },
+  { value: 'linear', label: 'Even' },
+  { value: 'easeOutBack', label: 'Playful' },
+];
+
+function speedBand(speed: number): 'slow' | 'normal' | 'fast' {
+  if (speed < 0.85) return 'slow';
+  if (speed > 1.25) return 'fast';
+  return 'normal';
+}
+
+function strategyLabel(strategy: AutoAnimateAnalysis['strategy']): string {
+  return strategy
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function MagicControls() {
+  const project = useProjectStore((state) => state.project);
+  const targets = useProjectStore((state) => state.targets);
+  const targetIds = useMemo(
+    () => targets.map((target) => target.id),
+    [targets],
+  );
+  const selectedElementIds = useUIStore(
+    (state) => state.selectedElementIds,
+  );
+  const [direction, setDirection] = useState<Direction>('left');
+  const [speed, setSpeed] = useState(1);
+  const [staggerMs, setStaggerMs] = useState(80);
+  const [easing, setEasing] = useState<EasingType>('easeOut');
+  const [analysis, setAnalysis] = useState<AutoAnimateAnalysis | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+  const hasSelection = selectedElementIds.length > 0;
+
+  const applySelectedPreset = (preset: Preset) => {
+    if (!hasSelection) return;
+    const commandPreset = preset === 'slide' ? `slide-${direction}` : preset;
+    const result = applyPreset({
+      preset: commandPreset,
+      targetIds: selectedElementIds,
+      timing: {
+        startMs: 0,
+        durationMs: Math.round(560 / speed),
+        staggerMs,
+        startMode: 'absolute',
+      },
+      easing,
+    });
+    if (!result.ok) {
+      notifications.show({
+        title: 'Preset was not applied',
+        message: result.error.message,
+        color: 'red',
+      });
+      return;
+    }
+    useUIStore.getState().setCanvasMode('preview');
+    trackCreatorEvent('creator_preset_applied', {
+      preset,
+      ...(preset === 'slide' ? { direction } : {}),
+      selection_size: selectedElementIds.length,
+      speed_band: speedBand(speed),
+    });
+    notifications.show({
+      title: 'Preset applied',
+      message: `${preset.charAt(0).toUpperCase() + preset.slice(1)} was added as one undoable action.`,
+      color: 'green',
+      icon: <IconCircleCheck size={18} />,
+    });
+  };
+
+  const previewAutoAnimate = async () => {
+    const elements = project?.scene.elements;
+    if (!elements || elements.length === 0) return;
+    const scope = hasSelection ? 'selection' : 'diagram';
+    try {
+      setAnalyzing(true);
+      const nextAnalysis = await analyzeAutoAnimateInWorker({
+        elements,
+        scope,
+        ...(hasSelection ? { selectedElementIds } : {}),
+      });
+      setAnalysis(nextAnalysis);
+      trackCreatorEvent('creator_auto_animate_previewed', {
+        scope,
+        strategy: nextAnalysis.strategy,
+        confidence_band: nextAnalysis.confidenceBand,
+        target_count: nextAnalysis.semanticTargets.length,
+      });
+    } catch (error) {
+      notifications.show({
+        title: 'Local analysis failed',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'The arrangement worker could not complete.',
+        color: 'red',
+      });
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  const acceptAnalysis = () => {
+    if (!analysis) return;
+    const knownTargets = new Set(targetIds);
+    const inputs = analysis.recipes
+      .map((recipe) => ({
+        preset: recipe.preset,
+        targetIds: recipe.targetIds.filter((id) => knownTargets.has(id)),
+        timing: {
+          startMs: Math.round(recipe.startMs / speed),
+          durationMs: Math.round(recipe.durationMs / speed),
+          staggerMs:
+            recipe.targetIds.length > 1
+              ? recipe.staggerMs
+              : Math.max(recipe.staggerMs, staggerMs),
+          startMode: 'absolute' as const,
+        },
+        easing,
+      }))
+      .filter((input) => input.targetIds.length > 0);
+    const result = applyPresetBatch(inputs);
+    if (!result.ok) {
+      notifications.show({
+        title: 'Animation plan was not applied',
+        message: result.error.message,
+        color: 'red',
+      });
+      return;
+    }
+    trackCreatorEvent('creator_auto_animate_applied', {
+      scope: analysis.scope,
+      strategy: analysis.strategy,
+      confidence_band: analysis.confidenceBand,
+      recipe_count: inputs.length,
+    });
+    setAnalysis(null);
+    useUIStore.getState().setCanvasMode('preview');
+    notifications.show({
+      title: 'Animation plan applied',
+      message: `${inputs.length} steps were committed and can be undone in one step.`,
+      color: 'green',
+      icon: <IconCircleCheck size={18} />,
+    });
+  };
+
+  const rejectAnalysis = () => {
+    if (!analysis) return;
+    trackCreatorEvent('creator_auto_animate_rejected', {
+      scope: analysis.scope,
+      strategy: analysis.strategy,
+      confidence_band: analysis.confidenceBand,
+    });
+    setAnalysis(null);
+  };
+
+  const escalate = (destination: 'sequence' | 'studio') => {
+    useUIStore.getState().setWorkspace(destination);
+    trackCreatorEvent('creator_escalated', { destination });
+    trackCreatorEvent('creator_workspace_changed', {
+      workspace: destination,
+      source: 'escalation',
+    });
+  };
+
+  return (
+    <>
+      <Stack className="magic-controls-surface" gap="md" p="md">
+        <Stack gap={4}>
+          <Group justify="space-between" align="center">
+            <Title order={3} size="h4">
+              Animate
+            </Title>
+            <Badge variant="light">
+              {hasSelection ? 'Selection' : 'Whole diagram'}
+            </Badge>
+          </Group>
+          <Text size="sm" c="dimmed">
+            Preview every local suggestion before it changes the timeline.
+          </Text>
+        </Stack>
+
+        <Button
+          size="md"
+          loading={analyzing}
+          leftSection={<IconSparkles size={19} aria-hidden="true" />}
+          onClick={() => void previewAutoAnimate()}
+        >
+          Auto Animate
+        </Button>
+
+        <Divider label="Selected element presets" labelPosition="center" />
+        <Text size="xs" c="dimmed">
+          {hasSelection
+            ? `${selectedElementIds.length} selected`
+            : 'Select one or more canvas elements to apply a preset.'}
+        </Text>
+        <Group grow>
+          <Button
+            variant="light"
+            disabled={!hasSelection}
+            onClick={() => applySelectedPreset('fade')}
+          >
+            Fade
+          </Button>
+          <Button
+            variant="light"
+            disabled={!hasSelection}
+            onClick={() => applySelectedPreset('slide')}
+          >
+            Slide
+          </Button>
+        </Group>
+        <Group grow>
+          <Button
+            variant="light"
+            disabled={!hasSelection}
+            onClick={() => applySelectedPreset('draw')}
+          >
+            Draw
+          </Button>
+          <Button
+            variant="light"
+            disabled={!hasSelection}
+            onClick={() => applySelectedPreset('pop')}
+          >
+            Pop
+          </Button>
+        </Group>
+
+        <Stack gap={6}>
+          <Text size="sm" fw={600}>
+            Slide direction
+          </Text>
+          <SegmentedControl
+            aria-label="Slide direction"
+            fullWidth
+            value={direction}
+            onChange={(value) => setDirection(value as Direction)}
+            data={[
+              { value: 'left', label: 'Left' },
+              { value: 'right', label: 'Right' },
+              { value: 'up', label: 'Up' },
+              { value: 'down', label: 'Down' },
+            ]}
+          />
+        </Stack>
+
+        <Stack gap={6}>
+          <Text size="sm" fw={600}>
+            Speed: {speedBand(speed)}
+          </Text>
+          <Slider
+            aria-label="Animation speed"
+            min={0.5}
+            max={2}
+            step={0.25}
+            value={speed}
+            onChange={setSpeed}
+            marks={[
+              { value: 0.5, label: 'Slow' },
+              { value: 1, label: 'Normal' },
+              { value: 2, label: 'Fast' },
+            ]}
+          />
+        </Stack>
+
+        <Stack gap={6} mt="xs">
+          <Text size="sm" fw={600}>
+            Stagger: {staggerMs} ms
+          </Text>
+          <Slider
+            aria-label="Animation stagger"
+            min={0}
+            max={400}
+            step={20}
+            value={staggerMs}
+            onChange={setStaggerMs}
+          />
+        </Stack>
+
+        <Select
+          label="Motion style"
+          description="Controls how each animation settles."
+          value={easing}
+          data={EASING_OPTIONS}
+          allowDeselect={false}
+          onChange={(value) => {
+            if (value) setEasing(value as EasingType);
+          }}
+        />
+
+        <Divider label="More control" labelPosition="center" />
+        <Button
+          variant="subtle"
+          leftSection={<IconListDetails size={18} aria-hidden="true" />}
+          rightSection={<IconArrowRight size={16} aria-hidden="true" />}
+          onClick={() => escalate('sequence')}
+        >
+          Refine sequence
+        </Button>
+        <Button
+          variant="subtle"
+          leftSection={<IconLayoutBoard size={18} aria-hidden="true" />}
+          rightSection={<IconArrowRight size={16} aria-hidden="true" />}
+          onClick={() => escalate('studio')}
+        >
+          Open Studio
+        </Button>
+      </Stack>
+
+      <Modal
+        opened={analysis !== null}
+        onClose={rejectAnalysis}
+        title="Review animation plan"
+        centered
+        size="lg"
+        closeButtonProps={{ 'aria-label': 'Reject animation plan' }}
+      >
+        {analysis && (
+          <Stack gap="md">
+            <Group justify="space-between">
+              <Group gap="xs">
+                <IconChartDots size={22} aria-hidden="true" />
+                <Text fw={700}>{strategyLabel(analysis.strategy)}</Text>
+              </Group>
+              <Badge
+                color={
+                  analysis.confidenceBand === 'high'
+                    ? 'green'
+                    : analysis.confidenceBand === 'medium'
+                      ? 'yellow'
+                      : 'orange'
+                }
+              >
+                {analysis.confidenceBand} confidence
+              </Badge>
+            </Group>
+            {analysis.ambiguous && (
+              <Alert color="orange" title="No single pattern is clearly dominant">
+                This is a deterministic local arrangement suggestion. Review the
+                order before applying it.
+              </Alert>
+            )}
+            <Stack gap={4}>
+              {analysis.reasons.map((reason) => (
+                <Text key={reason.code} size="sm">
+                  {reason.message}
+                </Text>
+              ))}
+            </Stack>
+            <Text size="sm" c="dimmed" aria-live="polite">
+              {analysis.recipes.length} steps for{' '}
+              {analysis.semanticTargets.length} semantic groups. Labels stay with
+              their shapes, and outbound arrows follow their source nodes.
+            </Text>
+            <Group justify="flex-end">
+              <Button variant="default" onClick={rejectAnalysis}>
+                Reject
+              </Button>
+              <Button
+                leftSection={<IconPlayerPlay size={18} aria-hidden="true" />}
+                onClick={acceptAnalysis}
+              >
+                Apply plan
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Workspace/MagicWorkspace.tsx
+++ b/src/components/Workspace/MagicWorkspace.tsx
@@ -1,0 +1,288 @@
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Drawer,
+  Group,
+  Paper,
+  ScrollArea,
+  SegmentedControl,
+  Tooltip,
+} from '@mantine/core';
+import { useMediaQuery, useReducedMotion } from '@mantine/hooks';
+import {
+  IconAdjustments,
+  IconArrowBackUp,
+  IconPlayerPlay,
+  IconShare,
+} from '@tabler/icons-react';
+import { ErrorBoundary } from '../common/ErrorBoundary';
+import { WelcomeOverlay } from '../Onboarding/WelcomeOverlay';
+import { FileControls } from '../Toolbar/FileControls';
+import { ExportControls } from '../Toolbar/ExportControls';
+import { PlaybackControls } from '../Toolbar/PlaybackControls';
+import { ThemeToggle } from '../Toolbar/ThemeToggle';
+import { useShareOperations } from '../Toolbar/useShareOperations';
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
+import { MagicControls } from './MagicControls';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useUndoRedoStore } from '../../stores/undoRedoStore';
+import { useSceneChangeSync } from '../App/useSceneChangeSync';
+import {
+  computeFrameAtTime,
+  getPlaybackController,
+} from '../../core/engine/playbackSingleton';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
+import {
+  getMagicControlsPlacement,
+  getMagicPreviewPolicy,
+} from '../../core/workspace/workspaceLayout';
+
+const ExcalidrawEditor = lazy(() =>
+  import('../Canvas/ExcalidrawEditor').then((module) => ({
+    default: module.ExcalidrawEditor,
+  })),
+);
+const AnimateCanvasWrapper = lazy(() =>
+  import('../App/AnimateCanvasWrapper').then((module) => ({
+    default: module.AnimateCanvasWrapper,
+  })),
+);
+
+export function MagicWorkspace() {
+  const mobile = useMediaQuery('(max-width: 47.99em)', false);
+  const reducedMotion = useReducedMotion();
+  const firstPreviewTracked = useRef(false);
+  const [controlsOpen, setControlsOpen] = useState(false);
+  const project = useProjectStore((state) => state.project);
+  const theme = useUIStore((state) => state.theme);
+  const targets = useProjectStore((state) => state.targets);
+  const cameraFrame = useProjectStore((state) => state.cameraFrame);
+  const canvasMode = useUIStore((state) => state.canvasMode);
+  const selectedElementIds = useUIStore(
+    (state) => state.selectedElementIds,
+  );
+  const canUndo = useUndoRedoStore((state) => state.canUndo);
+  const { handleSceneChange, handleElementsSelected } = useSceneChangeSync();
+  const { loading: shareLoading, handleShare } = useShareOperations();
+  const hasElements =
+    project?.scene.elements.some((element) => !element.isDeleted) ?? false;
+  const controlsPlacement = getMagicControlsPlacement(mobile, hasElements);
+  const previewPolicy = getMagicPreviewPolicy(reducedMotion);
+
+  const setCanvasMode = (mode: 'design' | 'preview') => {
+    useUIStore.getState().setCanvasMode(mode);
+  };
+
+  useEffect(() => {
+    if (canvasMode === 'preview' && !firstPreviewTracked.current) {
+      firstPreviewTracked.current = true;
+      trackCreatorEvent('creator_first_preview', {
+        workspace: 'magic',
+        reduced_motion: reducedMotion,
+      });
+    }
+  }, [canvasMode, reducedMotion]);
+
+  const undo = () => {
+    const result = useUndoRedoStore.getState().undo();
+    computeFrameAtTime(result?.time ?? 0);
+  };
+
+  const startPlayback = () => {
+    setCanvasMode('preview');
+    getPlaybackController().togglePlayPause();
+  };
+
+  return (
+    <Box
+      h="100vh"
+      w="100vw"
+      bg="var(--color-surface)"
+      c="var(--color-text)"
+      style={{ display: 'flex', flexDirection: 'column' }}
+    >
+      <Paper
+        className="magic-toolbar"
+        component="header"
+        role="toolbar"
+        aria-label="Magic workspace toolbar"
+        radius={0}
+        withBorder
+        px={{ base: 'xs', sm: 'md' }}
+        py="xs"
+      >
+        <Group justify="space-between" gap="xs" wrap="wrap">
+          <Group gap="xs" wrap="wrap">
+            <img
+              src={
+                theme === 'dark'
+                  ? '/excalimate_logo_dark.svg'
+                  : '/excalimate_logo.svg'
+              }
+              alt="Excalimate logo"
+              style={{ height: 22 }}
+            />
+            <FileControls />
+            <WorkspaceSwitcher />
+          </Group>
+          <Group gap="xs" wrap="wrap">
+            <SegmentedControl
+              aria-label="Canvas mode"
+              size="xs"
+              value={canvasMode}
+              onChange={(value) =>
+                setCanvasMode(value as 'design' | 'preview')
+              }
+              data={[
+                { value: 'design', label: 'Design' },
+                { value: 'preview', label: 'Preview' },
+              ]}
+            />
+            {canvasMode === 'preview' && !mobile ? (
+              <PlaybackControls />
+            ) : (
+              <Button
+                size="compact-sm"
+                variant="light"
+                leftSection={<IconPlayerPlay size={16} aria-hidden="true" />}
+                onClick={startPlayback}
+                disabled={!hasElements}
+              >
+                Play
+              </Button>
+            )}
+            <Tooltip label="Undo animation action">
+              <ActionIcon
+                aria-label="Undo animation action"
+                size={mobile ? 'lg' : 'md'}
+                variant="subtle"
+                disabled={!canUndo}
+                onClick={undo}
+              >
+                <IconArrowBackUp size={18} />
+              </ActionIcon>
+            </Tooltip>
+            <ExportControls />
+            <Button
+              size="compact-sm"
+              variant="subtle"
+              loading={shareLoading}
+              leftSection={<IconShare size={16} aria-hidden="true" />}
+              onClick={() => void handleShare()}
+            >
+              Share
+            </Button>
+            <ThemeToggle />
+            {mobile && hasElements && (
+              <Button
+                size="compact-sm"
+                leftSection={<IconAdjustments size={16} aria-hidden="true" />}
+                onClick={() => setControlsOpen(true)}
+              >
+                Controls
+              </Button>
+            )}
+          </Group>
+        </Group>
+      </Paper>
+
+      <Group
+        align="stretch"
+        gap="sm"
+        p="sm"
+        wrap="nowrap"
+        style={{ flex: 1, minHeight: 0 }}
+      >
+        <Box
+          component="main"
+          aria-label="Magic canvas"
+          data-preview-transition={previewPolicy.transition}
+          pos="relative"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--mantine-radius-md)',
+          }}
+        >
+          <ErrorBoundary
+            fallback={
+              <Box
+                h="100%"
+                style={{ display: 'grid', placeItems: 'center' }}
+              >
+                Canvas error
+              </Box>
+            }
+          >
+            <Suspense
+              fallback={
+                <Box
+                  h="100%"
+                  style={{ display: 'grid', placeItems: 'center' }}
+                >
+                  Loading editor...
+                </Box>
+              }
+            >
+              {canvasMode === 'design' ? (
+                <ExcalidrawEditor
+                  key={project?.id ?? 'empty'}
+                  onSceneChange={handleSceneChange}
+                  onElementsSelected={handleElementsSelected}
+                  initialData={project?.scene}
+                />
+              ) : (
+                <AnimateCanvasWrapper
+                  scene={project?.scene ?? null}
+                  targets={targets}
+                  selectedElementIds={selectedElementIds}
+                  cameraFrame={cameraFrame}
+                  onSelectElements={(ids) =>
+                    useUIStore.getState().setSelectedElements(ids)
+                  }
+                  onDragElement={() => undefined}
+                  onResizeElement={() => undefined}
+                  onRotateElement={() => undefined}
+                />
+              )}
+            </Suspense>
+          </ErrorBoundary>
+          <WelcomeOverlay />
+        </Box>
+
+        {controlsPlacement === 'sidebar' && (
+          <Paper
+            component="aside"
+            aria-label="Magic animation controls"
+            withBorder
+            radius="md"
+            w={330}
+            miw={300}
+          >
+            <ScrollArea h="100%" type="auto">
+              <MagicControls />
+            </ScrollArea>
+          </Paper>
+        )}
+      </Group>
+
+      <Drawer
+        opened={controlsPlacement === 'drawer' && controlsOpen}
+        onClose={() => setControlsOpen(false)}
+        title="Magic animation controls"
+        position="bottom"
+        size="85%"
+        closeButtonProps={{ 'aria-label': 'Close animation controls' }}
+      >
+        <ScrollArea h="calc(85vh - 72px)">
+          <MagicControls />
+        </ScrollArea>
+      </Drawer>
+    </Box>
+  );
+}

--- a/src/components/Workspace/StudioWorkspace.tsx
+++ b/src/components/Workspace/StudioWorkspace.tsx
@@ -1,0 +1,341 @@
+import { lazy, Suspense, useCallback } from 'react';
+import {
+  ActionIcon,
+  Button,
+  Center,
+  CloseButton,
+  Paper,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
+import {
+  IconChevronUp,
+  IconDeviceDesktop,
+  IconLayoutSidebarLeftExpand,
+  IconWand,
+} from '@tabler/icons-react';
+import { Toolbar } from '../Toolbar';
+import { ToolbarHints } from '../Onboarding/ToolbarHints';
+import { LayersPanel } from '../Layers/LayersPanel';
+import { SequenceRevealPanel } from '../SequenceReveal/SequenceRevealPanel';
+import { ErrorBoundary } from '../common/ErrorBoundary';
+import { useAnimationStore } from '../../stores/animationStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useSceneChangeSync } from '../App/useSceneChangeSync';
+import { useSelectionDerivedState } from '../App/useSelectionDerivedState';
+import { useKeyframeActions } from '../App/useKeyframeActions';
+import { TimelinePanelWrapper } from '../App/TimelinePanelWrapper';
+import { PropertyPanelWrapper } from '../App/PropertyPanelWrapper';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
+import { getWorkspaceMinimumWidth } from '../../core/workspace/workspaceLayout';
+
+const ExcalidrawEditor = lazy(() =>
+  import('../Canvas/ExcalidrawEditor').then((module) => ({
+    default: module.ExcalidrawEditor,
+  })),
+);
+const AnimateCanvasWrapper = lazy(() =>
+  import('../App/AnimateCanvasWrapper').then((module) => ({
+    default: module.AnimateCanvasWrapper,
+  })),
+);
+
+export function StudioWorkspace({
+  legacyShell = false,
+}: {
+  legacyShell?: boolean;
+}) {
+  const workspace = useUIStore((state) => state.workspace);
+  const minimumWidth = getWorkspaceMinimumWidth(
+    workspace === 'studio' ? 'studio' : 'sequence',
+  );
+  const isSupported = useMediaQuery(
+    `(min-width: ${minimumWidth}px)`,
+    true,
+  );
+
+  if (!legacyShell && !isSupported) {
+    return (
+      <Center h="100vh" p="xl">
+        <Paper withBorder shadow="md" radius="lg" p="xl" maw={520}>
+          <Stack align="center" gap="md">
+            <IconDeviceDesktop
+              size={44}
+              stroke={1.5}
+              color="var(--mantine-color-indigo-6)"
+              aria-hidden="true"
+            />
+            <Title order={2} ta="center">
+              {workspace === 'studio'
+                ? 'Studio needs a larger screen'
+                : 'Sequence works best on a tablet or desktop'}
+            </Title>
+            <Text c="dimmed" ta="center">
+              Your project and timeline are unchanged. Open Magic to keep editing
+              on this device, or return on a wider screen.
+            </Text>
+            <Button
+              leftSection={<IconWand size={18} aria-hidden="true" />}
+              onClick={() => {
+                useUIStore.getState().setWorkspace('magic');
+                trackCreatorEvent('creator_workspace_changed', {
+                  workspace: 'magic',
+                  source: 'escalation',
+                });
+              }}
+            >
+              Open Magic
+            </Button>
+          </Stack>
+        </Paper>
+      </Center>
+    );
+  }
+
+  return <StudioShell legacyShell={legacyShell} />;
+}
+
+function StudioShell({ legacyShell }: { legacyShell: boolean }) {
+  const mode = useUIStore((state) => state.mode);
+  const selectedElementIds = useUIStore(
+    (state) => state.selectedElementIds,
+  );
+  const sequenceRevealOpen = useUIStore(
+    (state) => state.sequenceRevealOpen,
+  );
+  const layersPanelOpen = useUIStore((state) => state.layersPanelOpen);
+  const timelinePanelOpen = useUIStore((state) => state.timelinePanelOpen);
+  const targets = useProjectStore((state) => state.targets);
+  const project = useProjectStore((state) => state.project);
+  const cameraFrame = useProjectStore((state) => state.cameraFrame);
+  const timeline = useAnimationStore((state) => state.timeline);
+  const selectedTrackId = useAnimationStore(
+    (state) => state.selectedTrackId,
+  );
+  const selectedKeyframeIds = useAnimationStore(
+    (state) => state.selectedKeyframeIds,
+  );
+  const clipStart = useAnimationStore((state) => state.clipStart);
+  const clipEnd = useAnimationStore((state) => state.clipEnd);
+  const { handleSceneChange, handleElementsSelected } = useSceneChangeSync();
+  const {
+    targetLabels,
+    targetOrder,
+    targetParents,
+    selectedTargets,
+    selectedTargetTracks,
+    selectedKeyframeDetails,
+  } = useSelectionDerivedState({
+    targets,
+    timeline,
+    selectedElementIds,
+    selectedKeyframeIds,
+  });
+  const {
+    handleScrub,
+    handleSelectTrack,
+    handleSelectKeyframes,
+    handleAddKeyframe,
+    handleMoveKeyframe,
+    handleRemoveKeyframe,
+    handleToggleTrackEnabled,
+    handleRemoveTrack,
+    handleUpdateKeyframe,
+    handleSelectTarget,
+    handleSelectElements,
+    handleAddOrUpdateKeyframe,
+    handleDragElement,
+    handleAddTrackProp,
+    handleResizeElement,
+    handleRotateElement,
+  } = useKeyframeActions();
+
+  const closePropertyPanel = useCallback(() => {
+    useUIStore.getState().setSelectedElements([]);
+    useAnimationStore.getState().clearKeyframeSelection();
+  }, []);
+
+  return (
+    <div className="flex flex-col h-screen w-screen bg-surface text-text">
+      <Toolbar legacyShell={legacyShell} />
+      <ToolbarHints />
+
+      <div className="flex flex-1 overflow-hidden px-2 pb-2 gap-2">
+        {mode === 'animate' && layersPanelOpen && (
+          <aside
+            data-hint="layers"
+            className="w-[200px] border border-border bg-surface rounded-lg shadow-float overflow-y-auto shrink-0"
+          >
+            <LayersPanel
+              targets={targets}
+              tracks={timeline.tracks}
+              selectedElementIds={selectedElementIds}
+              onSelectElements={handleSelectElements}
+            />
+          </aside>
+        )}
+
+        <main className="flex-1 relative overflow-hidden bg-surface rounded-lg border border-border shadow-float">
+          <ErrorBoundary
+            fallback={
+              <div className="flex items-center justify-center h-full text-sm text-danger">
+                Canvas error
+              </div>
+            }
+          >
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center h-full text-sm text-text-muted">
+                  Loading editor...
+                </div>
+              }
+            >
+              {mode === 'edit' ? (
+                <ExcalidrawEditor
+                  key={project?.id ?? 'empty'}
+                  onSceneChange={handleSceneChange}
+                  onElementsSelected={handleElementsSelected}
+                  initialData={project?.scene}
+                />
+              ) : (
+                <AnimateCanvasWrapper
+                  scene={project?.scene ?? null}
+                  targets={targets}
+                  selectedElementIds={selectedElementIds}
+                  cameraFrame={cameraFrame}
+                  onSelectElements={handleSelectElements}
+                  onDragElement={handleDragElement}
+                  onResizeElement={handleResizeElement}
+                  onRotateElement={handleRotateElement}
+                />
+              )}
+            </Suspense>
+          </ErrorBoundary>
+          {mode === 'animate' && sequenceRevealOpen && (
+            <SequenceRevealPanel
+              targets={targets}
+              selectedElementIds={selectedElementIds}
+            />
+          )}
+          {mode === 'animate' && !layersPanelOpen && (
+            <div className="absolute top-2 left-2 z-20">
+              <Tooltip label="Show layers" position="right">
+                <ActionIcon
+                  aria-label="Show layers"
+                  variant="filled"
+                  color="indigo"
+                  size="md"
+                  onClick={() =>
+                    useUIStore.getState().toggleLayersPanel()
+                  }
+                >
+                  <IconLayoutSidebarLeftExpand size={18} />
+                </ActionIcon>
+              </Tooltip>
+            </div>
+          )}
+          {!timelinePanelOpen && (
+            <div className="absolute bottom-2 right-2 z-20">
+              <Tooltip label="Show timeline" position="left">
+                <ActionIcon
+                  aria-label="Show timeline"
+                  variant="filled"
+                  color="indigo"
+                  size="md"
+                  onClick={() =>
+                    useUIStore.getState().toggleTimelinePanel()
+                  }
+                >
+                  <IconChevronUp size={18} />
+                </ActionIcon>
+              </Tooltip>
+            </div>
+          )}
+        </main>
+
+        {(selectedTargets.length > 0 ||
+          selectedKeyframeIds.length > 0) && (
+          <aside className="w-[280px] border border-border bg-surface rounded-lg shadow-float overflow-hidden shrink-0 flex flex-col">
+            <div className="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0">
+              <span className="text-[10px] text-text-muted uppercase tracking-wider font-semibold">
+                Properties
+              </span>
+              <CloseButton
+                aria-label="Close properties"
+                size="sm"
+                onClick={closePropertyPanel}
+              />
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              <ErrorBoundary
+                fallback={
+                  <div className="flex items-center justify-center h-full text-sm text-danger">
+                    Property panel error
+                  </div>
+                }
+              >
+                <PropertyPanelWrapper
+                  selectedTargets={selectedTargets}
+                  allTargets={targets}
+                  tracks={selectedTargetTracks}
+                  selectedKeyframes={selectedKeyframeDetails}
+                  onAddTrack={handleAddTrackProp}
+                  onAddOrUpdateKeyframe={handleAddOrUpdateKeyframe}
+                  onUpdateKeyframe={handleUpdateKeyframe}
+                  onDeleteKeyframe={handleRemoveKeyframe}
+                  onSelectTarget={handleSelectTarget}
+                />
+              </ErrorBoundary>
+            </div>
+          </aside>
+        )}
+      </div>
+
+      {timelinePanelOpen && (
+        <div
+          data-hint="timeline"
+          className="h-[250px] mx-2 mb-2 border border-border bg-surface-alt rounded-lg shadow-float overflow-hidden"
+        >
+          <ErrorBoundary
+            fallback={
+              <div className="flex items-center justify-center h-full text-sm text-danger">
+                Timeline error
+              </div>
+            }
+          >
+            <TimelinePanelWrapper
+              tracks={timeline.tracks}
+              duration={timeline.duration}
+              selectedTrackId={selectedTrackId}
+              rawSelectedKeyframeIds={selectedKeyframeIds}
+              clipStart={clipStart}
+              clipEnd={clipEnd}
+              onSelectTrack={handleSelectTrack}
+              onSelectKeyframes={handleSelectKeyframes}
+              onAddKeyframe={handleAddKeyframe}
+              onMoveKeyframe={handleMoveKeyframe}
+              onDeleteKeyframe={handleRemoveKeyframe}
+              onScrub={handleScrub}
+              onToggleTrackEnabled={handleToggleTrackEnabled}
+              onRemoveTrack={handleRemoveTrack}
+              onClipRangeChange={(start, end) =>
+                useAnimationStore.getState().setClipRange(start, end)
+              }
+              targetLabels={targetLabels}
+              targetOrder={targetOrder}
+              targetParents={targetParents}
+              selectedElementIds={selectedElementIds}
+              onCollapse={() =>
+                useUIStore.getState().toggleTimelinePanel()
+              }
+            />
+          </ErrorBoundary>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,0 +1,61 @@
+import { Group, SegmentedControl, Text } from '@mantine/core';
+import {
+  IconLayoutBoard,
+  IconListDetails,
+  IconWand,
+} from '@tabler/icons-react';
+import { useUIStore } from '../../stores/uiStore';
+import type { WorkspaceMode } from '../../types/ui';
+import { trackCreatorEvent } from '../../services/analytics/posthog';
+
+const WORKSPACES = [
+  {
+    value: 'magic',
+    label: (
+      <Group gap={5} wrap="nowrap">
+        <IconWand size={14} aria-hidden="true" />
+        <Text span size="xs">Magic</Text>
+      </Group>
+    ),
+  },
+  {
+    value: 'sequence',
+    label: (
+      <Group gap={5} wrap="nowrap">
+        <IconListDetails size={14} aria-hidden="true" />
+        <Text span size="xs">Sequence</Text>
+      </Group>
+    ),
+  },
+  {
+    value: 'studio',
+    label: (
+      <Group gap={5} wrap="nowrap">
+        <IconLayoutBoard size={14} aria-hidden="true" />
+        <Text span size="xs">Studio</Text>
+      </Group>
+    ),
+  },
+] as const;
+
+export function WorkspaceSwitcher() {
+  const workspace = useUIStore((state) => state.workspace);
+  const setWorkspace = useUIStore((state) => state.setWorkspace);
+
+  return (
+    <SegmentedControl
+      aria-label="Workspace"
+      size="xs"
+      value={workspace}
+      data={[...WORKSPACES]}
+      onChange={(value) => {
+        const nextWorkspace = value as WorkspaceMode;
+        setWorkspace(nextWorkspace);
+        trackCreatorEvent('creator_workspace_changed', {
+          workspace: nextWorkspace,
+          source: 'switcher',
+        });
+      }}
+    />
+  );
+}

--- a/src/core/models/Project.ts
+++ b/src/core/models/Project.ts
@@ -62,6 +62,7 @@ export function createProject(
       clipEnd: Math.min(10_000, timeline.duration),
       cameraFrame,
     },
+    preferredWorkspace: 'magic',
   });
   return { ...project, scene };
 }
@@ -78,7 +79,9 @@ export function createProjectFromContent(
     timeline: content.timeline,
     playback: content.playback,
     authoring: content.authoring,
-    preferredWorkspace: content.preferredWorkspace,
+    preferredWorkspace:
+      content.preferredWorkspace ??
+      (content.timeline.tracks.length > 0 ? 'studio' : 'magic'),
   });
 }
 

--- a/src/core/workspace/workspaceFlags.ts
+++ b/src/core/workspace/workspaceFlags.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceMode } from '../../types/ui';
+
+export interface WorkspaceShellFlags {
+  forceStudioShell: boolean;
+  workspaceOverride?: WorkspaceMode;
+}
+
+export function resolveWorkspaceShellFlags(
+  search: string,
+  buildForceStudio = false,
+): WorkspaceShellFlags {
+  const params = new URLSearchParams(search);
+  const queryForcesStudio =
+    params.get('legacyStudio') === '1' || params.get('studio') === 'legacy';
+  const requestedWorkspace = params.get('workspace');
+  const workspaceOverride =
+    requestedWorkspace === 'magic' ||
+    requestedWorkspace === 'sequence' ||
+    requestedWorkspace === 'studio'
+      ? requestedWorkspace
+      : undefined;
+
+  return {
+    forceStudioShell: buildForceStudio || queryForcesStudio,
+    ...(workspaceOverride ? { workspaceOverride } : {}),
+  };
+}
+
+export function getWorkspaceShellFlags(): WorkspaceShellFlags {
+  return resolveWorkspaceShellFlags(
+    window.location.search,
+    import.meta.env.VITE_FORCE_STUDIO_SHELL === 'true',
+  );
+}

--- a/src/core/workspace/workspaceLayout.ts
+++ b/src/core/workspace/workspaceLayout.ts
@@ -1,0 +1,23 @@
+export function getMagicControlsPlacement(
+  mobile: boolean,
+  hasElements: boolean,
+): 'drawer' | 'sidebar' | 'hidden' {
+  if (!hasElements) return 'hidden';
+  return mobile ? 'drawer' : 'sidebar';
+}
+
+export function getMagicPreviewPolicy(reducedMotion: boolean): {
+  autoPlay: false;
+  transition: 'none' | 'standard';
+} {
+  return {
+    autoPlay: false,
+    transition: reducedMotion ? 'none' : 'standard',
+  };
+}
+
+export function getWorkspaceMinimumWidth(
+  workspace: 'sequence' | 'studio',
+): number {
+  return workspace === 'studio' ? 960 : 768;
+}

--- a/src/core/workspace/workspaceState.test.ts
+++ b/src/core/workspace/workspaceState.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  migrateV1Project,
+  parseProjectDocument,
+} from '@excalimate/project-schema';
+import { createProject } from '../models/Project';
+import { getPlaybackController } from '../engine/playbackSingleton';
+import { useAnimationStore } from '../../stores/animationStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUIStore } from '../../stores/uiStore';
+import {
+  captureProjectDocument,
+  loadProjectDocumentIntoStores,
+} from '../../services/ProjectDocumentService';
+import {
+  SYNTHETIC_V1_PROJECT,
+  createSyntheticV2Project,
+} from '../../test-fixtures/projectDocuments';
+import { resolveWorkspaceShellFlags } from './workspaceFlags';
+import {
+  getMagicControlsPlacement,
+  getMagicPreviewPolicy,
+  getWorkspaceMinimumWidth,
+} from './workspaceLayout';
+
+describe('progressive workspace state', () => {
+  beforeEach(() => {
+    getPlaybackController();
+    useProjectStore.setState({
+      project: null,
+      targets: [],
+      isDirty: false,
+    });
+    useUIStore.setState({
+      workspace: 'magic',
+      canvasMode: 'design',
+      mode: 'edit',
+      startSurfaceDismissed: false,
+    });
+  });
+
+  it('defaults new and import-only projects to Magic design', () => {
+    const project = createProject('Untitled', {
+      elements: [],
+      appState: {},
+      files: {},
+    });
+
+    expect(project.preferredWorkspace).toBe('magic');
+    expect(useUIStore.getState()).toMatchObject({
+      workspace: 'magic',
+      canvasMode: 'design',
+      mode: 'edit',
+    });
+  });
+
+  it('migrates legacy animation tracks to Studio and empty legacy files to Magic', () => {
+    const animated = migrateV1Project(structuredClone(SYNTHETIC_V1_PROJECT));
+    const empty = migrateV1Project({
+      ...structuredClone(SYNTHETIC_V1_PROJECT),
+      timeline: {
+        ...SYNTHETIC_V1_PROJECT.timeline,
+        tracks: [],
+      },
+    });
+
+    expect(animated.preferredWorkspace).toBe('studio');
+    expect(empty.preferredWorkspace).toBe('magic');
+  });
+
+  it('honors and persists the Studio preference without converting timeline data', () => {
+    const document = createSyntheticV2Project();
+    document.preferredWorkspace = 'studio';
+    const originalTimeline = structuredClone(document.timeline);
+
+    loadProjectDocumentIntoStores(document);
+    expect(useUIStore.getState().workspace).toBe('studio');
+
+    useUIStore.getState().setWorkspace('magic');
+    useUIStore.getState().setWorkspace('studio');
+
+    expect(useAnimationStore.getState().timeline).toEqual(originalTimeline);
+    expect(captureProjectDocument()?.preferredWorkspace).toBe('studio');
+  });
+
+  it('preserves the existing edit/animate compatibility mode when requested', () => {
+    const document = createSyntheticV2Project();
+    document.preferredWorkspace = 'studio';
+    useUIStore.setState({ mode: 'edit' });
+
+    loadProjectDocumentIntoStores(document, {
+      activateAnimationMode: false,
+    });
+
+    expect(useUIStore.getState()).toMatchObject({
+      workspace: 'studio',
+      mode: 'edit',
+    });
+  });
+
+  it('accepts Studio as a typed V2 preferred workspace', () => {
+    const document = createSyntheticV2Project();
+    document.preferredWorkspace = 'studio';
+
+    expect(parseProjectDocument(document).preferredWorkspace).toBe('studio');
+  });
+
+  it('provides build and query rollback routes to the legacy Studio shell', () => {
+    expect(resolveWorkspaceShellFlags('?legacyStudio=1')).toEqual({
+      forceStudioShell: true,
+    });
+    expect(resolveWorkspaceShellFlags('?studio=legacy')).toEqual({
+      forceStudioShell: true,
+    });
+    expect(resolveWorkspaceShellFlags('', true)).toEqual({
+      forceStudioShell: true,
+    });
+    expect(resolveWorkspaceShellFlags('?workspace=sequence')).toEqual({
+      forceStudioShell: false,
+      workspaceOverride: 'sequence',
+    });
+  });
+
+  it('uses responsive control surfaces and never auto-starts reduced-motion previews', () => {
+    expect(getMagicControlsPlacement(true, true)).toBe('drawer');
+    expect(getMagicControlsPlacement(false, true)).toBe('sidebar');
+    expect(getMagicControlsPlacement(true, false)).toBe('hidden');
+    expect(getWorkspaceMinimumWidth('sequence')).toBe(768);
+    expect(getWorkspaceMinimumWidth('studio')).toBe(960);
+    expect(getMagicPreviewPolicy(true)).toEqual({
+      autoPlay: false,
+      transition: 'none',
+    });
+    expect(getMagicPreviewPolicy(false)).toEqual({
+      autoPlay: false,
+      transition: 'standard',
+    });
+  });
+});

--- a/src/hooks/useAppHotkeys.ts
+++ b/src/hooks/useAppHotkeys.ts
@@ -7,6 +7,7 @@ import { usePlaybackStore } from '../stores/playbackStore';
 import { useProjectStore } from '../stores/projectStore';
 import { getPlaybackController, computeFrameAtTime } from '../core/engine/playbackSingleton';
 import { trackGroupAction } from '../services/analytics/posthog';
+import { trackCreatorEvent } from '../services/analytics/posthog';
 
 const FRAME_DURATION = 1000 / 60;
 
@@ -86,7 +87,11 @@ export function useAppHotkeys() {
 
   useHotkeys([
     // Playback
-    ['Space', () => getPlaybackController().togglePlayPause()],
+    ['Space', () => {
+      const { workspace, canvasMode } = useUIStore.getState();
+      if (workspace === 'magic' && canvasMode === 'design') return;
+      getPlaybackController().togglePlayPause();
+    }],
     ['Home', () => computeFrameAtTime(0)],
     ['End', () => {
       const dur = useAnimationStore.getState().timeline.duration;
@@ -131,8 +136,22 @@ export function useAppHotkeys() {
       }
     }],
 
-    // Mode toggle
-    ['mod+E', () => useUIStore.getState().toggleMode()],
+    // Mode toggle remains compatible with Studio and maps to canvas mode in Magic.
+    ['mod+E', () => {
+      const state = useUIStore.getState();
+      if (state.workspace === 'magic') {
+        state.setCanvasMode(
+          state.canvasMode === 'design' ? 'preview' : 'design',
+        );
+      } else {
+        state.toggleMode();
+      }
+    }],
+
+    // Progressive workspace navigation.
+    ['mod+1', () => switchWorkspace('magic')],
+    ['mod+2', () => switchWorkspace('sequence')],
+    ['mod+3', () => switchWorkspace('studio')],
 
     // Close property panel / deselect
     ['Escape', () => {
@@ -144,4 +163,12 @@ export function useAppHotkeys() {
       }
     }],
   ]);
+}
+
+function switchWorkspace(workspace: 'magic' | 'sequence' | 'studio') {
+  useUIStore.getState().setWorkspace(workspace);
+  trackCreatorEvent('creator_workspace_changed', {
+    workspace,
+    source: 'switcher',
+  });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -113,3 +113,19 @@ body {
 .excalidraw-animate-mode .excalidraw .eraser-buttons {
   display: none !important;
 }
+@media (max-width: 48em), (pointer: coarse) {
+  .magic-toolbar :where(button, [role='radio']) {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .magic-toolbar *,
+  .magic-controls-surface * {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/src/services/AnimationCommandService.test.ts
+++ b/src/services/AnimationCommandService.test.ts
@@ -11,6 +11,7 @@ import { useProjectStore } from '../stores/projectStore';
 import { useUndoRedoStore } from '../stores/undoRedoStore';
 import {
   applyPreset,
+  applyPresetBatch,
   createAction,
   createCameraMove,
   deleteAction,
@@ -257,5 +258,67 @@ describe('AnimationCommandService', () => {
             ?.ownership.some((ownership) => ownership.trackId === track.id),
         ),
     ).toBe(false);
+  });
+
+  it.each([
+    ['fade', 'opacity'],
+    ['slide-left', 'translateX'],
+    ['slide-right', 'translateX'],
+    ['slide-up', 'translateY'],
+    ['slide-down', 'translateY'],
+    ['draw', 'drawProgress'],
+    ['pop', 'scaleX'],
+  ] as const)('applies the %s preset through the command service', (preset, property) => {
+    const result = applyPreset({
+      preset,
+      targetIds: ['element-1'],
+      timing: {
+        startMs: 0,
+        durationMs: 500,
+        staggerMs: 0,
+        startMode: 'absolute',
+      },
+      easing: 'easeInOut',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      useAnimationStore
+        .getState()
+        .timeline.tracks.some((track) => track.property === property),
+    ).toBe(true);
+  });
+
+  it('applies an auto-animate preset batch as one undoable commit', () => {
+    const result = applyPresetBatch([
+      {
+        preset: 'fade',
+        targetIds: ['element-1'],
+        timing: {
+          startMs: 0,
+          durationMs: 400,
+          staggerMs: 0,
+          startMode: 'absolute',
+        },
+      },
+      {
+        preset: 'draw',
+        targetIds: ['element-2'],
+        timing: {
+          startMs: 200,
+          durationMs: 500,
+          staggerMs: 0,
+          startMode: 'absolute',
+        },
+      },
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(useAnimationStore.getState().actions).toHaveLength(2);
+    expect(useUndoRedoStore.getState().past).toHaveLength(1);
+
+    useUndoRedoStore.getState().undo();
+    expect(useAnimationStore.getState().actions).toEqual([]);
+    expect(useAnimationStore.getState().timeline.tracks).toEqual([]);
   });
 });

--- a/src/services/AnimationCommandService.ts
+++ b/src/services/AnimationCommandService.ts
@@ -9,6 +9,7 @@ import type {
   AnimationAction,
   AnimationActionTiming,
   AnimationTimeline,
+  EasingType,
   ProjectAuthoring,
   ProjectDocument,
 } from '@excalimate/project-schema';
@@ -188,36 +189,55 @@ function compileAndCommit(
 export function createAction(
   draft: AnimationActionDraft,
 ): AnimationCommandResult<AnimationCommandValue> {
+  return createActions([draft]);
+}
+
+export function createActions(
+  drafts: readonly AnimationActionDraft[],
+): AnimationCommandResult<AnimationCommandValue> {
+  if (drafts.length === 0) {
+    return failure('INVALID_INPUT', 'At least one animation action is required');
+  }
   const current = useAnimationStore.getState();
-  const occurrence = current.actions.filter(
-    (action) => action.type === draft.type,
-  ).length;
-  const action = createAnimationAction(draft, occurrence);
-  if (current.actions.some((candidate) => candidate.id === action.id)) {
-    return failure(
-      'DUPLICATE_ACTION',
-      `Animation action "${action.id}" already exists`,
-    );
+  const occurrences = new Map<AnimationAction['type'], number>();
+  for (const action of current.actions) {
+    occurrences.set(action.type, (occurrences.get(action.type) ?? 0) + 1);
   }
-  const parsed = AnimationActionSchema.safeParse(action);
-  if (!parsed.success) {
-    const details = parsed.error.issues.map((issue) => issue.message);
-    return failure(
-      'INVALID_INPUT',
-      details[0] ?? 'Invalid animation action',
-      details,
-    );
+  const newActions: AnimationAction[] = [];
+  const knownIds = new Set(current.actions.map((action) => action.id));
+  for (const draft of drafts) {
+    const occurrence = occurrences.get(draft.type) ?? 0;
+    occurrences.set(draft.type, occurrence + 1);
+    const action = createAnimationAction(draft, occurrence);
+    if (knownIds.has(action.id)) {
+      return failure(
+        'DUPLICATE_ACTION',
+        `Animation action "${action.id}" already exists`,
+      );
+    }
+    const parsed = AnimationActionSchema.safeParse(action);
+    if (!parsed.success) {
+      const details = parsed.error.issues.map((issue) => issue.message);
+      return failure(
+        'INVALID_INPUT',
+        details[0] ?? 'Invalid animation action',
+        details,
+      );
+    }
+    const references = validateReferences(parsed.data);
+    if (!references.ok) return references;
+    knownIds.add(parsed.data.id);
+    newActions.push(parsed.data);
   }
-  const references = validateReferences(parsed.data);
-  if (!references.ok) return references;
-  const result = compileAndCommit([...current.actions, parsed.data]);
+  const result = compileAndCommit([...current.actions, ...newActions]);
   if (!result.ok) return result;
+  const lastAction = newActions.at(-1);
   return {
     ...result,
     value: {
       ...result.value,
       action: result.value.actions.find(
-        (candidate) => candidate.id === parsed.data.id,
+        (candidate) => candidate.id === lastAction?.id,
       ),
     },
   };
@@ -269,15 +289,40 @@ export function applyPreset(input: {
   preset: string;
   targetIds: readonly string[];
   timing: AnimationActionTiming;
+  easing?: EasingType;
 }): AnimationCommandResult<AnimationCommandValue> {
   try {
-    return createAction(
-      presetDraft(input.preset, input.targetIds, input.timing),
-    );
+    return createAction({
+      ...presetDraft(input.preset, input.targetIds, input.timing),
+      ...(input.easing ? { easing: input.easing } : {}),
+    });
   } catch (error) {
     return failure(
       'INVALID_INPUT',
       error instanceof Error ? error.message : 'Invalid animation preset',
+    );
+  }
+}
+
+export function applyPresetBatch(
+  inputs: readonly {
+    preset: string;
+    targetIds: readonly string[];
+    timing: AnimationActionTiming;
+    easing?: EasingType;
+  }[],
+): AnimationCommandResult<AnimationCommandValue> {
+  try {
+    return createActions(
+      inputs.map((input) => ({
+        ...presetDraft(input.preset, input.targetIds, input.timing),
+        ...(input.easing ? { easing: input.easing } : {}),
+      })),
+    );
+  } catch (error) {
+    return failure(
+      'INVALID_INPUT',
+      error instanceof Error ? error.message : 'Invalid animation preset batch',
     );
   }
 }
@@ -405,6 +450,7 @@ export function replaceProject(
     );
   }
   const appProject = fromProjectDocument(document);
+  const previousMode = useUIStore.getState().mode;
   if (options.pushUndo) useUndoRedoStore.getState().pushState(true);
   const targets = extractTargets(appProject.scene.elements);
   useProjectStore.setState({
@@ -413,6 +459,10 @@ export function replaceProject(
     cameraFrame: appProject.playback.cameraFrame,
     isDirty: false,
   });
+  const workspace =
+    document.preferredWorkspace ??
+    (document.timeline.tracks.length > 0 ? 'studio' : 'magic');
+  useUIStore.getState().hydrateWorkspace(workspace);
   runAnimationStoreTransaction(() => {
     useAnimationStore.setState({
       timeline: appProject.timeline,
@@ -424,9 +474,13 @@ export function replaceProject(
     });
   });
   invalidatePlaybackCache();
-  if (options.activateAnimationMode ?? true) {
-    useUIStore.getState().setMode('animate');
-    computeFrameAtTime(0);
+  if (workspace !== 'magic') {
+    if (options.activateAnimationMode ?? true) {
+      useUIStore.getState().setMode('animate');
+      computeFrameAtTime(0);
+    } else {
+      useUIStore.getState().setMode(previousMode);
+    }
   }
   return { ok: true, value: appProject };
 }

--- a/src/services/AutoAnimateService.test.ts
+++ b/src/services/AutoAnimateService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+import { toAutoAnimateElements } from './AutoAnimateService';
+
+describe('AutoAnimateService', () => {
+  it('sends only geometry and relationship fields to the local worker', () => {
+    const element = {
+      id: 'shape',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 60,
+      angle: 0,
+      text: 'private diagram text',
+      link: 'https://private.example',
+      boundElements: [{ id: 'label', type: 'text' }],
+      isDeleted: false,
+    } as unknown as ExcalidrawElement;
+
+    expect(toAutoAnimateElements([element])).toEqual([
+      {
+        id: 'shape',
+        type: 'rectangle',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 60,
+        zIndex: 0,
+        isDeleted: false,
+        boundElements: [{ id: 'label', type: 'text' }],
+      },
+    ]);
+  });
+});

--- a/src/services/AutoAnimateService.ts
+++ b/src/services/AutoAnimateService.ts
@@ -1,0 +1,96 @@
+import {
+  analyzeAutoAnimate,
+  type AutoAnimateAnalysis,
+  type AutoAnimateElement,
+  type AutoAnimateScope,
+} from '@excalimate/animation-core';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+import type {
+  AutoAnimateWorkerMessage,
+  AutoAnimateWorkerResponse,
+} from '../workers/autoAnimate.worker';
+
+let requestId = 0;
+
+export function toAutoAnimateElements(
+  elements: readonly ExcalidrawElement[],
+): AutoAnimateElement[] {
+  return elements.map((element, zIndex) => {
+    const semantic = element as ExcalidrawElement & {
+      groupIds?: readonly string[];
+      containerId?: string | null;
+      boundElements?: readonly { id: string; type: string }[];
+      startBinding?: { elementId: string } | null;
+      endBinding?: { elementId: string } | null;
+    };
+    return {
+      id: element.id,
+      type: element.type,
+      x: element.x,
+      y: element.y,
+      width: element.width,
+      height: element.height,
+      zIndex,
+      isDeleted: element.isDeleted,
+      ...(semantic.groupIds ? { groupIds: semantic.groupIds } : {}),
+      ...(semantic.containerId !== undefined
+        ? { containerId: semantic.containerId }
+        : {}),
+      ...(semantic.boundElements
+        ? { boundElements: semantic.boundElements }
+        : {}),
+      ...(semantic.startBinding
+        ? { startBinding: { elementId: semantic.startBinding.elementId } }
+        : {}),
+      ...(semantic.endBinding
+        ? { endBinding: { elementId: semantic.endBinding.elementId } }
+        : {}),
+    };
+  });
+}
+
+export async function analyzeAutoAnimateInWorker(input: {
+  elements: readonly ExcalidrawElement[];
+  scope: AutoAnimateScope;
+  selectedElementIds?: readonly string[];
+}): Promise<AutoAnimateAnalysis> {
+  const request = {
+    elements: toAutoAnimateElements(input.elements),
+    scope: input.scope,
+    ...(input.selectedElementIds
+      ? { selectedElementIds: input.selectedElementIds }
+      : {}),
+  };
+
+  if (typeof Worker === 'undefined') {
+    return analyzeAutoAnimate(request);
+  }
+
+  const currentRequestId = ++requestId;
+  const worker = new Worker(
+    new URL('../workers/autoAnimate.worker.ts', import.meta.url),
+    { type: 'module', name: 'excalimate-auto-animate' },
+  );
+  return new Promise<AutoAnimateAnalysis>((resolve, reject) => {
+    worker.addEventListener(
+      'message',
+      (event: MessageEvent<AutoAnimateWorkerResponse>) => {
+        if (event.data.requestId !== currentRequestId) return;
+        worker.terminate();
+        if (event.data.ok) {
+          resolve(event.data.analysis);
+        } else {
+          reject(new Error(event.data.error));
+        }
+      },
+    );
+    worker.addEventListener('error', (event) => {
+      worker.terminate();
+      reject(new Error(event.message || 'Local arrangement worker failed'));
+    });
+    worker.postMessage({
+      requestId: currentRequestId,
+      request,
+    } satisfies AutoAnimateWorkerMessage);
+  });
+}

--- a/src/services/ProjectDocumentService.ts
+++ b/src/services/ProjectDocumentService.ts
@@ -4,7 +4,9 @@ import { toProjectDocument } from '../core/models/Project';
 import type { AnimationProject } from '../core/models/Project';
 import { useAnimationStore } from '../stores/animationStore';
 import { useProjectStore } from '../stores/projectStore';
+import { useUIStore } from '../stores/uiStore';
 import { replaceProject } from './AnimationCommandService';
+import { trackCreatorEvent } from './analytics/posthog';
 
 export function captureProjectDocument(): ProjectDocument | null {
   const project = useProjectStore.getState().project;
@@ -46,5 +48,9 @@ export function loadProjectDocumentIntoStores(
 ): AnimationProject {
   const result = replaceProject(project, options);
   if (!result.ok) throw new Error(result.error.message);
+  trackCreatorEvent('creator_workspace_changed', {
+    workspace: useUIStore.getState().workspace,
+    source: 'project-load',
+  });
   return result.value;
 }

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -1,2 +1,15 @@
-export { getPostHogClient, isPostHogConfigured, enableCapture, disableCapture, trackEvent, trackExport, trackMcpConnection, trackSceneCreated, trackShare } from './posthog';
+export {
+  getPostHogClient,
+  isPostHogConfigured,
+  enableCapture,
+  disableCapture,
+  trackEvent,
+  trackCreatorEvent,
+  sanitizeCreatorAnalyticsPayload,
+  trackExport,
+  trackMcpConnection,
+  trackSceneCreated,
+  trackShare,
+} from './posthog';
+export type { CreatorAnalyticsEventMap } from './posthog';
 export { CONSENT_KEY, CONSENT_VERSION, type ConsentState, type StoredConsent, canStorePreferences, storePreference, readPreference } from './consent';

--- a/src/services/analytics/posthog.test.ts
+++ b/src/services/analytics/posthog.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeCreatorAnalyticsPayload,
+  trackCreatorEvent,
+} from './posthog';
+
+describe('creator analytics', () => {
+  it('allows only content-free properties declared for the event', () => {
+    const payload = sanitizeCreatorAnalyticsPayload(
+      'creator_auto_animate_previewed',
+      {
+        scope: 'diagram',
+        strategy: 'hierarchical',
+        confidence_band: 'high',
+        target_count: 4,
+        label: 'private diagram text',
+        project_id: 'private-id',
+        url: 'https://private.example',
+      },
+    );
+
+    expect(payload).toEqual({
+      scope: 'diagram',
+      strategy: 'hierarchical',
+      confidence_band: 'high',
+      target_count: 4,
+    });
+  });
+
+  it('is a no-op when PostHog is not configured', () => {
+    expect(() =>
+      trackCreatorEvent('creator_workspace_changed', {
+        workspace: 'magic',
+        source: 'switcher',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/services/analytics/posthog.ts
+++ b/src/services/analytics/posthog.ts
@@ -1,5 +1,7 @@
 import posthog, { type PostHog } from 'posthog-js';
 import { CONSENT_KEY, type StoredConsent } from './consent';
+import type { AutoAnimateConfidenceBand, AutoAnimateStrategy } from '@excalimate/animation-core';
+import type { WorkspaceMode } from '../../types/ui';
 
 /**
  * PostHog configuration — reads from Vite env vars.
@@ -52,6 +54,101 @@ export function disableCapture(): void {
 export function trackEvent(event: string, properties?: Record<string, unknown>): void {
   if (!isPostHogConfigured() || posthog.has_opted_out_capturing()) return;
   posthog.capture(event, properties);
+}
+
+export interface CreatorAnalyticsEventMap {
+  creator_workspace_changed: {
+    workspace: WorkspaceMode;
+    source: 'switcher' | 'escalation' | 'project-load' | 'query';
+  };
+  creator_project_started: {
+    path: 'draw' | 'import-excalidraw' | 'open-project' | 'mcp' | 'template-teaser';
+  };
+  creator_auto_animate_previewed: {
+    scope: 'selection' | 'diagram';
+    strategy: AutoAnimateStrategy;
+    confidence_band: AutoAnimateConfidenceBand;
+    target_count: number;
+  };
+  creator_auto_animate_applied: {
+    scope: 'selection' | 'diagram';
+    strategy: AutoAnimateStrategy;
+    confidence_band: AutoAnimateConfidenceBand;
+    recipe_count: number;
+  };
+  creator_auto_animate_rejected: {
+    scope: 'selection' | 'diagram';
+    strategy: AutoAnimateStrategy;
+    confidence_band: AutoAnimateConfidenceBand;
+  };
+  creator_preset_applied: {
+    preset: 'fade' | 'slide' | 'draw' | 'pop';
+    direction?: 'left' | 'right' | 'up' | 'down';
+    selection_size: number;
+    speed_band: 'slow' | 'normal' | 'fast';
+  };
+  creator_first_preview: {
+    workspace: WorkspaceMode;
+    reduced_motion: boolean;
+  };
+  creator_escalated: {
+    destination: 'sequence' | 'studio';
+  };
+}
+
+const CREATOR_PROPERTY_ALLOWLIST = {
+  creator_workspace_changed: ['workspace', 'source'],
+  creator_project_started: ['path'],
+  creator_auto_animate_previewed: [
+    'scope',
+    'strategy',
+    'confidence_band',
+    'target_count',
+  ],
+  creator_auto_animate_applied: [
+    'scope',
+    'strategy',
+    'confidence_band',
+    'recipe_count',
+  ],
+  creator_auto_animate_rejected: ['scope', 'strategy', 'confidence_band'],
+  creator_preset_applied: [
+    'preset',
+    'direction',
+    'selection_size',
+    'speed_band',
+  ],
+  creator_first_preview: ['workspace', 'reduced_motion'],
+  creator_escalated: ['destination'],
+} as const satisfies {
+  [Event in keyof CreatorAnalyticsEventMap]: readonly (
+    keyof CreatorAnalyticsEventMap[Event]
+  )[];
+};
+
+export function sanitizeCreatorAnalyticsPayload<
+  Event extends keyof CreatorAnalyticsEventMap,
+>(
+  event: Event,
+  payload: CreatorAnalyticsEventMap[Event] & Record<string, unknown>,
+): CreatorAnalyticsEventMap[Event] {
+  const sanitized: Record<string, unknown> = {};
+  for (const key of CREATOR_PROPERTY_ALLOWLIST[event]) {
+    if (payload[key] !== undefined) sanitized[key] = payload[key];
+  }
+  return sanitized as CreatorAnalyticsEventMap[Event];
+}
+
+export function trackCreatorEvent<
+  Event extends keyof CreatorAnalyticsEventMap,
+>(event: Event, payload: CreatorAnalyticsEventMap[Event]): void {
+  trackEvent(
+    event,
+    sanitizeCreatorAnalyticsPayload(
+      event,
+      payload as CreatorAnalyticsEventMap[Event] & Record<string, unknown>,
+    ),
+  );
 }
 
 export function trackExport(format: string): void {

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import type {
   AspectRatio,
   CameraFrame,
+  PreferredWorkspace,
 } from '@excalimate/project-schema';
 import { CAMERA_FRAME_TARGET_ID } from '@excalimate/project-schema';
 import type { AnimationProject } from '../core/models/Project';
@@ -50,6 +51,7 @@ interface ProjectState {
   updateScene: (scene: ExcalidrawSceneData) => void;
   updateProjectName: (name: string) => void;
   setTargets: (targets: AnimatableTarget[]) => void;
+  setPreferredWorkspace: (workspace: PreferredWorkspace) => void;
   markClean: () => void;
   groupElements: (selectedIds: string[]) => void;
   ungroupTarget: (groupId: string) => void;
@@ -123,6 +125,21 @@ export const useProjectStore = create<ProjectState>()((set, get) => ({
     if (cameraFrame.x === 640 && cameraFrame.y === 360) {
       get().fitFrameToScene();
     }
+  },
+
+  setPreferredWorkspace: (workspace: PreferredWorkspace): void => {
+    const { project } = get();
+    if (!project || project.preferredWorkspace === workspace) return;
+    const updatedAt = new Date().toISOString();
+    set({
+      project: {
+        ...project,
+        preferredWorkspace: workspace,
+        updatedAt,
+        metadata: { ...project.metadata, updatedAt },
+      },
+      isDirty: true,
+    });
   },
 
   markClean: (): void => {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,11 +1,14 @@
 import { create } from 'zustand';
 import type {
   AppMode,
+  CanvasMode,
   PanelSizes,
   TimelineViewport,
+  WorkspaceMode,
 } from '../types/ui';
 import { computeFrameAtTime } from '../core/engine/playbackSingleton';
 import { usePlaybackStore } from './playbackStore';
+import { useProjectStore } from './projectStore';
 
 export type Theme = 'light' | 'dark';
 
@@ -18,6 +21,8 @@ function getInitialTheme(): Theme {
 interface UIState {
   // State
   mode: AppMode;
+  workspace: WorkspaceMode;
+  canvasMode: CanvasMode;
   theme: Theme;
   selectedElementIds: string[];
   panelSizes: PanelSizes;
@@ -29,12 +34,16 @@ interface UIState {
   liveMode: boolean;
   /** True when a shape/draw tool is active in Excalidraw (not selection/hand). */
   drawToolActive: boolean;
+  startSurfaceDismissed: boolean;
   /** The currently displayed page. null = main app. */
   activePage: string | null;
 
   // Actions
   setMode: (mode: AppMode) => void;
   toggleMode: () => void;
+  setWorkspace: (workspace: WorkspaceMode) => void;
+  hydrateWorkspace: (workspace: WorkspaceMode) => void;
+  setCanvasMode: (mode: CanvasMode) => void;
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
   setSelectedElements: (ids: string[]) => void;
@@ -50,11 +59,14 @@ interface UIState {
   toggleTimelinePanel: () => void;
   setLiveMode: (live: boolean) => void;
   setDrawToolActive: (active: boolean) => void;
+  setStartSurfaceDismissed: (dismissed: boolean) => void;
   setActivePage: (page: string | null) => void;
 }
 
 export const useUIStore = create<UIState>()((set, get) => ({
   mode: 'edit',
+  workspace: 'magic',
+  canvasMode: 'design',
   theme: getInitialTheme(),
   selectedElementIds: [],
   ghostMode: false,
@@ -63,6 +75,7 @@ export const useUIStore = create<UIState>()((set, get) => ({
   timelinePanelOpen: true,
   liveMode: false,
   drawToolActive: false,
+  startSurfaceDismissed: false,
   activePage: null,
   panelSizes: {
     leftPanel: 48,
@@ -78,7 +91,12 @@ export const useUIStore = create<UIState>()((set, get) => ({
   },
 
   setMode: (mode: AppMode): void => {
-    set({ mode });
+    set((state) => ({
+      mode,
+      ...(state.workspace === 'magic'
+        ? { canvasMode: mode === 'edit' ? 'design' : 'preview' }
+        : {}),
+    }));
     // Ensure the animation frame is computed when entering animate mode,
     // so the canvas immediately shows the correct animated state.
     if (mode === 'animate') {
@@ -89,6 +107,52 @@ export const useUIStore = create<UIState>()((set, get) => ({
   toggleMode: (): void => {
     const next = get().mode === 'edit' ? 'animate' : 'edit';
     get().setMode(next);
+  },
+
+  setWorkspace: (workspace: WorkspaceMode): void => {
+    const canvasMode = get().canvasMode;
+    set((state) => ({
+      workspace,
+      mode:
+        workspace === 'magic'
+          ? canvasMode === 'design'
+            ? 'edit'
+            : 'animate'
+          : 'animate',
+      sequenceRevealOpen:
+        workspace === 'sequence' ? true : state.sequenceRevealOpen,
+    }));
+    useProjectStore.getState().setPreferredWorkspace(workspace);
+    if (workspace !== 'magic' || canvasMode === 'preview') {
+      computeFrameAtTime(usePlaybackStore.getState().currentTime);
+    }
+  },
+
+  hydrateWorkspace: (workspace: WorkspaceMode): void => {
+    const canvasMode: CanvasMode = 'design';
+    set((state) => ({
+      workspace,
+      canvasMode,
+      mode: workspace === 'magic' ? 'edit' : 'animate',
+      sequenceRevealOpen:
+        workspace === 'sequence' ? true : state.sequenceRevealOpen,
+      startSurfaceDismissed: false,
+    }));
+    if (workspace !== 'magic') {
+      computeFrameAtTime(usePlaybackStore.getState().currentTime);
+    }
+  },
+
+  setCanvasMode: (canvasMode: CanvasMode): void => {
+    set((state) => ({
+      canvasMode,
+      ...(state.workspace === 'magic'
+        ? { mode: canvasMode === 'design' ? 'edit' : 'animate' }
+        : {}),
+    }));
+    if (canvasMode === 'preview') {
+      computeFrameAtTime(usePlaybackStore.getState().currentTime);
+    }
   },
 
   setTheme: (theme: Theme): void => {
@@ -163,6 +227,10 @@ export const useUIStore = create<UIState>()((set, get) => ({
 
   setDrawToolActive: (active: boolean): void => {
     set({ drawToolActive: active });
+  },
+
+  setStartSurfaceDismissed: (dismissed: boolean): void => {
+    set({ startSurfaceDismissed: dismissed });
   },
 
   setActivePage: (page: string | null): void => {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,4 +1,6 @@
 export type AppMode = 'edit' | 'animate';
+export type WorkspaceMode = 'magic' | 'sequence' | 'studio';
+export type CanvasMode = 'design' | 'preview';
 export type PlaybackState = 'playing' | 'paused' | 'stopped';
 export type LoopMode = 'none' | 'loop' | 'pingpong';
 export type PlaybackSpeed = 0.25 | 0.5 | 1 | 2;

--- a/src/workers/autoAnimate.worker.ts
+++ b/src/workers/autoAnimate.worker.ts
@@ -1,0 +1,49 @@
+/// <reference lib="webworker" />
+
+import {
+  analyzeAutoAnimate,
+  type AutoAnimateAnalysis,
+  type AutoAnimateRequest,
+} from '@excalimate/animation-core';
+
+export interface AutoAnimateWorkerMessage {
+  requestId: number;
+  request: AutoAnimateRequest;
+}
+
+export type AutoAnimateWorkerResponse =
+  | {
+      requestId: number;
+      ok: true;
+      analysis: AutoAnimateAnalysis;
+    }
+  | {
+      requestId: number;
+      ok: false;
+      error: string;
+    };
+
+self.addEventListener(
+  'message',
+  (event: MessageEvent<AutoAnimateWorkerMessage>) => {
+    try {
+      const analysis = analyzeAutoAnimate(event.data.request);
+      self.postMessage({
+        requestId: event.data.requestId,
+        ok: true,
+        analysis,
+      } satisfies AutoAnimateWorkerResponse);
+    } catch (error) {
+      self.postMessage({
+        requestId: event.data.requestId,
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Local arrangement analysis failed',
+      } satisfies AutoAnimateWorkerResponse);
+    }
+  },
+);
+
+export {};


### PR DESCRIPTION
## Summary
- add persisted `magic | sequence | studio` workspace state and orthogonal `design | preview` canvas state while retaining the existing `edit | animate` internals
- default new/import-only projects to Magic design, honor V2 workspace preferences including Studio, and migrate legacy projects with tracks to Studio without converting timeline data
- move the existing layers/property/timeline shell behind `StudioWorkspace`; Sequence temporarily uses that experience
- add rollback through `VITE_FORCE_STUDIO_SHELL=true`, `?legacyStudio=1`, or `?studio=legacy`
- replace the empty-canvas overlay with a Mantine Magic start surface for drawing, Excalidraw import/drop, Excalimate open, MCP connect, and a disabled template teaser
- add responsive Magic controls for local Auto Animate, selected Fade/Slide/Draw/Pop presets, direction, speed, stagger, easing, design/preview, playback, undo, export, share, and escalation
- add deterministic pure semantic graph analysis in `@excalimate/animation-core` with stable hierarchy/radial/timeline/linear/z-order scoring, confidence/reasons, selected/diagram scope, grouped labels, cycle fallback, and node-before-arrow recipes
- run analysis in a browser Worker that receives geometry/relationship fields only; accepted plans compile through the command service as one undoable commit and preserve unrelated/custom keyframes
- add consent-gated typed PostHog events with per-event property allowlists and no diagram text, labels, names, IDs, URLs, share data, or MCP hosts

## Accessibility and responsive behavior
- Mantine controls and Tabler icons throughout changed UI; no raw button controls
- keyboard-operable start/workspace/canvas controls, labeled controls, text plus color state, notifications/live plan summary, and 44px coarse-pointer toolbar targets
- Magic uses a bottom Drawer on mobile; Studio and Sequence use explicit supported-device thresholds instead of rendering broken layouts
- Mantine and custom controls respect `prefers-reduced-motion`; previews never auto-start
- wrapping/flex layout reflows at narrow widths and 200% zoom

## Validation
- `npm test` — 23 files, 361 tests passed
- `npm run lint`
- `npx tsc -b --pretty false`
- `npm run build`
- `npm run build --workspace @excalimate/project-schema`
- `npm run build --workspace @excalimate/animation-core`
- `npm run build --prefix mcp-server`
- `npm run build --prefix landing-page`
- `npx tsc -p share-worker/tsconfig.json --noEmit`
- `npm run benchmark:animation` — deterministic analyzer reports 1,720 analyses/s at 25 nodes, 780/s at 100 nodes, and 127/s at 500 nodes on this run; unit tests contain no wall-clock assertions
- live browser validation covered the Magic start surface, Studio query routing, legacy Studio rollback, local low-confidence preview, accepted command application, exactly one undo entry, and one-step rollback

## Scope
Stacked on `davidszakacs-v2-animation-core` / #88. This intentionally does not implement the new Sequence Action List, templates, smart scene transitions, hosted player, export refactor, MCP changes, or share-worker changes.