### PR TITLE
Add GitHub-backed feedback portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,15 @@ jobs:
           cache-dependency-path: landing-page/package-lock.json
       - working-directory: landing-page
         run: npm ci
+      - name: Type check
+        working-directory: landing-page
+        run: npm run check
+      - name: Test
+        working-directory: landing-page
+        run: npm test
       - name: Build
         working-directory: landing-page
-        run: npx astro build
+        run: npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: landing-page-dist

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ dist-ssr
 .dev.vars*
 !.dev.vars.example
 !.env.example
+landing-page/.astro/dev.json
+landing-page/.astro/integrations/
 
 .agents/*
 skills-lock.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   [![license](https://img.shields.io/github/license/excalimate/excalimate?style=flat-square)](LICENSE)
   [![GitHub stars](https://img.shields.io/github/stars/excalimate/excalimate?style=flat-square)](https://github.com/excalimate/excalimate)
 
-  [App](https://app.excalimate.com) · [Landing Page](https://excalimate.com) · [MCP Server Docs](mcp-server/README.md) · [Report Bug](https://github.com/excalimate/excalimate/issues)
+  [App](https://app.excalimate.com) · [Landing Page](https://excalimate.com) · [Feedback](https://excalimate.com/feedback) · [MCP Server Docs](mcp-server/README.md) · [Report Bug](https://github.com/excalimate/excalimate/issues)
 
 </div>
 

--- a/landing-page/.dev.vars.example
+++ b/landing-page/.dev.vars.example
@@ -1,7 +1,7 @@
 # Cloudflare Turnstile documented always-pass test keys
 TURNSTILE_SITE_KEY=1x00000000000000000000AA
 TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
-TURNSTILE_ALLOWED_HOSTNAMES=localhost,dummy-key-pass
+TURNSTILE_ALLOWED_HOSTNAMES=localhost,127.0.0.1
 
 # Create a GitHub App with Issues read/write and install it on the repository
 GITHUB_APP_ID=

--- a/landing-page/.dev.vars.example
+++ b/landing-page/.dev.vars.example
@@ -1,0 +1,15 @@
+# Cloudflare Turnstile documented always-pass test keys
+TURNSTILE_SITE_KEY=1x00000000000000000000AA
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+TURNSTILE_ALLOWED_HOSTNAMES=localhost,dummy-key-pass
+
+# Create a GitHub App with Issues read/write and install it on the repository
+GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+GITHUB_APP_BOT_LOGIN=excalimate-feedback[bot]
+GITHUB_REPOSITORY_OWNER=excalimate
+GITHUB_REPOSITORY_NAME=excalimate
+
+# Replace with at least 32 random characters
+FEEDBACK_COOKIE_SECRET=replace-with-a-random-secret-at-least-32-characters

--- a/landing-page/.env.example
+++ b/landing-page/.env.example
@@ -1,3 +1,17 @@
 # PostHog Analytics (optional — leave PUBLIC_POSTHOG_KEY empty to disable analytics)
 PUBLIC_POSTHOG_KEY=
 PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# Feedback portal runtime (set secrets with `wrangler secret put`)
+GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_BOT_LOGIN=excalimate-feedback[bot]
+FEEDBACK_COOKIE_SECRET=
+TURNSTILE_SECRET_KEY=
+TURNSTILE_SITE_KEY=
+
+# Non-secret Worker variables (production defaults live in wrangler.toml)
+GITHUB_REPOSITORY_OWNER=excalimate
+GITHUB_REPOSITORY_NAME=excalimate
+TURNSTILE_ALLOWED_HOSTNAMES=excalimate.com,www.excalimate.com

--- a/landing-page/DESIGN-GUIDE.md
+++ b/landing-page/DESIGN-GUIDE.md
@@ -719,15 +719,15 @@ export default defineConfig({
 
 ### Key Technical Decisions
 
-1. **No JS framework** — Pure Astro components (`.astro` files). Zero client-side JS for layout. Only add `<script>` tags for:
+1. **Astro-first UI** — Marketing pages remain pure Astro components with minimal client-side JS. Interactive product surfaces may use focused React islands with Mantine:
    - IntersectionObserver (scroll animations)
    - Mobile menu toggle
-   - Optional: GitHub stars API fetch
+   - Feedback board, forms, voting, and discussion
 2. **CSS-only animations** — All motion via CSS. No animation library needed.
 3. **Self-hosted fonts** — Load Satoshi and Virgil from `public/fonts/` for performance. Use `font-display: swap`.
 4. **Image optimization** — Use Astro's built-in `<Image />` component for automatic optimization.
 5. **No Tailwind** — The landing page is simple enough to use vanilla CSS with custom properties. This keeps it independent from the main app's Tailwind config.
-6. **Deployment** — Static build. Can be deployed to Cloudflare Pages alongside the main app (separate route/subdomain), or as standalone.
+6. **Deployment** — Prerender marketing pages and run feedback/API routes on Cloudflare Workers through the official Astro adapter. GitHub Issues is the feedback source of truth; Cloudflare stores no durable feedback data.
 
 ---
 

--- a/landing-page/astro.config.ts
+++ b/landing-page/astro.config.ts
@@ -1,9 +1,18 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, sessionDrivers } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://excalimate.com',
-  integrations: [sitemap()],
+  adapter: cloudflare({
+    imageService: 'compile',
+  }),
+  integrations: [react(), sitemap()],
+  session: {
+    // Sessions are not used; this prevents the adapter from provisioning KV.
+    driver: sessionDrivers.lruCache(),
+  },
   build: {
     assets: '_assets',
   },

--- a/landing-page/package-lock.json
+++ b/landing-page/package-lock.json
@@ -8,12 +8,129 @@
       "name": "excalimate-landing",
       "version": "1.0.0",
       "dependencies": {
+        "@astrojs/cloudflare": "^14.1.2",
+        "@astrojs/react": "^6.0.1",
         "@astrojs/sitemap": "^3.7.3",
-        "astro": "^7.0.3"
+        "@mantine/core": "8.3.17",
+        "@mantine/form": "8.3.17",
+        "@mantine/hooks": "8.3.17",
+        "@mantine/notifications": "8.3.17",
+        "@tabler/icons-react": "3.40.0",
+        "astro": "^7.0.3",
+        "jose": "^6.2.3",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
+        "@cloudflare/workers-types": "^5.20260711.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "happy-dom": "^20.10.6",
+        "tsx": "^4.23.0",
+        "typescript": "5.9.3",
+        "vitest": "^4.1.10",
         "wrangler": "^4.76.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/cloudflare": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-14.1.2.tgz",
+      "integrity": "sha512-JpRPG4dDkZcn+WRGL3tsjdzU7qDKxiR4IycX26MD1dI4ECYEr1AbdY9jQut0irI/4tBT02vvWZzkqF7X2QXX9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/underscore-redirects": "1.0.3",
+        "@cloudflare/vite-plugin": "^1.39.0",
+        "piccolore": "^0.1.3",
+        "vite": "^8.0.13"
+      },
+      "peerDependencies": {
+        "astro": "^7.0.0",
+        "wrangler": "^4.83.0"
+      }
+    },
+    "node_modules/@astrojs/cloudflare/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.2.3",
@@ -204,6 +321,48 @@
         "unified": "^11.0.5"
       }
     },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.11.tgz",
+      "integrity": "sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.4",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.71",
+        "volar-service-emmet": "0.0.71",
+        "volar-service-html": "0.0.71",
+        "volar-service-prettier": "0.0.71",
+        "volar-service-typescript": "0.0.71",
+        "volar-service-typescript-twoslash-queries": "0.0.71",
+        "volar-service-yaml": "0.0.71",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@astrojs/markdown-satteri": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz",
@@ -226,6 +385,44 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-6.0.1.tgz",
+      "integrity": "sha512-Afs1sEm72P2plDnrOGxmIteJ7bjx/VqxlcaQLNip5eHJ5tIvKUORQetC9UKcvgwKnj51t60HWl5mOANkOsWs4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@vitejs/plugin-react": "^5.2.0",
+        "devalue": "^5.8.1",
+        "ultrahtml": "^1.6.0",
+        "vite": "^8.0.13"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -255,31 +452,239 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@astrojs/underscore-redirects": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.3.tgz",
+      "integrity": "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg==",
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -288,14 +693,85 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -458,7 +934,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
       "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -468,7 +943,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
       "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -480,14 +954,33 @@
         }
       }
     },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.44.0.tgz",
+      "integrity": "sha512-8wGGunqRcs34o4GRq0Rurp7GZg30xtLJeRGUU81a49r9zQRjlp3xIlsWr3nFlSCso4eE3cjZfiKC/2y116M4TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.1",
+        "miniflare": "4.20260708.1",
+        "unenv": "2.0.0-rc.24",
+        "wrangler": "4.110.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "cf-vite": "bin/cf-vite"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.110.0"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
-      "integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260708.1.tgz",
+      "integrity": "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -498,13 +991,12 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
-      "integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260708.1.tgz",
+      "integrity": "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -515,13 +1007,12 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
-      "integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260708.1.tgz",
+      "integrity": "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -532,13 +1023,12 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
-      "integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260708.1.tgz",
+      "integrity": "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -549,13 +1039,12 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
-      "integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260708.1.tgz",
+      "integrity": "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -565,11 +1054,17 @@
         "node": ">=16"
       }
     },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260711.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260711.1.tgz",
+      "integrity": "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA==",
+      "devOptional": true,
+      "license": "MIT OR Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -577,6 +1072,68 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1025,11 +1582,63 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1042,7 +1651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1065,7 +1673,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1088,7 +1695,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1105,7 +1711,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1122,7 +1727,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1139,7 +1743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1156,7 +1759,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1173,7 +1775,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1190,7 +1791,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1207,7 +1807,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1224,7 +1823,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1241,7 +1839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1258,7 +1855,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1281,7 +1877,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1304,7 +1899,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1327,7 +1921,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1350,7 +1943,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1373,7 +1965,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1396,7 +1987,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1419,7 +2009,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1442,7 +2031,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1462,7 +2050,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1482,7 +2069,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1502,7 +2088,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1515,11 +2100,50 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1535,11 +2159,76 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mantine/core": {
+      "version": "8.3.17",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.17.tgz",
+      "integrity": "sha512-JoZdnEKz8TVPdY0bjo8kx1M6KPHZ61yZJkMv2hFx3LexI4+NFKcZa1dmWbfRvy2FptMCR6ZLbJdqvbovoYTFJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.4",
+        "react-remove-scroll": "^2.7.1",
+        "react-textarea-autosize": "8.5.9",
+        "type-fest": "^4.41.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "8.3.17",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/form": {
+      "version": "8.3.17",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.17.tgz",
+      "integrity": "sha512-UKLT2KztUtGhHN9QN83OaqfqCotEZeHyQmuFL4cPFExuBaGovDPohsgxnafblVuTvkiq0Sk00ZC31iVByT74UA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.6"
+      },
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "8.3.17",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.17.tgz",
+      "integrity": "sha512-MqVw4ad0qrcY7IgVk8+GJh7qCRIwLXTfEtGeXwmaZagMDn2YB8EUtrnuZO2be5bi3yketWtOPYvl3adh05hZRg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/notifications": {
+      "version": "8.3.17",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.17.tgz",
+      "integrity": "sha512-ZTvmBbVsprjPEKaixfxc1HLBokIaojHvLTVNQNq76H9hF4e9vgu/gwWs3AQeHksZvExByW1ok7XR6blCKqvTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mantine/store": "8.3.17",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "8.3.17",
+        "@mantine/hooks": "8.3.17",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "8.3.17",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.17.tgz",
+      "integrity": "sha512-uwI/0lhzSwdfdzqA6YlnlNP/9KjUc5SxbuB3OH/P8aasn2utsVNsKIYDlAU/oFsjggSAoQxzEGR1V2ktTjLlXg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1579,27 +2268,15 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
-      }
-    },
-    "node_modules/@poppinss/colors/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@poppinss/dumper": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -1611,7 +2288,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1890,356 +2566,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
     "node_modules/@shikijs/core": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.0.tgz",
@@ -2344,7 +2670,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2357,8 +2682,127 @@
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
       "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
-      "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.40.0.tgz",
+      "integrity": "sha512-V/Q4VgNPKubRTiLdmWjV/zscYcj5IIk+euicUtaVVqF6luSC9rDngYWgST5/yh3Mrg/mYUwRv1YVTk71Jp0twQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.40.0.tgz",
+      "integrity": "sha512-oO5+6QCnna4a//mYubx4euZfECtzQZFDGsDMIdzZUhbdyBCT+3bRVFBPueGIcemWld4Vb/0UQ39C/cmGfGylAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.40.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -2370,10 +2814,77 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -2421,6 +2932,24 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/sax": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
@@ -2436,11 +2965,314 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
     },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",
@@ -2452,6 +3284,30 @@
       },
       "bin": {
         "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -2498,6 +3354,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -2606,11 +3472,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -2618,6 +3495,72 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2627,6 +3570,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities-html4": {
@@ -2679,6 +3632,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2687,6 +3655,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2715,6 +3703,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2785,6 +3779,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
@@ -2818,6 +3819,29 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -2848,6 +3872,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/devalue": {
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
@@ -2874,6 +3904,24 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -2952,6 +4000,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "license": "ISC"
+    },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2968,7 +4046,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3021,16 +4098,51 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -3047,6 +4159,23 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
@@ -3118,6 +4247,34 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "5.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
@@ -3154,6 +4311,38 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -3282,6 +4471,16 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -3304,6 +4503,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-inside-container": {
@@ -3366,6 +4575,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -3388,11 +4612,60 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3643,6 +4916,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -3650,6 +4935,17 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3788,17 +5084,26 @@
       ],
       "license": "MIT"
     },
-    "node_modules/miniflare": {
-      "version": "4.20260625.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
-      "integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260708.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260708.1.tgz",
+      "integrity": "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260625.1",
+        "workerd": "1.20260708.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -3817,6 +5122,19 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
@@ -3870,6 +5188,15 @@
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3889,6 +5216,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/obug": {
@@ -3999,18 +5335,23 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/piccolore": {
@@ -4065,6 +5406,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -4083,6 +5464,17 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -4099,6 +5491,154 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-number-format": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -4110,6 +5650,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regex": {
@@ -4182,6 +5736,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4239,52 +5820,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/satteri": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.3.tgz",
@@ -4316,6 +5851,12 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -4332,7 +5873,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4392,6 +5932,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4448,11 +5995,40 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4468,11 +6044,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4506,10 +6107,23 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -4546,6 +6160,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4570,8 +6194,69 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -4595,7 +6280,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4611,7 +6295,6 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -4811,6 +6494,124 @@
         }
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -4949,6 +6750,379 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/volar-service-css": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.71.tgz",
+      "integrity": "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
+      "integrity": "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.71.tgz",
+      "integrity": "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
+      "integrity": "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
+      "integrity": "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
+      "integrity": "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
+      "integrity": "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.23.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -4957,6 +7131,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which-pm-runs": {
@@ -4968,11 +7152,27 @@
         "node": ">=4"
       }
     },
-    "node_modules/workerd": {
-      "version": "1.20260625.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
-      "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260708.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260708.1.tgz",
+      "integrity": "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4982,28 +7182,27 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260625.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260625.1",
-        "@cloudflare/workerd-linux-64": "1.20260625.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260625.1",
-        "@cloudflare/workerd-windows-64": "1.20260625.1"
+        "@cloudflare/workerd-darwin-64": "1.20260708.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260708.1",
+        "@cloudflare/workerd-linux-64": "1.20260708.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260708.1",
+        "@cloudflare/workerd-windows-64": "1.20260708.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.105.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
-      "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
-      "dev": true,
+      "version": "4.110.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.110.0.tgz",
+      "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260625.0",
+        "miniflare": "4.20260708.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260625.1"
+        "workerd": "1.20260708.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -5017,7 +7216,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260625.1"
+        "@cloudflare/workers-types": "^5.20260708.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -5025,11 +7224,44 @@
         }
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5053,6 +7285,104 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.8.3"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
@@ -5060,6 +7390,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -5078,7 +7418,6 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -5092,7 +7431,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -6,14 +6,38 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview",
-    "deploy": "astro build && wrangler versions upload"
+    "preview": "astro build && wrangler dev --config dist/server/wrangler.json",
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "feedback:setup": "tsx scripts/setup-feedback-labels.ts",
+    "deploy": "astro build && wrangler versions upload --config dist/server/wrangler.json"
   },
   "dependencies": {
+    "@astrojs/cloudflare": "^14.1.2",
+    "@astrojs/react": "^6.0.1",
     "@astrojs/sitemap": "^3.7.3",
-    "astro": "^7.0.3"
+    "@mantine/core": "8.3.17",
+    "@mantine/form": "8.3.17",
+    "@mantine/hooks": "8.3.17",
+    "@mantine/notifications": "8.3.17",
+    "@tabler/icons-react": "3.40.0",
+    "astro": "^7.0.3",
+    "jose": "^6.2.3",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
+    "@cloudflare/workers-types": "^5.20260711.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "happy-dom": "^20.10.6",
+    "tsx": "^4.23.0",
+    "typescript": "5.9.3",
+    "vitest": "^4.1.10",
     "wrangler": "^4.76.0"
   }
 }

--- a/landing-page/scripts/setup-feedback-labels.ts
+++ b/landing-page/scripts/setup-feedback-labels.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+import { FEEDBACK_LABEL_DEFINITIONS } from '../src/lib/feedback/config.ts';
+
+const owner = process.env.GITHUB_REPOSITORY_OWNER || 'excalimate';
+const repository = process.env.GITHUB_REPOSITORY_NAME || 'excalimate';
+const token =
+  process.env.GITHUB_TOKEN ||
+  execFileSync('gh', ['auth', 'token'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+
+if (!token) throw new Error('Authenticate gh or set GITHUB_TOKEN before provisioning labels.');
+
+const headers = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'excalimate-feedback-setup',
+};
+const baseUrl = `https://api.github.com/repos/${owner}/${repository}`;
+
+async function github(path: string, init: RequestInit = {}): Promise<Response> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: { ...headers, ...init.headers },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub ${init.method || 'GET'} ${path} failed with ${response.status}.`);
+  }
+  return response;
+}
+
+const existing = new Set<string>();
+for (let page = 1; ; page += 1) {
+  const response = await github(`/labels?per_page=100&page=${page}`);
+  const labels = (await response.json()) as Array<{ name: string }>;
+  labels.forEach((label) => existing.add(label.name.toLocaleLowerCase()));
+  if (labels.length < 100) break;
+}
+
+for (const label of FEEDBACK_LABEL_DEFINITIONS) {
+  const exists = existing.has(label.name.toLocaleLowerCase());
+  await github(exists ? `/labels/${encodeURIComponent(label.name)}` : '/labels', {
+    method: exists ? 'PATCH' : 'POST',
+    body: JSON.stringify(
+      exists ? { new_name: label.name, color: label.color, description: label.description } : label,
+    ),
+  });
+  console.log(`${exists ? 'Updated' : 'Created'} ${label.name}`);
+}

--- a/landing-page/src/components/Footer.astro
+++ b/landing-page/src/components/Footer.astro
@@ -18,8 +18,8 @@ const columns: FooterColumn[] = [
   {
     heading: 'Product',
     links: [
-      { label: 'Features', href: '#features' },
-      { label: 'Export Formats', href: '#export' },
+      { label: 'Features', href: '/#features' },
+      { label: 'Export Formats', href: '/#export' },
       { label: 'MCP Server', href: 'https://github.com/excalimate/excalimate/tree/main/mcp-server' },
       { label: 'AI Skills', href: 'https://github.com/excalimate/excalimate/tree/main/skills' },
     ],
@@ -37,6 +37,7 @@ const columns: FooterColumn[] = [
   {
     heading: 'Community',
     links: [
+      { label: 'Feedback', href: '/feedback' },
       { label: 'GitHub Discussions', href: 'https://github.com/excalimate/excalimate/discussions' },
       { label: 'Report an Issue', href: 'https://github.com/excalimate/excalimate/issues' },
     ],

--- a/landing-page/src/components/Nav.astro
+++ b/landing-page/src/components/Nav.astro
@@ -4,9 +4,10 @@
  * Uses CSS custom properties from global.css for theming.
  */
 const links = [
-  { label: 'Features', href: '#features' },
-  { label: 'How It Works', href: '#how-it-works' },
-  { label: 'Open Source', href: '#open-source' },
+  { label: 'Features', href: '/#features' },
+  { label: 'How It Works', href: '/#how-it-works' },
+  { label: 'Open Source', href: '/#open-source' },
+  { label: 'Feedback', href: '/feedback' },
 ];
 ---
 

--- a/landing-page/src/components/feedback/FeedbackBoard.test.tsx
+++ b/landing-page/src/components/feedback/FeedbackBoard.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { markFeedbackListStale } from '../../lib/feedback/api';
 import FeedbackBoard from './FeedbackBoard';
@@ -44,6 +44,7 @@ describe('FeedbackBoard', () => {
     render(<FeedbackBoard />);
 
     await waitFor(() => expect(listFeedbackMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('tab', { name: 'All statuses' })).toHaveClass('feedback-status-tab');
     markFeedbackListStale();
     const pageShow = new Event('pageshow');
     Object.defineProperty(pageShow, 'persisted', { value: true });

--- a/landing-page/src/components/feedback/FeedbackBoard.test.tsx
+++ b/landing-page/src/components/feedback/FeedbackBoard.test.tsx
@@ -1,0 +1,58 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { markFeedbackListStale } from '../../lib/feedback/api';
+import FeedbackBoard from './FeedbackBoard';
+
+const { listFeedbackMock } = vi.hoisted(() => ({
+  listFeedbackMock: vi.fn(),
+}));
+
+vi.mock('../../lib/feedback/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/feedback/api')>(
+    '../../lib/feedback/api',
+  );
+  return {
+    ...actual,
+    listFeedback: listFeedbackMock,
+  };
+});
+
+vi.mock('./SubmitFeedbackModal', () => ({
+  SubmitFeedbackModal: () => null,
+}));
+
+vi.mock('./Turnstile', () => ({
+  TurnstileAction: () => null,
+}));
+
+const response = {
+  items: [],
+  page: 1,
+  pageSize: 20,
+  total: 0,
+  totalPages: 1,
+  turnstileSiteKey: 'site-key',
+};
+
+describe('FeedbackBoard', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('requests fresh feedback when restored from browser history', async () => {
+    listFeedbackMock.mockResolvedValue(response);
+    render(<FeedbackBoard />);
+
+    await waitFor(() => expect(listFeedbackMock).toHaveBeenCalledTimes(1));
+    markFeedbackListStale();
+    const pageShow = new Event('pageshow');
+    Object.defineProperty(pageShow, 'persisted', { value: true });
+    window.dispatchEvent(pageShow);
+
+    await waitFor(() => expect(listFeedbackMock).toHaveBeenCalledTimes(2));
+    expect(listFeedbackMock).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ fresh: true }),
+    );
+  });
+});

--- a/landing-page/src/components/feedback/FeedbackBoard.tsx
+++ b/landing-page/src/components/feedback/FeedbackBoard.tsx
@@ -253,9 +253,11 @@ function FeedbackBoardContent() {
               variant="pills"
             >
               <Tabs.List>
-                <Tabs.Tab value="all">All statuses</Tabs.Tab>
+                <Tabs.Tab className="feedback-status-tab" value="all">
+                  All statuses
+                </Tabs.Tab>
                 {FEEDBACK_STATUS_IDS.map((id) => (
-                  <Tabs.Tab key={id} value={id}>
+                  <Tabs.Tab className="feedback-status-tab" key={id} value={id}>
                     {FEEDBACK_STATUSES[id].label}
                   </Tabs.Tab>
                 ))}

--- a/landing-page/src/components/feedback/FeedbackBoard.tsx
+++ b/landing-page/src/components/feedback/FeedbackBoard.tsx
@@ -19,9 +19,11 @@ import {
 import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { IconAlertCircle, IconMessagePlus, IconSearch, IconSparkles } from '@tabler/icons-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  clearFeedbackListStale,
   FeedbackApiError,
+  isFeedbackListStale,
   listFeedback,
   setFeedbackVote,
   type FeedbackListQuery,
@@ -71,11 +73,14 @@ function FeedbackBoardContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [votingNumber, setVotingNumber] = useState<number>();
+  const [refreshVersion, setRefreshVersion] = useState(0);
   const [submitOpened, submitControls] = useDisclosure(false);
   const voteChallengeRef = useRef<TurnstileActionHandle>(null);
+  const freshRequestRef = useRef(isFeedbackListStale());
 
   useEffect(() => {
     const controller = new AbortController();
+    const fresh = freshRequestRef.current || isFeedbackListStale();
     const effectiveQuery: FeedbackListQuery = {
       search: debouncedSearch,
       category: query.category,
@@ -83,10 +88,14 @@ function FeedbackBoardContent() {
       sort: query.sort,
       page: query.page,
     };
-    void listFeedback(effectiveQuery, controller.signal)
+    void listFeedback(effectiveQuery, { signal: controller.signal, fresh })
       .then((result) => {
         setData(result);
         setError(undefined);
+        if (fresh) {
+          freshRequestRef.current = false;
+          clearFeedbackListStale();
+        }
         if (result.page !== query.page) {
           setQuery((current) => ({ ...current, page: result.page }));
         }
@@ -101,7 +110,18 @@ function FeedbackBoardContent() {
         if (!controller.signal.aborted) setLoading(false);
       });
     return () => controller.abort();
-  }, [debouncedSearch, query.category, query.page, query.sort, query.status]);
+  }, [debouncedSearch, query.category, query.page, query.sort, query.status, refreshVersion]);
+
+  useEffect(() => {
+    const refreshRestoredPage = (event: PageTransitionEvent) => {
+      if (!event.persisted && !isFeedbackListStale()) return;
+      freshRequestRef.current = true;
+      submitControls.close();
+      setRefreshVersion((version) => version + 1);
+    };
+    window.addEventListener('pageshow', refreshRestoredPage);
+    return () => window.removeEventListener('pageshow', refreshRestoredPage);
+  }, [submitControls.close]);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -116,6 +136,14 @@ function FeedbackBoardContent() {
 
   const updateQuery = (values: Partial<FeedbackListQuery>) =>
     setQuery((current) => ({ ...current, ...values, page: values.page ?? 1 }));
+
+  const openSubmittedFeedback = useCallback(
+    (url: string) => {
+      submitControls.close();
+      window.location.assign(url);
+    },
+    [submitControls.close],
+  );
 
   const vote = async (item: FeedbackSummary) => {
     if (!data?.turnstileSiteKey || !voteChallengeRef.current) return;
@@ -293,6 +321,7 @@ function FeedbackBoardContent() {
       <SubmitFeedbackModal
         opened={submitOpened}
         onClose={submitControls.close}
+        onSubmitted={openSubmittedFeedback}
         siteKey={data?.turnstileSiteKey ?? ''}
       />
       <TurnstileAction

--- a/landing-page/src/components/feedback/FeedbackBoard.tsx
+++ b/landing-page/src/components/feedback/FeedbackBoard.tsx
@@ -1,0 +1,313 @@
+import {
+  Alert,
+  Button,
+  Center,
+  Container,
+  Group,
+  Loader,
+  Pagination,
+  Paper,
+  SegmentedControl,
+  Select,
+  Skeleton,
+  Stack,
+  Tabs,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { IconAlertCircle, IconMessagePlus, IconSearch, IconSparkles } from '@tabler/icons-react';
+import { useEffect, useRef, useState } from 'react';
+import {
+  FeedbackApiError,
+  listFeedback,
+  setFeedbackVote,
+  type FeedbackListQuery,
+} from '../../lib/feedback/api';
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_CATEGORY_IDS,
+  FEEDBACK_STATUSES,
+  FEEDBACK_STATUS_IDS,
+} from '../../lib/feedback/config';
+import type { FeedbackListResponse, FeedbackSummary } from '../../lib/feedback/types';
+import { FeedbackCard } from './FeedbackCard';
+import { FeedbackProvider } from './FeedbackProvider';
+import { SubmitFeedbackModal } from './SubmitFeedbackModal';
+import { TurnstileAction, type TurnstileActionHandle } from './Turnstile';
+
+function initialQuery(): FeedbackListQuery {
+  if (typeof window === 'undefined') {
+    return { search: '', category: 'all', status: 'all', sort: 'top', page: 1 };
+  }
+  const params = new URLSearchParams(window.location.search);
+  const category = params.get('category') ?? 'all';
+  const status = params.get('status') ?? 'all';
+  const sort = params.get('sort') ?? 'top';
+  const page = Number(params.get('page') || 1);
+  return {
+    search: params.get('search') ?? '',
+    category:
+      category === 'all' ||
+      FEEDBACK_CATEGORY_IDS.includes(category as (typeof FEEDBACK_CATEGORY_IDS)[number])
+        ? category
+        : 'all',
+    status:
+      status === 'all' ||
+      FEEDBACK_STATUS_IDS.includes(status as (typeof FEEDBACK_STATUS_IDS)[number])
+        ? status
+        : 'all',
+    sort: sort === 'newest' ? 'newest' : 'top',
+    page: Number.isSafeInteger(page) && page > 0 ? page : 1,
+  };
+}
+
+function FeedbackBoardContent() {
+  const [query, setQuery] = useState<FeedbackListQuery>(initialQuery);
+  const [debouncedSearch] = useDebouncedValue(query.search, 300);
+  const [data, setData] = useState<FeedbackListResponse>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [votingNumber, setVotingNumber] = useState<number>();
+  const [submitOpened, submitControls] = useDisclosure(false);
+  const voteChallengeRef = useRef<TurnstileActionHandle>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const effectiveQuery: FeedbackListQuery = {
+      search: debouncedSearch,
+      category: query.category,
+      status: query.status,
+      sort: query.sort,
+      page: query.page,
+    };
+    void listFeedback(effectiveQuery, controller.signal)
+      .then((result) => {
+        setData(result);
+        setError(undefined);
+        if (result.page !== query.page) {
+          setQuery((current) => ({ ...current, page: result.page }));
+        }
+      })
+      .catch((requestError: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(
+          requestError instanceof Error ? requestError.message : 'Feedback could not be loaded.',
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [debouncedSearch, query.category, query.page, query.sort, query.status]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (debouncedSearch) params.set('search', debouncedSearch);
+    if (query.category !== 'all') params.set('category', query.category);
+    if (query.status !== 'all') params.set('status', query.status);
+    if (query.sort !== 'top') params.set('sort', query.sort);
+    if (query.page !== 1) params.set('page', String(query.page));
+    const suffix = params.size ? `?${params}` : window.location.pathname;
+    window.history.replaceState(null, '', suffix);
+  }, [debouncedSearch, query.category, query.page, query.sort, query.status]);
+
+  const updateQuery = (values: Partial<FeedbackListQuery>) =>
+    setQuery((current) => ({ ...current, ...values, page: values.page ?? 1 }));
+
+  const vote = async (item: FeedbackSummary) => {
+    if (!data?.turnstileSiteKey || !voteChallengeRef.current) return;
+    setVotingNumber(item.number);
+    try {
+      const token = await voteChallengeRef.current.execute();
+      const result = await setFeedbackVote(item.number, true, token);
+      setData((current) =>
+        current
+          ? {
+              ...current,
+              items: current.items.map((candidate) =>
+                candidate.number === item.number
+                  ? { ...candidate, voteCount: result.voteCount }
+                  : candidate,
+              ),
+            }
+          : current,
+      );
+      notifications.show({
+        color: 'green',
+        title: 'Vote recorded',
+        message: 'Thanks for helping the team prioritize.',
+      });
+    } catch (voteError) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not record vote',
+        message:
+          voteError instanceof FeedbackApiError || voteError instanceof Error
+            ? voteError.message
+            : 'Please try again.',
+      });
+    } finally {
+      setVotingNumber(undefined);
+    }
+  };
+
+  return (
+    <Container size="lg" className="feedback-shell">
+      <Stack gap="xl">
+        <Group justify="space-between" align="flex-end">
+          <Stack gap={8} className="feedback-heading">
+            <Group gap={8}>
+              <IconSparkles size={20} />
+              <Text fw={700} size="sm">
+                Built in public
+              </Text>
+            </Group>
+            <Title order={1}>Help shape Excalimate</Title>
+            <Text c="dimmed" size="lg">
+              Suggest improvements, support the ideas that matter, and follow their progress from
+              review to completion.
+            </Text>
+          </Stack>
+          <Button
+            size="md"
+            leftSection={<IconMessagePlus size={19} />}
+            onClick={submitControls.open}
+            disabled={!data?.turnstileSiteKey}
+          >
+            Submit feedback
+          </Button>
+        </Group>
+
+        <Paper className="feedback-filters" withBorder>
+          <Stack>
+            <Group grow align="flex-end">
+              <TextInput
+                label="Search feedback"
+                placeholder="Search ideas and requests"
+                leftSection={<IconSearch size={17} />}
+                value={query.search}
+                onChange={(event) =>
+                  setQuery((current) => ({
+                    ...current,
+                    search: event.currentTarget.value,
+                    page: 1,
+                  }))
+                }
+              />
+              <Select
+                label="Category"
+                value={query.category}
+                allowDeselect={false}
+                data={[
+                  { value: 'all', label: 'All categories' },
+                  ...FEEDBACK_CATEGORY_IDS.map((id) => ({
+                    value: id,
+                    label: FEEDBACK_CATEGORIES[id].label,
+                  })),
+                ]}
+                onChange={(value) => updateQuery({ category: value ?? 'all' })}
+              />
+              <SegmentedControl
+                value={query.sort}
+                data={[
+                  { value: 'top', label: 'Top' },
+                  { value: 'newest', label: 'Newest' },
+                ]}
+                onChange={(sort) => updateQuery({ sort })}
+              />
+            </Group>
+            <Tabs
+              value={query.status}
+              onChange={(status) => updateQuery({ status: status ?? 'all' })}
+              variant="pills"
+            >
+              <Tabs.List>
+                <Tabs.Tab value="all">All statuses</Tabs.Tab>
+                {FEEDBACK_STATUS_IDS.map((id) => (
+                  <Tabs.Tab key={id} value={id}>
+                    {FEEDBACK_STATUSES[id].label}
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
+          </Stack>
+        </Paper>
+
+        {error && (
+          <Alert
+            color="red"
+            title="Feedback could not be loaded"
+            icon={<IconAlertCircle size={18} />}
+          >
+            {error}
+          </Alert>
+        )}
+
+        {loading && !data ? (
+          <Stack>
+            {Array.from({ length: 4 }, (_, index) => (
+              <Skeleton key={index} height={180} radius="md" />
+            ))}
+          </Stack>
+        ) : data?.items.length ? (
+          <Stack>
+            {data.items.map((item) => (
+              <FeedbackCard
+                key={item.number}
+                item={item}
+                voting={votingNumber === item.number}
+                onVote={vote}
+              />
+            ))}
+          </Stack>
+        ) : !error ? (
+          <Paper className="feedback-empty" withBorder>
+            <Center>
+              <Stack align="center">
+                <IconSearch size={32} />
+                <Title order={2}>No matching feedback</Title>
+                <Text c="dimmed">Try a different search or filter.</Text>
+              </Stack>
+            </Center>
+          </Paper>
+        ) : null}
+
+        {loading && data && (
+          <Center>
+            <Loader size="sm" />
+          </Center>
+        )}
+        {data && data.totalPages > 1 && (
+          <Center>
+            <Pagination
+              value={data.page}
+              total={data.totalPages}
+              onChange={(page) => updateQuery({ page })}
+            />
+          </Center>
+        )}
+      </Stack>
+      <SubmitFeedbackModal
+        opened={submitOpened}
+        onClose={submitControls.close}
+        siteKey={data?.turnstileSiteKey ?? ''}
+      />
+      <TurnstileAction
+        ref={voteChallengeRef}
+        siteKey={data?.turnstileSiteKey ?? ''}
+        action="vote_feedback"
+      />
+    </Container>
+  );
+}
+
+export default function FeedbackBoard() {
+  return (
+    <FeedbackProvider>
+      <FeedbackBoardContent />
+    </FeedbackProvider>
+  );
+}

--- a/landing-page/src/components/feedback/FeedbackCard.test.tsx
+++ b/landing-page/src/components/feedback/FeedbackCard.test.tsx
@@ -28,6 +28,9 @@ describe('FeedbackCard', () => {
 
     expect(screen.getByRole('heading', { name: item.title })).toBeInTheDocument();
     expect(screen.getByText('Completed')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /12 votes/u })).toBeDisabled();
+    const voteButton = screen.getByRole('button', { name: /12 votes/u });
+    expect(voteButton).toBeDisabled();
+    expect(voteButton).toHaveClass('feedback-button');
+    expect(screen.getByText('Completed').closest('.feedback-status-badge')).not.toBeNull();
   });
 });

--- a/landing-page/src/components/feedback/FeedbackCard.test.tsx
+++ b/landing-page/src/components/feedback/FeedbackCard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FeedbackSummary } from '../../lib/feedback/types';
+import { FeedbackCard } from './FeedbackCard';
+import { FeedbackProvider } from './FeedbackProvider';
+
+const item: FeedbackSummary = {
+  number: 42,
+  title: 'Add timeline snapping',
+  excerpt: 'Make keyframes easier to align.',
+  category: 'improvement',
+  status: 'completed',
+  voteCount: 12,
+  commentCount: 3,
+  createdAt: '2026-07-11T00:00:00Z',
+  updatedAt: '2026-07-11T00:00:00Z',
+  authorName: 'Anonymous',
+  htmlUrl: 'https://github.com/excalimate/excalimate/issues/42',
+};
+
+describe('FeedbackCard', () => {
+  it('renders status and disables voting for terminal feedback', () => {
+    render(
+      <FeedbackProvider>
+        <FeedbackCard item={item} voting={false} onVote={vi.fn()} />
+      </FeedbackProvider>,
+    );
+
+    expect(screen.getByRole('heading', { name: item.title })).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /12 votes/u })).toBeDisabled();
+  });
+});

--- a/landing-page/src/components/feedback/FeedbackCard.tsx
+++ b/landing-page/src/components/feedback/FeedbackCard.tsx
@@ -39,7 +39,11 @@ export function FeedbackCard({ item, voting, onVote }: Props) {
         </Button>
         <Stack gap={8} className="feedback-card-content">
           <Group gap={8}>
-            <Badge color={statusColors[item.status]} variant="light">
+            <Badge
+              className="feedback-status-badge"
+              color={statusColors[item.status]}
+              variant="light"
+            >
               {FEEDBACK_STATUSES[item.status].label}
             </Badge>
             <Badge color="dark" variant="outline">

--- a/landing-page/src/components/feedback/FeedbackCard.tsx
+++ b/landing-page/src/components/feedback/FeedbackCard.tsx
@@ -1,0 +1,77 @@
+import { Anchor, Badge, Button, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { IconMessageCircle, IconThumbUp } from '@tabler/icons-react';
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_STATUSES,
+  isTerminalStatus,
+} from '../../lib/feedback/config';
+import type { FeedbackSummary } from '../../lib/feedback/types';
+
+interface Props {
+  item: FeedbackSummary;
+  voting: boolean;
+  onVote: (item: FeedbackSummary) => void;
+}
+
+const statusColors = {
+  'under-review': 'gray',
+  planned: 'violet',
+  'in-progress': 'yellow',
+  completed: 'green',
+  rejected: 'red',
+} as const;
+
+export function FeedbackCard({ item, voting, onVote }: Props) {
+  const terminal = isTerminalStatus(item.status);
+  return (
+    <Paper className="feedback-card" withBorder>
+      <Group align="flex-start" wrap="nowrap" gap="md">
+        <Button
+          className="feedback-vote"
+          variant={item.voteCount > 0 ? 'light' : 'default'}
+          leftSection={<IconThumbUp size={17} />}
+          loading={voting}
+          disabled={terminal}
+          aria-label={`${item.voteCount} votes for ${item.title}`}
+          onClick={() => onVote(item)}
+        >
+          {item.voteCount}
+        </Button>
+        <Stack gap={8} className="feedback-card-content">
+          <Group gap={8}>
+            <Badge color={statusColors[item.status]} variant="light">
+              {FEEDBACK_STATUSES[item.status].label}
+            </Badge>
+            <Badge color="dark" variant="outline">
+              {FEEDBACK_CATEGORIES[item.category].label}
+            </Badge>
+          </Group>
+          <Anchor href={`/feedback/${item.number}`} underline="never">
+            <Title order={2} className="feedback-card-title">
+              {item.title}
+            </Title>
+          </Anchor>
+          <Text c="dimmed" lineClamp={2}>
+            {item.excerpt}
+          </Text>
+          <Group gap="lg" className="feedback-card-meta">
+            <Text size="sm">
+              #{item.number} by {item.authorName}
+            </Text>
+            <Group gap={5}>
+              <IconMessageCircle size={16} />
+              <Text size="sm">{item.commentCount}</Text>
+            </Group>
+            <Text size="sm">
+              {new Intl.DateTimeFormat('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              }).format(new Date(item.createdAt))}
+            </Text>
+          </Group>
+        </Stack>
+      </Group>
+    </Paper>
+  );
+}

--- a/landing-page/src/components/feedback/FeedbackDetail.tsx
+++ b/landing-page/src/components/feedback/FeedbackDetail.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionIcon,
   Alert,
   Anchor,
   Avatar,
@@ -225,21 +226,29 @@ function FeedbackDetailContent({ number, initialItem }: Props) {
           <Stack gap="lg">
             <Group justify="space-between" align="flex-start">
               <Group gap={8}>
-                <Badge color={statusColors[item.status]} variant="light">
+                <Badge
+                  className="feedback-status-badge"
+                  color={statusColors[item.status]}
+                  variant="light"
+                >
                   {FEEDBACK_STATUSES[item.status].label}
                 </Badge>
                 <Badge color="dark" variant="outline">
                   {FEEDBACK_CATEGORIES[item.category].label}
                 </Badge>
               </Group>
-              <Anchor
+              <ActionIcon
+                component="a"
                 href={item.htmlUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Open this feedback issue on GitHub"
+                className="feedback-github-link"
+                variant="default"
+                size={44}
               >
-                <IconBrandGithub size={22} />
-              </Anchor>
+                <IconBrandGithub size={24} />
+              </ActionIcon>
             </Group>
             <Title order={1}>{item.title}</Title>
             <Text className="feedback-body">{item.body}</Text>

--- a/landing-page/src/components/feedback/FeedbackDetail.tsx
+++ b/landing-page/src/components/feedback/FeedbackDetail.tsx
@@ -1,0 +1,381 @@
+import {
+  Alert,
+  Anchor,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Container,
+  Divider,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAlertCircle,
+  IconArrowLeft,
+  IconBrandGithub,
+  IconMessageCircle,
+  IconSend,
+  IconThumbUp,
+} from '@tabler/icons-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  addFeedbackComment,
+  FeedbackApiError,
+  getFeedback,
+  setFeedbackVote,
+} from '../../lib/feedback/api';
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_STATUSES,
+  isTerminalStatus,
+} from '../../lib/feedback/config';
+import type { FeedbackDetail as FeedbackDetailType } from '../../lib/feedback/types';
+import { FeedbackProvider } from './FeedbackProvider';
+import { TurnstileAction, type TurnstileActionHandle, TurnstileWidget } from './Turnstile';
+
+interface Props {
+  number: number;
+  initialItem?: FeedbackDetailType;
+}
+
+interface CommentForm {
+  body: string;
+  displayName: string;
+  turnstileToken: string;
+}
+
+const statusColors = {
+  'under-review': 'gray',
+  planned: 'violet',
+  'in-progress': 'yellow',
+  completed: 'green',
+  rejected: 'red',
+} as const;
+
+function FeedbackDetailContent({ number, initialItem }: Props) {
+  const [item, setItem] = useState(initialItem);
+  const [siteKey, setSiteKey] = useState('');
+  const [loading, setLoading] = useState(!initialItem);
+  const [error, setError] = useState<string>();
+  const [voting, setVoting] = useState(false);
+  const [commenting, setCommenting] = useState(false);
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
+  const voteChallengeRef = useRef<TurnstileActionHandle>(null);
+  const commentForm = useForm<CommentForm>({
+    initialValues: { body: '', displayName: '', turnstileToken: '' },
+    validate: {
+      body: (value) => (value.trim().length < 2 ? 'Write at least 2 characters.' : null),
+      turnstileToken: (value) => (!value ? 'Complete the verification.' : null),
+    },
+  });
+  const setCommentToken = useCallback(
+    (token: string | undefined) => commentForm.setFieldValue('turnstileToken', token ?? ''),
+    [commentForm],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void getFeedback(number, controller.signal)
+      .then((response) => {
+        setItem(response.item);
+        setSiteKey(response.turnstileSiteKey);
+        setError(undefined);
+      })
+      .catch((requestError: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(
+          requestError instanceof Error ? requestError.message : 'Feedback could not be loaded.',
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [number]);
+
+  const vote = async () => {
+    if (!item || !siteKey || !voteChallengeRef.current) return;
+    setVoting(true);
+    try {
+      const token = await voteChallengeRef.current.execute();
+      const result = await setFeedbackVote(number, !item.viewerHasVoted, token);
+      setItem((current) =>
+        current
+          ? {
+              ...current,
+              voteCount: result.voteCount,
+              viewerHasVoted: result.viewerHasVoted,
+            }
+          : current,
+      );
+      notifications.show({
+        color: result.viewerHasVoted ? 'green' : 'gray',
+        title: result.viewerHasVoted ? 'Vote recorded' : 'Vote removed',
+        message: result.viewerHasVoted
+          ? 'Thanks for helping prioritize this request.'
+          : 'Your vote has been removed.',
+      });
+    } catch (voteError) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not update vote',
+        message: voteError instanceof Error ? voteError.message : 'Please try again.',
+      });
+    } finally {
+      setVoting(false);
+    }
+  };
+
+  const submitComment = commentForm.onSubmit(async (values) => {
+    setCommenting(true);
+    try {
+      const result = await addFeedbackComment(number, values);
+      setItem((current) =>
+        current
+          ? {
+              ...current,
+              comments: result.comments,
+              commentCount: result.comments.length,
+            }
+          : current,
+      );
+      commentForm.setValues({ body: '', displayName: '', turnstileToken: '' });
+      setTurnstileResetKey((value) => value + 1);
+      notifications.show({
+        color: 'green',
+        title: 'Comment added',
+        message: 'Your comment is now part of the discussion.',
+      });
+    } catch (commentError) {
+      if (commentError instanceof FeedbackApiError && commentError.fieldErrors) {
+        commentForm.setErrors(
+          Object.fromEntries(
+            Object.entries(commentError.fieldErrors).map(([field, messages]) => [
+              field,
+              messages[0],
+            ]),
+          ),
+        );
+      }
+      notifications.show({
+        color: 'red',
+        title: 'Could not add comment',
+        message: commentError instanceof Error ? commentError.message : 'Please try again.',
+      });
+      commentForm.setFieldValue('turnstileToken', '');
+      setTurnstileResetKey((value) => value + 1);
+    } finally {
+      setCommenting(false);
+    }
+  });
+
+  if (loading && !item) {
+    return (
+      <Container size="md" className="feedback-shell">
+        <Group justify="center">
+          <Loader />
+        </Group>
+      </Container>
+    );
+  }
+
+  if (!item) {
+    return (
+      <Container size="md" className="feedback-shell">
+        <Alert
+          color="red"
+          title="Feedback could not be loaded"
+          icon={<IconAlertCircle size={18} />}
+        >
+          {error || 'This feedback item does not exist.'}
+        </Alert>
+      </Container>
+    );
+  }
+
+  const terminal = isTerminalStatus(item.status);
+  return (
+    <Container size="md" className="feedback-shell">
+      <Stack gap="xl">
+        <Anchor href="/feedback" className="feedback-back">
+          <Group gap={6}>
+            <IconArrowLeft size={17} />
+            <Text size="sm" fw={600}>
+              Back to feedback
+            </Text>
+          </Group>
+        </Anchor>
+
+        {error && (
+          <Alert color="yellow" title="Could not refresh feedback">
+            Showing the latest available version. {error}
+          </Alert>
+        )}
+
+        <Paper className="feedback-detail-card" withBorder>
+          <Stack gap="lg">
+            <Group justify="space-between" align="flex-start">
+              <Group gap={8}>
+                <Badge color={statusColors[item.status]} variant="light">
+                  {FEEDBACK_STATUSES[item.status].label}
+                </Badge>
+                <Badge color="dark" variant="outline">
+                  {FEEDBACK_CATEGORIES[item.category].label}
+                </Badge>
+              </Group>
+              <Anchor
+                href={item.htmlUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open this feedback issue on GitHub"
+              >
+                <IconBrandGithub size={22} />
+              </Anchor>
+            </Group>
+            <Title order={1}>{item.title}</Title>
+            <Text className="feedback-body">{item.body}</Text>
+            <Divider />
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">
+                #{item.number} submitted by {item.authorName}
+              </Text>
+              <Button
+                variant={item.viewerHasVoted ? 'filled' : 'default'}
+                leftSection={<IconThumbUp size={18} />}
+                loading={voting}
+                disabled={terminal || !siteKey}
+                onClick={vote}
+              >
+                {item.viewerHasVoted ? 'Supported' : 'Support'} · {item.voteCount}
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        {terminal && (
+          <Alert color={item.status === 'completed' ? 'green' : 'red'}>
+            This item is {FEEDBACK_STATUSES[item.status].label.toLowerCase()} and is now read-only.
+          </Alert>
+        )}
+
+        <Stack gap="md">
+          <Group gap={8}>
+            <IconMessageCircle size={21} />
+            <Title order={2}>Discussion ({item.commentCount})</Title>
+          </Group>
+          {item.comments.length ? (
+            item.comments.map((comment) => (
+              <Paper key={comment.id} className="feedback-comment" withBorder>
+                <Group align="flex-start" wrap="nowrap">
+                  <Avatar
+                    src={comment.authorAvatarUrl}
+                    name={comment.authorName}
+                    color={comment.isDeveloper ? 'violet' : 'yellow'}
+                    radius="xl"
+                  />
+                  <Stack gap={6} className="feedback-comment-content">
+                    <Group gap={8}>
+                      {comment.authorUrl ? (
+                        <Anchor
+                          href={comment.authorUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          fw={700}
+                        >
+                          {comment.authorName}
+                        </Anchor>
+                      ) : (
+                        <Text fw={700}>{comment.authorName}</Text>
+                      )}
+                      {comment.isDeveloper && (
+                        <Badge color="violet" size="sm">
+                          Excalimate team
+                        </Badge>
+                      )}
+                      <Text size="xs" c="dimmed">
+                        {new Intl.DateTimeFormat('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        }).format(new Date(comment.createdAt))}
+                      </Text>
+                    </Group>
+                    <Text className="feedback-body">{comment.body}</Text>
+                  </Stack>
+                </Group>
+              </Paper>
+            ))
+          ) : (
+            <Text c="dimmed">No comments yet. Start the discussion.</Text>
+          )}
+        </Stack>
+
+        {!terminal && (
+          <Paper className="feedback-comment-form" withBorder>
+            <Box component="form" onSubmit={submitComment}>
+              <Stack>
+                <Title order={3}>Add to the discussion</Title>
+                <Textarea
+                  label="Comment"
+                  placeholder="Share context, a use case, or a question"
+                  autosize
+                  minRows={4}
+                  maxRows={8}
+                  maxLength={2000}
+                  required
+                  {...commentForm.getInputProps('body')}
+                />
+                <TextInput
+                  label="Display name"
+                  description="Optional and public. Leave blank to post as Anonymous."
+                  placeholder="Anonymous"
+                  maxLength={60}
+                  {...commentForm.getInputProps('displayName')}
+                />
+                <TurnstileWidget
+                  siteKey={siteKey}
+                  action="comment_feedback"
+                  resetKey={turnstileResetKey}
+                  onToken={setCommentToken}
+                />
+                {commentForm.errors.turnstileToken && (
+                  <Text c="red" size="sm" role="alert">
+                    {commentForm.errors.turnstileToken}
+                  </Text>
+                )}
+                <Group justify="flex-end">
+                  <Button
+                    type="submit"
+                    loading={commenting}
+                    disabled={!siteKey}
+                    leftSection={<IconSend size={17} />}
+                  >
+                    Post comment
+                  </Button>
+                </Group>
+              </Stack>
+            </Box>
+          </Paper>
+        )}
+      </Stack>
+      <TurnstileAction ref={voteChallengeRef} siteKey={siteKey} action="vote_feedback" />
+    </Container>
+  );
+}
+
+export default function FeedbackDetail(props: Props) {
+  return (
+    <FeedbackProvider>
+      <FeedbackDetailContent {...props} />
+    </FeedbackProvider>
+  );
+}

--- a/landing-page/src/components/feedback/FeedbackProvider.tsx
+++ b/landing-page/src/components/feedback/FeedbackProvider.tsx
@@ -1,0 +1,43 @@
+import '@mantine/core/styles.css';
+import '@mantine/notifications/styles.css';
+import './feedback.css';
+
+import { createTheme, MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
+import type { ReactNode } from 'react';
+
+const theme = createTheme({
+  fontFamily: "'InterVariable', 'Inter', system-ui, sans-serif",
+  headings: {
+    fontFamily: "'BricolageGrotesqueVariable', system-ui, sans-serif",
+  },
+  primaryColor: 'excalimate',
+  colors: {
+    excalimate: [
+      '#fff9db',
+      '#fff0ad',
+      '#ffe77c',
+      '#ffdc45',
+      '#ffd21a',
+      '#ffc800',
+      '#ffc300',
+      '#e0a900',
+      '#c89400',
+      '#ad7f00',
+    ],
+  },
+  defaultRadius: 'md',
+});
+
+interface Props {
+  children: ReactNode;
+}
+
+export function FeedbackProvider({ children }: Props) {
+  return (
+    <MantineProvider theme={theme}>
+      <Notifications position="bottom-right" />
+      {children}
+    </MantineProvider>
+  );
+}

--- a/landing-page/src/components/feedback/FeedbackProvider.tsx
+++ b/landing-page/src/components/feedback/FeedbackProvider.tsx
@@ -2,7 +2,7 @@ import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
 import './feedback.css';
 
-import { createTheme, MantineProvider } from '@mantine/core';
+import { Button, createTheme, MantineProvider, type CSSVariablesResolver } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import type { ReactNode } from 'react';
 
@@ -12,6 +12,7 @@ const theme = createTheme({
     fontFamily: "'BricolageGrotesqueVariable', system-ui, sans-serif",
   },
   primaryColor: 'excalimate',
+  autoContrast: true,
   colors: {
     excalimate: [
       '#fff9db',
@@ -27,6 +28,22 @@ const theme = createTheme({
     ],
   },
   defaultRadius: 'md',
+  components: {
+    Button: Button.extend({
+      classNames: {
+        root: 'feedback-button',
+      },
+    }),
+  },
+});
+
+const cssVariablesResolver: CSSVariablesResolver = () => ({
+  variables: {
+    '--mantine-color-dimmed': 'var(--tx3)',
+    '--mantine-color-placeholder': 'var(--tx3)',
+  },
+  light: {},
+  dark: {},
 });
 
 interface Props {
@@ -35,7 +52,7 @@ interface Props {
 
 export function FeedbackProvider({ children }: Props) {
   return (
-    <MantineProvider theme={theme}>
+    <MantineProvider theme={theme} cssVariablesResolver={cssVariablesResolver}>
       <Notifications position="bottom-right" />
       {children}
     </MantineProvider>

--- a/landing-page/src/components/feedback/SubmitFeedbackModal.test.tsx
+++ b/landing-page/src/components/feedback/SubmitFeedbackModal.test.tsx
@@ -1,0 +1,69 @@
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isFeedbackListStale } from '../../lib/feedback/api';
+import { SubmitFeedbackModal } from './SubmitFeedbackModal';
+
+const { createFeedbackMock } = vi.hoisted(() => ({
+  createFeedbackMock: vi.fn(),
+}));
+
+vi.mock('../../lib/feedback/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/feedback/api')>(
+    '../../lib/feedback/api',
+  );
+  return {
+    ...actual,
+    createFeedback: createFeedbackMock,
+  };
+});
+
+vi.mock('./Turnstile', () => ({
+  TurnstileWidget: ({ onToken }: { onToken: (token: string) => void }) => (
+    <button type="button" onClick={() => onToken('turnstile-token')}>
+      Complete verification
+    </button>
+  ),
+}));
+
+describe('SubmitFeedbackModal', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('shows confirmation before navigating and marks the feedback list stale', async () => {
+    createFeedbackMock.mockResolvedValue({ number: 123, url: '/feedback/123' });
+    const onSubmitted = vi.fn();
+
+    render(
+      <MantineProvider>
+        <SubmitFeedbackModal
+          opened
+          onClose={vi.fn()}
+          onSubmitted={onSubmitted}
+          siteKey="site-key"
+        />
+      </MantineProvider>,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: /^Title/u }), {
+      target: { value: 'Add a presentation timer' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /^Description/u }), {
+      target: { value: 'Show elapsed and remaining time while presenting a scene.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Complete verification' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit feedback' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Feedback submitted' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Opening your feedback...')).toBeInTheDocument();
+    expect(isFeedbackListStale()).toBe(true);
+    expect(onSubmitted).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalledWith('/feedback/123'), {
+      timeout: 2_000,
+    });
+  });
+});

--- a/landing-page/src/components/feedback/SubmitFeedbackModal.tsx
+++ b/landing-page/src/components/feedback/SubmitFeedbackModal.tsx
@@ -1,0 +1,154 @@
+import { Box, Button, Group, Modal, Select, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { IconBulb, IconSend } from '@tabler/icons-react';
+import { useCallback, useState } from 'react';
+import { createFeedback, FeedbackApiError } from '../../lib/feedback/api';
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_CATEGORY_IDS,
+  type FeedbackCategory,
+} from '../../lib/feedback/config';
+import { TurnstileWidget } from './Turnstile';
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  siteKey: string;
+}
+
+interface FormValues {
+  title: string;
+  description: string;
+  displayName: string;
+  category: FeedbackCategory;
+  turnstileToken: string;
+}
+
+export function SubmitFeedbackModal({ opened, onClose, siteKey }: Props) {
+  const [submitting, setSubmitting] = useState(false);
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
+  const form = useForm<FormValues>({
+    initialValues: {
+      title: '',
+      description: '',
+      displayName: '',
+      category: 'feature',
+      turnstileToken: '',
+    },
+    validate: {
+      title: (value) => (value.trim().length < 5 ? 'Use at least 5 characters.' : null),
+      description: (value) => (value.trim().length < 20 ? 'Use at least 20 characters.' : null),
+      turnstileToken: (value) => (!value ? 'Complete the verification.' : null),
+    },
+  });
+  const setTurnstileToken = useCallback(
+    (token: string | undefined) => form.setFieldValue('turnstileToken', token ?? ''),
+    [form],
+  );
+
+  const submit = form.onSubmit(async (values) => {
+    setSubmitting(true);
+    try {
+      const result = await createFeedback(values);
+      notifications.show({
+        color: 'green',
+        title: 'Feedback submitted',
+        message: 'Your suggestion is now under review.',
+      });
+      window.location.assign(result.url);
+    } catch (error) {
+      if (error instanceof FeedbackApiError && error.fieldErrors) {
+        form.setErrors(
+          Object.fromEntries(
+            Object.entries(error.fieldErrors).map(([field, messages]) => [field, messages[0]]),
+          ),
+        );
+      }
+      notifications.show({
+        color: 'red',
+        title: 'Could not submit feedback',
+        message: error instanceof Error ? error.message : 'Please try again.',
+      });
+      form.setFieldValue('turnstileToken', '');
+      setTurnstileResetKey((value) => value + 1);
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Suggest an improvement"
+      size="lg"
+      centered
+      closeOnClickOutside={!submitting}
+      closeOnEscape={!submitting}
+    >
+      <Box component="form" onSubmit={submit}>
+        <Stack>
+          <Text size="sm" c="dimmed">
+            Share one clear problem or idea. Similar requests can be merged by the team in GitHub.
+          </Text>
+          <TextInput
+            label="Title"
+            placeholder="What should Excalimate improve?"
+            maxLength={120}
+            required
+            leftSection={<IconBulb size={17} />}
+            {...form.getInputProps('title')}
+          />
+          <Select
+            label="Category"
+            data={FEEDBACK_CATEGORY_IDS.map((id) => ({
+              value: id,
+              label: FEEDBACK_CATEGORIES[id].label,
+            }))}
+            allowDeselect={false}
+            required
+            {...form.getInputProps('category')}
+          />
+          <Textarea
+            label="Description"
+            description="Explain the problem, desired outcome, and why it matters."
+            placeholder="Today I have to... It would be better if..."
+            autosize
+            minRows={5}
+            maxRows={10}
+            maxLength={5000}
+            required
+            {...form.getInputProps('description')}
+          />
+          <TextInput
+            label="Display name"
+            description="Optional and public. Leave blank to post as Anonymous."
+            placeholder="Anonymous"
+            maxLength={60}
+            {...form.getInputProps('displayName')}
+          />
+          <TurnstileWidget
+            siteKey={siteKey}
+            action="submit_feedback"
+            resetKey={turnstileResetKey}
+            onToken={setTurnstileToken}
+          />
+          {form.errors.turnstileToken && (
+            <Text c="red" size="sm" role="alert">
+              {form.errors.turnstileToken}
+            </Text>
+          )}
+          <Group justify="flex-end">
+            <Button variant="default" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={submitting} leftSection={<IconSend size={17} />}>
+              Submit feedback
+            </Button>
+          </Group>
+        </Stack>
+      </Box>
+    </Modal>
+  );
+}

--- a/landing-page/src/components/feedback/SubmitFeedbackModal.tsx
+++ b/landing-page/src/components/feedback/SubmitFeedbackModal.tsx
@@ -1,9 +1,25 @@
-import { Box, Button, Group, Modal, Select, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import {
+  Box,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  ThemeIcon,
+} from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
-import { IconBulb, IconSend } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
-import { createFeedback, FeedbackApiError } from '../../lib/feedback/api';
+import { IconBulb, IconCheck, IconSend } from '@tabler/icons-react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  createFeedback,
+  FeedbackApiError,
+  markFeedbackListStale,
+} from '../../lib/feedback/api';
 import {
   FEEDBACK_CATEGORIES,
   FEEDBACK_CATEGORY_IDS,
@@ -14,6 +30,7 @@ import { TurnstileWidget } from './Turnstile';
 interface Props {
   opened: boolean;
   onClose: () => void;
+  onSubmitted: (url: string) => void;
   siteKey: string;
 }
 
@@ -25,8 +42,11 @@ interface FormValues {
   turnstileToken: string;
 }
 
-export function SubmitFeedbackModal({ opened, onClose, siteKey }: Props) {
+const SUCCESS_STATE_DURATION_MS = 1_200;
+
+export function SubmitFeedbackModal({ opened, onClose, onSubmitted, siteKey }: Props) {
   const [submitting, setSubmitting] = useState(false);
+  const [submittedUrl, setSubmittedUrl] = useState<string>();
   const [turnstileResetKey, setTurnstileResetKey] = useState(0);
   const form = useForm<FormValues>({
     initialValues: {
@@ -47,16 +67,23 @@ export function SubmitFeedbackModal({ opened, onClose, siteKey }: Props) {
     [form],
   );
 
+  useEffect(() => {
+    if (!submittedUrl) return;
+    const timeout = window.setTimeout(() => onSubmitted(submittedUrl), SUCCESS_STATE_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [onSubmitted, submittedUrl]);
+
+  useEffect(() => {
+    if (!opened) setSubmittedUrl(undefined);
+  }, [opened]);
+
   const submit = form.onSubmit(async (values) => {
     setSubmitting(true);
     try {
       const result = await createFeedback(values);
-      notifications.show({
-        color: 'green',
-        title: 'Feedback submitted',
-        message: 'Your suggestion is now under review.',
-      });
-      window.location.assign(result.url);
+      markFeedbackListStale();
+      form.reset();
+      setSubmittedUrl(result.url);
     } catch (error) {
       if (error instanceof FeedbackApiError && error.fieldErrors) {
         form.setErrors(
@@ -80,75 +107,93 @@ export function SubmitFeedbackModal({ opened, onClose, siteKey }: Props) {
   return (
     <Modal
       opened={opened}
-      onClose={onClose}
-      title="Suggest an improvement"
+      onClose={submittedUrl ? () => undefined : onClose}
+      title={submittedUrl ? 'Feedback submitted' : 'Suggest an improvement'}
       size="lg"
       centered
-      closeOnClickOutside={!submitting}
-      closeOnEscape={!submitting}
+      closeOnClickOutside={!submitting && !submittedUrl}
+      closeOnEscape={!submitting && !submittedUrl}
+      withCloseButton={!submitting && !submittedUrl}
     >
-      <Box component="form" onSubmit={submit}>
-        <Stack>
-          <Text size="sm" c="dimmed">
-            Share one clear problem or idea. Similar requests can be merged by the team in GitHub.
+      {submittedUrl ? (
+        <Stack align="center" gap="md" py="xl" role="status" aria-live="polite">
+          <ThemeIcon color="green" variant="light" radius="xl" size={64}>
+            <IconCheck size={34} stroke={2.5} />
+          </ThemeIcon>
+          <Text c="dimmed" ta="center">
+            Your feedback is live and is now under review.
           </Text>
-          <TextInput
-            label="Title"
-            placeholder="What should Excalimate improve?"
-            maxLength={120}
-            required
-            leftSection={<IconBulb size={17} />}
-            {...form.getInputProps('title')}
-          />
-          <Select
-            label="Category"
-            data={FEEDBACK_CATEGORY_IDS.map((id) => ({
-              value: id,
-              label: FEEDBACK_CATEGORIES[id].label,
-            }))}
-            allowDeselect={false}
-            required
-            {...form.getInputProps('category')}
-          />
-          <Textarea
-            label="Description"
-            description="Explain the problem, desired outcome, and why it matters."
-            placeholder="Today I have to... It would be better if..."
-            autosize
-            minRows={5}
-            maxRows={10}
-            maxLength={5000}
-            required
-            {...form.getInputProps('description')}
-          />
-          <TextInput
-            label="Display name"
-            description="Optional and public. Leave blank to post as Anonymous."
-            placeholder="Anonymous"
-            maxLength={60}
-            {...form.getInputProps('displayName')}
-          />
-          <TurnstileWidget
-            siteKey={siteKey}
-            action="submit_feedback"
-            resetKey={turnstileResetKey}
-            onToken={setTurnstileToken}
-          />
-          {form.errors.turnstileToken && (
-            <Text c="red" size="sm" role="alert">
-              {form.errors.turnstileToken}
+          <Group gap="xs">
+            <Loader size="xs" color="green" />
+            <Text size="sm" fw={600}>
+              Opening your feedback...
             </Text>
-          )}
-          <Group justify="flex-end">
-            <Button variant="default" onClick={onClose} disabled={submitting}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={submitting} leftSection={<IconSend size={17} />}>
-              Submit feedback
-            </Button>
           </Group>
         </Stack>
-      </Box>
+      ) : (
+        <Box component="form" onSubmit={submit}>
+          <Stack>
+            <Text size="sm" c="dimmed">
+              Share one clear problem or idea. Similar requests can be merged by the team in GitHub.
+            </Text>
+            <TextInput
+              label="Title"
+              placeholder="What should Excalimate improve?"
+              maxLength={120}
+              required
+              leftSection={<IconBulb size={17} />}
+              {...form.getInputProps('title')}
+            />
+            <Select
+              label="Category"
+              data={FEEDBACK_CATEGORY_IDS.map((id) => ({
+                value: id,
+                label: FEEDBACK_CATEGORIES[id].label,
+              }))}
+              allowDeselect={false}
+              required
+              {...form.getInputProps('category')}
+            />
+            <Textarea
+              label="Description"
+              description="Explain the problem, desired outcome, and why it matters."
+              placeholder="Today I have to... It would be better if..."
+              autosize
+              minRows={5}
+              maxRows={10}
+              maxLength={5000}
+              required
+              {...form.getInputProps('description')}
+            />
+            <TextInput
+              label="Display name"
+              description="Optional and public. Leave blank to post as Anonymous."
+              placeholder="Anonymous"
+              maxLength={60}
+              {...form.getInputProps('displayName')}
+            />
+            <TurnstileWidget
+              siteKey={siteKey}
+              action="submit_feedback"
+              resetKey={turnstileResetKey}
+              onToken={setTurnstileToken}
+            />
+            {form.errors.turnstileToken && (
+              <Text c="red" size="sm" role="alert">
+                {form.errors.turnstileToken}
+              </Text>
+            )}
+            <Group justify="flex-end">
+              <Button variant="default" onClick={onClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" loading={submitting} leftSection={<IconSend size={17} />}>
+                Submit feedback
+              </Button>
+            </Group>
+          </Stack>
+        </Box>
+      )}
     </Modal>
   );
 }

--- a/landing-page/src/components/feedback/Turnstile.test.tsx
+++ b/landing-page/src/components/feedback/Turnstile.test.tsx
@@ -1,0 +1,36 @@
+import { MantineProvider } from '@mantine/core';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TurnstileAction } from './Turnstile';
+
+describe('TurnstileAction', () => {
+  afterEach(() => {
+    delete window.turnstile;
+  });
+
+  it('uses the supported interaction-only configuration', async () => {
+    const renderWidget = vi.fn().mockReturnValue('widget-id');
+    window.turnstile = {
+      render: renderWidget,
+      execute: vi.fn(),
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(
+      <MantineProvider>
+        <TurnstileAction siteKey="test-site-key" action="vote_feedback" />
+      </MantineProvider>,
+    );
+
+    await waitFor(() => expect(renderWidget).toHaveBeenCalled());
+    expect(renderWidget).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        size: 'flexible',
+        appearance: 'interaction-only',
+        execution: 'execute',
+      }),
+    );
+  });
+});

--- a/landing-page/src/components/feedback/Turnstile.tsx
+++ b/landing-page/src/components/feedback/Turnstile.tsx
@@ -4,7 +4,8 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, type RefObject } fr
 interface TurnstileOptions {
   sitekey: string;
   action: string;
-  size?: 'normal' | 'compact' | 'flexible' | 'invisible';
+  size?: 'normal' | 'compact' | 'flexible';
+  appearance?: 'always' | 'execute' | 'interaction-only';
   execution?: 'render' | 'execute';
   callback: (token: string) => void;
   'error-callback': () => void;
@@ -122,7 +123,8 @@ export const TurnstileAction = forwardRef<TurnstileActionHandle, ActionProps>(
           widgetIdRef.current = api.render(container, {
             sitekey: siteKey,
             action,
-            size: 'invisible',
+            size: 'flexible',
+            appearance: 'interaction-only',
             execution: 'execute',
             callback: (token) => {
               shouldResetRef.current = true;

--- a/landing-page/src/components/feedback/Turnstile.tsx
+++ b/landing-page/src/components/feedback/Turnstile.tsx
@@ -1,0 +1,181 @@
+import { Box } from '@mantine/core';
+import { forwardRef, useEffect, useImperativeHandle, useRef, type RefObject } from 'react';
+
+interface TurnstileOptions {
+  sitekey: string;
+  action: string;
+  size?: 'normal' | 'compact' | 'flexible' | 'invisible';
+  execution?: 'render' | 'execute';
+  callback: (token: string) => void;
+  'error-callback': () => void;
+  'expired-callback': () => void;
+}
+
+interface TurnstileApi {
+  render(container: HTMLElement, options: TurnstileOptions): string;
+  execute(widgetId: string): void;
+  reset(widgetId: string): void;
+  remove(widgetId: string): void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+let scriptPromise: Promise<TurnstileApi> | undefined;
+
+function loadTurnstile(): Promise<TurnstileApi> {
+  if (window.turnstile) return Promise.resolve(window.turnstile);
+  if (scriptPromise) return scriptPromise;
+  const promise = new Promise<TurnstileApi>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    script.async = true;
+    script.defer = true;
+    script.onload = () =>
+      window.turnstile ? resolve(window.turnstile) : reject(new Error('Turnstile failed to load.'));
+    script.onerror = () => reject(new Error('Turnstile failed to load.'));
+    document.head.appendChild(script);
+  }).catch((error: unknown): never => {
+    scriptPromise = undefined;
+    throw error;
+  });
+  scriptPromise = promise;
+  return promise;
+}
+
+interface WidgetProps {
+  siteKey: string;
+  action: string;
+  resetKey: number;
+  onToken: (token: string | undefined) => void;
+}
+
+export function TurnstileWidget({ siteKey, action, resetKey, onToken }: WidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onTokenRef = useRef(onToken);
+
+  useEffect(() => {
+    onTokenRef.current = onToken;
+  }, [onToken]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !siteKey) return;
+    let widgetId: string | undefined;
+    let disposed = false;
+    void loadTurnstile()
+      .then((api) => {
+        if (disposed) return;
+        widgetId = api.render(container, {
+          sitekey: siteKey,
+          action,
+          size: 'flexible',
+          callback: (token) => onTokenRef.current(token),
+          'error-callback': () => onTokenRef.current(undefined),
+          'expired-callback': () => onTokenRef.current(undefined),
+        });
+      })
+      .catch(() => onTokenRef.current(undefined));
+    return () => {
+      disposed = true;
+      if (widgetId && window.turnstile) window.turnstile.remove(widgetId);
+    };
+  }, [action, resetKey, siteKey]);
+
+  return <Box ref={containerRef} className="feedback-turnstile" />;
+}
+
+export interface TurnstileActionHandle {
+  execute: () => Promise<string>;
+}
+
+interface ActionProps {
+  siteKey: string;
+  action: string;
+}
+
+export const TurnstileAction = forwardRef<TurnstileActionHandle, ActionProps>(
+  function TurnstileAction({ siteKey, action }, forwardedRef) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const widgetIdRef = useRef<string | undefined>(undefined);
+    const apiRef = useRef<TurnstileApi | undefined>(undefined);
+    const pendingRef = useRef<
+      | {
+          resolve: (token: string) => void;
+          reject: (error: Error) => void;
+        }
+      | undefined
+    >(undefined);
+    const shouldResetRef = useRef(false);
+
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container || !siteKey) return;
+      let disposed = false;
+      void loadTurnstile()
+        .then((api) => {
+          if (disposed) return;
+          apiRef.current = api;
+          widgetIdRef.current = api.render(container, {
+            sitekey: siteKey,
+            action,
+            size: 'invisible',
+            execution: 'execute',
+            callback: (token) => {
+              shouldResetRef.current = true;
+              pendingRef.current?.resolve(token);
+              pendingRef.current = undefined;
+            },
+            'error-callback': () => {
+              pendingRef.current?.reject(new Error('Verification failed. Please try again.'));
+              pendingRef.current = undefined;
+            },
+            'expired-callback': () => {
+              pendingRef.current?.reject(new Error('Verification expired. Please try again.'));
+              pendingRef.current = undefined;
+            },
+          });
+        })
+        .catch((error: unknown) => {
+          pendingRef.current?.reject(
+            error instanceof Error ? error : new Error('Verification could not load.'),
+          );
+          pendingRef.current = undefined;
+        });
+      return () => {
+        disposed = true;
+        if (widgetIdRef.current && apiRef.current) {
+          apiRef.current.remove(widgetIdRef.current);
+        }
+      };
+    }, [action, siteKey]);
+
+    useImperativeHandle(
+      forwardedRef,
+      () => ({
+        execute: () => {
+          if (!apiRef.current || !widgetIdRef.current) {
+            return Promise.reject(new Error('Verification is still loading.'));
+          }
+          if (pendingRef.current) {
+            return Promise.reject(new Error('Verification is already in progress.'));
+          }
+          if (shouldResetRef.current) {
+            apiRef.current.reset(widgetIdRef.current);
+            shouldResetRef.current = false;
+          }
+          return new Promise<string>((resolve, reject) => {
+            pendingRef.current = { resolve, reject };
+            apiRef.current?.execute(widgetIdRef.current as string);
+          });
+        },
+      }),
+      [],
+    );
+
+    return <Box ref={containerRef as RefObject<HTMLDivElement>} />;
+  },
+);

--- a/landing-page/src/components/feedback/feedback.css
+++ b/landing-page/src/components/feedback/feedback.css
@@ -1,0 +1,138 @@
+.feedback-shell {
+  padding-block: 72px 96px;
+  min-height: calc(100vh - 64px);
+}
+
+.feedback-heading {
+  max-width: 720px;
+}
+
+.feedback-heading h1 {
+  font-size: clamp(2.5rem, 6vw, 4.75rem);
+  line-height: 1.04;
+  letter-spacing: -0.04em;
+}
+
+.feedback-filters,
+.feedback-card,
+.feedback-empty {
+  border: 2px solid var(--border-c);
+  background: var(--surface);
+  box-shadow: 4px 4px 0 var(--border-c);
+}
+
+.feedback-filters {
+  padding: 20px;
+}
+
+.feedback-card {
+  padding: 22px;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.feedback-card:hover {
+  box-shadow: 6px 6px 0 var(--border-c);
+  transform: translate(-1px, -1px);
+}
+
+.feedback-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.feedback-card-title {
+  color: var(--tx);
+  font-size: clamp(1.2rem, 3vw, 1.55rem);
+  transition: color 150ms ease;
+}
+
+.feedback-card-title:hover {
+  color: color-mix(in srgb, var(--tx) 72%, var(--p4));
+}
+
+.feedback-card-meta {
+  color: var(--tx3);
+}
+
+.feedback-vote {
+  min-width: 76px;
+}
+
+.feedback-empty {
+  min-height: 300px;
+  padding: 48px 24px;
+}
+
+.feedback-detail-card,
+.feedback-comment,
+.feedback-comment-form {
+  border: 2px solid var(--border-c);
+  background: var(--surface);
+}
+
+.feedback-detail-card {
+  padding: clamp(24px, 5vw, 48px);
+  box-shadow: 5px 5px 0 var(--border-c);
+}
+
+.feedback-detail-card h1 {
+  font-size: clamp(2rem, 6vw, 3.75rem);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.feedback-body {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.feedback-comment,
+.feedback-comment-form {
+  padding: 20px;
+}
+
+.feedback-comment-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.feedback-back {
+  align-self: flex-start;
+  color: var(--tx2);
+}
+
+.feedback-turnstile {
+  min-height: 65px;
+}
+
+@media (max-width: 767px) {
+  .feedback-shell {
+    padding-block: 48px 72px;
+  }
+
+  .feedback-filters > div > div:first-child {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .feedback-card {
+    padding: 16px;
+  }
+
+  .feedback-card > div {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .feedback-vote {
+    align-self: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feedback-card {
+    transition: none;
+  }
+}

--- a/landing-page/src/components/feedback/feedback.css
+++ b/landing-page/src/components/feedback/feedback.css
@@ -13,6 +13,68 @@
   letter-spacing: -0.04em;
 }
 
+.feedback-button {
+  color: var(--tx);
+  border: var(--border-w) solid var(--border-c);
+  box-shadow: 3px 3px 0 var(--border-c);
+  transition:
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.feedback-button[data-variant='filled'] {
+  color: var(--tx);
+}
+
+.feedback-button[data-variant='light'] {
+  color: var(--tx);
+  background: var(--mantine-color-excalimate-1);
+}
+
+.feedback-button:hover:not(:disabled, [data-disabled]) {
+  box-shadow: 5px 5px 0 var(--border-c);
+  transform: translate(-1px, -1px);
+}
+
+.feedback-button:active:not(:disabled, [data-disabled]) {
+  box-shadow: 1px 1px 0 var(--border-c);
+  transform: translate(2px, 2px);
+}
+
+.feedback-button:disabled,
+.feedback-button[data-disabled] {
+  box-shadow: none;
+}
+
+.feedback-status-tab {
+  color: var(--tx2);
+  font-weight: 600;
+  border: var(--border-w) solid transparent;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.feedback-status-tab[data-active] {
+  color: var(--tx);
+  background: var(--accent);
+  border-color: var(--border-c);
+  box-shadow: 3px 3px 0 var(--border-c);
+}
+
+.feedback-status-tab[data-active]:hover {
+  color: var(--tx);
+  background: var(--accent);
+  box-shadow: 4px 4px 0 var(--border-c);
+  transform: translate(-1px, -1px);
+}
+
+.feedback-status-badge {
+  color: var(--tx);
+}
+
 .feedback-filters,
 .feedback-card,
 .feedback-empty {
@@ -103,6 +165,35 @@
   color: var(--tx2);
 }
 
+.feedback-github-link {
+  color: var(--tx);
+  background: var(--surface);
+  border: var(--border-w) solid var(--border-c);
+  box-shadow: 3px 3px 0 var(--border-c);
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.feedback-github-link:hover {
+  color: var(--tx);
+  background: var(--accent);
+  box-shadow: 5px 5px 0 var(--border-c);
+  transform: translate(-1px, -1px);
+}
+
+.feedback-github-link:active {
+  box-shadow: 1px 1px 0 var(--border-c);
+  transform: translate(2px, 2px);
+}
+
+.feedback-shell :focus-visible,
+.mantine-Modal-root :focus-visible {
+  outline-color: var(--p4);
+}
+
 .feedback-turnstile {
   min-height: 65px;
 }
@@ -132,7 +223,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .feedback-card {
+  .feedback-button,
+  .feedback-card,
+  .feedback-github-link,
+  .feedback-status-tab {
     transition: none;
   }
 }

--- a/landing-page/src/env.d.ts
+++ b/landing-page/src/env.d.ts
@@ -1,0 +1,17 @@
+declare namespace Cloudflare {
+  interface Env {
+    ASSETS: Fetcher;
+    GITHUB_APP_ID: string;
+    GITHUB_APP_INSTALLATION_ID: string;
+    GITHUB_APP_PRIVATE_KEY: string;
+    GITHUB_APP_BOT_LOGIN: string;
+    GITHUB_REPOSITORY_OWNER: string;
+    GITHUB_REPOSITORY_NAME: string;
+    FEEDBACK_COOKIE_SECRET: string;
+    TURNSTILE_SECRET_KEY: string;
+    TURNSTILE_SITE_KEY: string;
+    TURNSTILE_ALLOWED_HOSTNAMES: string;
+    FEEDBACK_SUBMISSION_RATE_LIMITER: RateLimit;
+    FEEDBACK_INTERACTION_RATE_LIMITER: RateLimit;
+  }
+}

--- a/landing-page/src/lib/feedback/api.test.ts
+++ b/landing-page/src/lib/feedback/api.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listFeedback, type FeedbackListQuery } from './api';
+
+const query: FeedbackListQuery = {
+  search: '',
+  category: 'all',
+  status: 'all',
+  sort: 'top',
+  page: 1,
+};
+
+describe('feedback API client', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json({
+        items: [],
+        page: 1,
+        pageSize: 20,
+        total: 0,
+        totalPages: 1,
+        turnstileSiteKey: 'site-key',
+      }),
+    );
+  });
+
+  it('bypasses browser and edge caches for an explicit fresh list request', async () => {
+    await listFeedback(query, { fresh: true });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/api\/feedback\?.*_fresh=\d+$/u),
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+});

--- a/landing-page/src/lib/feedback/api.ts
+++ b/landing-page/src/lib/feedback/api.ts
@@ -7,6 +7,8 @@ import type {
   FeedbackMutationResponse,
 } from './types';
 
+const FEEDBACK_LIST_STALE_KEY = 'excalimate-feedback-list-stale';
+
 export class FeedbackApiError extends Error {
   constructor(
     message: string,
@@ -48,9 +50,33 @@ export interface FeedbackListQuery {
   page: number;
 }
 
+interface FeedbackListRequestOptions {
+  signal?: AbortSignal;
+  fresh?: boolean;
+}
+
+export function markFeedbackListStale(): void {
+  if (typeof window !== 'undefined') {
+    window.sessionStorage.setItem(FEEDBACK_LIST_STALE_KEY, 'true');
+  }
+}
+
+export function isFeedbackListStale(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.sessionStorage.getItem(FEEDBACK_LIST_STALE_KEY) === 'true'
+  );
+}
+
+export function clearFeedbackListStale(): void {
+  if (typeof window !== 'undefined') {
+    window.sessionStorage.removeItem(FEEDBACK_LIST_STALE_KEY);
+  }
+}
+
 export function listFeedback(
   query: FeedbackListQuery,
-  signal?: AbortSignal,
+  options: FeedbackListRequestOptions = {},
 ): Promise<FeedbackListResponse> {
   const search = new URLSearchParams({
     search: query.search,
@@ -59,7 +85,12 @@ export function listFeedback(
     sort: query.sort,
     page: String(query.page),
   });
-  return request<FeedbackListResponse>(`/api/feedback?${search}`, {}, signal);
+  if (options.fresh) search.set('_fresh', String(Date.now()));
+  return request<FeedbackListResponse>(
+    `/api/feedback?${search}`,
+    options.fresh ? { cache: 'no-store' } : {},
+    options.signal,
+  );
 }
 
 export function getFeedback(number: number, signal?: AbortSignal): Promise<FeedbackDetailResponse> {

--- a/landing-page/src/lib/feedback/api.ts
+++ b/landing-page/src/lib/feedback/api.ts
@@ -1,0 +1,105 @@
+import type {
+  ApiErrorResponse,
+  FeedbackCommentsResponse,
+  FeedbackCreatedResponse,
+  FeedbackDetailResponse,
+  FeedbackListResponse,
+  FeedbackMutationResponse,
+} from './types';
+
+export class FeedbackApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly fieldErrors?: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'FeedbackApiError';
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    credentials: 'same-origin',
+    signal,
+    headers: {
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      ...init.headers,
+    },
+  });
+  const payload = (await response.json()) as T | ApiErrorResponse;
+  if (!response.ok) {
+    const error = (payload as ApiErrorResponse).error;
+    throw new FeedbackApiError(
+      error?.message || 'Feedback could not be loaded.',
+      error?.code || 'request_failed',
+      error?.fieldErrors,
+    );
+  }
+  return payload as T;
+}
+
+export interface FeedbackListQuery {
+  search: string;
+  category: string;
+  status: string;
+  sort: string;
+  page: number;
+}
+
+export function listFeedback(
+  query: FeedbackListQuery,
+  signal?: AbortSignal,
+): Promise<FeedbackListResponse> {
+  const search = new URLSearchParams({
+    search: query.search,
+    category: query.category,
+    status: query.status,
+    sort: query.sort,
+    page: String(query.page),
+  });
+  return request<FeedbackListResponse>(`/api/feedback?${search}`, {}, signal);
+}
+
+export function getFeedback(number: number, signal?: AbortSignal): Promise<FeedbackDetailResponse> {
+  return request<FeedbackDetailResponse>(`/api/feedback/${number}`, {}, signal);
+}
+
+export function createFeedback(input: {
+  title: string;
+  description: string;
+  displayName: string;
+  category: string;
+  turnstileToken: string;
+}): Promise<FeedbackCreatedResponse> {
+  return request<FeedbackCreatedResponse>('/api/feedback', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export function setFeedbackVote(
+  number: number,
+  add: boolean,
+  turnstileToken: string,
+): Promise<FeedbackMutationResponse> {
+  return request<FeedbackMutationResponse>(`/api/feedback/${number}/vote`, {
+    method: add ? 'POST' : 'DELETE',
+    body: JSON.stringify({ turnstileToken }),
+  });
+}
+
+export function addFeedbackComment(
+  number: number,
+  input: {
+    body: string;
+    displayName: string;
+    turnstileToken: string;
+  },
+): Promise<FeedbackCommentsResponse> {
+  return request<FeedbackCommentsResponse>(`/api/feedback/${number}/comments`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}

--- a/landing-page/src/lib/feedback/config.test.ts
+++ b/landing-page/src/lib/feedback/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FEEDBACK_LABEL_DEFINITIONS,
+  getCategoryFromLabels,
+  getStatusFromLabels,
+  isTerminalStatus,
+} from './config';
+
+describe('feedback label mapping', () => {
+  it('maps labels and applies safe defaults', () => {
+    expect(getCategoryFromLabels(['feedback: integration'])).toBe('integration');
+    expect(getCategoryFromLabels([])).toBe('other');
+    expect(getStatusFromLabels(['status: planned'])).toBe('planned');
+    expect(getStatusFromLabels([])).toBe('under-review');
+  });
+
+  it('marks only completed and rejected as terminal', () => {
+    expect(isTerminalStatus('completed')).toBe(true);
+    expect(isTerminalStatus('rejected')).toBe(true);
+    expect(isTerminalStatus('in-progress')).toBe(false);
+  });
+
+  it('defines unique repository labels', () => {
+    const names = FEEDBACK_LABEL_DEFINITIONS.map((label) => label.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/landing-page/src/lib/feedback/config.ts
+++ b/landing-page/src/lib/feedback/config.ts
@@ -1,0 +1,127 @@
+export const FEEDBACK_SCOPE_LABEL = 'feedback';
+export const FEEDBACK_CATEGORY_IDS = [
+  'feature',
+  'improvement',
+  'bug',
+  'integration',
+  'other',
+] as const;
+export const FEEDBACK_STATUS_IDS = [
+  'under-review',
+  'planned',
+  'in-progress',
+  'completed',
+  'rejected',
+] as const;
+
+export const FEEDBACK_CATEGORIES = {
+  feature: {
+    label: 'Feature request',
+    githubLabel: 'feedback: feature',
+    color: 'FFC300',
+    description: 'A new capability or workflow',
+  },
+  improvement: {
+    label: 'Improvement',
+    githubLabel: 'feedback: improvement',
+    color: 'EE5622',
+    description: 'An improvement to existing behavior',
+  },
+  bug: {
+    label: 'Bug',
+    githubLabel: 'feedback: bug',
+    color: 'D73A4A',
+    description: 'Something is not working as expected',
+  },
+  integration: {
+    label: 'Integration',
+    githubLabel: 'feedback: integration',
+    color: '7129C5',
+    description: 'A request involving another tool or platform',
+  },
+  other: {
+    label: 'Other',
+    githubLabel: 'feedback: other',
+    color: '656570',
+    description: 'Feedback that does not fit another category',
+  },
+} as const;
+
+export const FEEDBACK_STATUSES = {
+  'under-review': {
+    label: 'Under review',
+    githubLabel: 'status: under review',
+    color: '656570',
+    description: 'The team is reviewing this feedback',
+    terminal: false,
+  },
+  planned: {
+    label: 'Planned',
+    githubLabel: 'status: planned',
+    color: '7129C5',
+    description: 'Accepted and planned for future work',
+    terminal: false,
+  },
+  'in-progress': {
+    label: 'In progress',
+    githubLabel: 'status: in progress',
+    color: 'FFC300',
+    description: 'Work is currently underway',
+    terminal: false,
+  },
+  completed: {
+    label: 'Completed',
+    githubLabel: 'status: completed',
+    color: '169B3E',
+    description: 'The requested work has been completed',
+    terminal: true,
+  },
+  rejected: {
+    label: 'Rejected',
+    githubLabel: 'status: rejected',
+    color: 'D73A4A',
+    description: 'The team is not planning to pursue this feedback',
+    terminal: true,
+  },
+} as const;
+
+export type FeedbackCategory = (typeof FEEDBACK_CATEGORY_IDS)[number];
+export type FeedbackStatus = (typeof FEEDBACK_STATUS_IDS)[number];
+
+export const DEFAULT_FEEDBACK_STATUS: FeedbackStatus = 'under-review';
+
+export const FEEDBACK_LABEL_DEFINITIONS = [
+  {
+    name: FEEDBACK_SCOPE_LABEL,
+    color: '221E22',
+    description: 'Public feedback shown on excalimate.com',
+  },
+  ...Object.values(FEEDBACK_CATEGORIES).map(({ githubLabel, color, description }) => ({
+    name: githubLabel,
+    color,
+    description,
+  })),
+  ...Object.values(FEEDBACK_STATUSES).map(({ githubLabel, color, description }) => ({
+    name: githubLabel,
+    color,
+    description,
+  })),
+];
+
+export function getCategoryFromLabels(labels: readonly string[]): FeedbackCategory {
+  const entry = Object.entries(FEEDBACK_CATEGORIES).find(([, value]) =>
+    labels.includes(value.githubLabel),
+  );
+  return (entry?.[0] as FeedbackCategory | undefined) ?? 'other';
+}
+
+export function getStatusFromLabels(labels: readonly string[]): FeedbackStatus {
+  const entry = Object.entries(FEEDBACK_STATUSES).find(([, value]) =>
+    labels.includes(value.githubLabel),
+  );
+  return (entry?.[0] as FeedbackStatus | undefined) ?? DEFAULT_FEEDBACK_STATUS;
+}
+
+export function isTerminalStatus(status: FeedbackStatus): boolean {
+  return FEEDBACK_STATUSES[status].terminal;
+}

--- a/landing-page/src/lib/feedback/errors.ts
+++ b/landing-page/src/lib/feedback/errors.ts
@@ -1,0 +1,21 @@
+export class FeedbackError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'FeedbackError';
+  }
+}
+
+export function asFeedbackError(error: unknown): FeedbackError {
+  if (error instanceof FeedbackError) return error;
+  return new FeedbackError(
+    500,
+    'internal_error',
+    'Something went wrong while processing your feedback.',
+    { cause: error },
+  );
+}

--- a/landing-page/src/lib/feedback/github.test.ts
+++ b/landing-page/src/lib/feedback/github.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+
+import { generateKeyPairSync } from 'node:crypto';
+import { importPKCS8 } from 'jose';
+import { describe, expect, it } from 'vitest';
+import { normalizeGitHubPrivateKey } from './github';
+
+describe('GitHub App private keys', () => {
+  it('converts GitHub PKCS#1 RSA keys to importable PKCS#8', async () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const pkcs1 = privateKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+
+    const normalized = normalizeGitHubPrivateKey(pkcs1);
+
+    expect(normalized).toContain('BEGIN PRIVATE KEY');
+    await expect(importPKCS8(normalized, 'RS256')).resolves.toBeDefined();
+  });
+
+  it('preserves PKCS#8 keys', () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const pkcs8 = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString().trim();
+    expect(normalizeGitHubPrivateKey(pkcs8)).toBe(pkcs8);
+  });
+});

--- a/landing-page/src/lib/feedback/github.ts
+++ b/landing-page/src/lib/feedback/github.ts
@@ -1,0 +1,199 @@
+import { importPKCS8, SignJWT } from 'jose';
+import { FeedbackError } from './errors';
+
+const GITHUB_API = 'https://api.github.com';
+const GITHUB_API_VERSION = '2022-11-28';
+const REQUEST_TIMEOUT_MS = 12_000;
+const TOKEN_REFRESH_WINDOW_MS = 60_000;
+
+interface InstallationTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+interface CachedInstallationToken {
+  key: string;
+  token: string;
+  expiresAt: number;
+}
+
+let cachedInstallationToken: CachedInstallationToken | undefined;
+
+function requireValue(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new FeedbackError(
+      503,
+      'configuration_error',
+      `Feedback is unavailable because ${name} is not configured.`,
+    );
+  }
+  return value;
+}
+
+function decodePem(value: string, label: string): Uint8Array {
+  const base64 = value
+    .replace(`-----BEGIN ${label}-----`, '')
+    .replace(`-----END ${label}-----`, '')
+    .replace(/\s+/gu, '');
+  try {
+    return Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+  } catch (error) {
+    throw new FeedbackError(503, 'configuration_error', 'The GitHub App private key is invalid.', {
+      cause: error,
+    });
+  }
+}
+
+function encodeDer(tag: number, value: Uint8Array): Uint8Array {
+  const lengthBytes: number[] = [];
+  let length = value.length;
+  if (length < 128) {
+    lengthBytes.push(length);
+  } else {
+    while (length > 0) {
+      lengthBytes.unshift(length & 0xff);
+      length >>>= 8;
+    }
+    lengthBytes.unshift(0x80 | lengthBytes.length);
+  }
+  return Uint8Array.from([tag, ...lengthBytes, ...value]);
+}
+
+function encodePem(value: Uint8Array, label: string): string {
+  let binary = '';
+  for (const byte of value) binary += String.fromCharCode(byte);
+  const base64 = btoa(binary);
+  const lines = base64.match(/.{1,64}/gu) ?? [];
+  return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----`;
+}
+
+export function normalizeGitHubPrivateKey(value: string): string {
+  const normalized = value.replace(/\\n/gu, '\n').trim();
+  if (normalized.includes('-----BEGIN PRIVATE KEY-----')) return normalized;
+  if (!normalized.includes('-----BEGIN RSA PRIVATE KEY-----')) {
+    throw new FeedbackError(503, 'configuration_error', 'The GitHub App private key is invalid.');
+  }
+
+  const pkcs1 = decodePem(normalized, 'RSA PRIVATE KEY');
+  const version = Uint8Array.from([0x02, 0x01, 0x00]);
+  const rsaAlgorithmIdentifier = Uint8Array.from([
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+  ]);
+  const privateKey = encodeDer(0x04, pkcs1);
+  const body = Uint8Array.from([...version, ...rsaAlgorithmIdentifier, ...privateKey]);
+  return encodePem(encodeDer(0x30, body), 'PRIVATE KEY');
+}
+
+async function createAppJwt(env: Cloudflare.Env): Promise<string> {
+  const appId = requireValue(env.GITHUB_APP_ID, 'GITHUB_APP_ID');
+  const privateKey = await importPKCS8(
+    normalizeGitHubPrivateKey(requireValue(env.GITHUB_APP_PRIVATE_KEY, 'GITHUB_APP_PRIVATE_KEY')),
+    'RS256',
+  );
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuedAt(now - 30)
+    .setExpirationTime(now + 9 * 60)
+    .setIssuer(appId)
+    .sign(privateKey);
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    throw new FeedbackError(502, 'github_unavailable', 'GitHub is temporarily unavailable.', {
+      cause: error,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getInstallationToken(env: Cloudflare.Env): Promise<string> {
+  const appId = requireValue(env.GITHUB_APP_ID, 'GITHUB_APP_ID');
+  const installationId = requireValue(env.GITHUB_APP_INSTALLATION_ID, 'GITHUB_APP_INSTALLATION_ID');
+  const cacheKey = `${appId}:${installationId}`;
+
+  if (
+    cachedInstallationToken?.key === cacheKey &&
+    cachedInstallationToken.expiresAt - TOKEN_REFRESH_WINDOW_MS > Date.now()
+  ) {
+    return cachedInstallationToken.token;
+  }
+
+  const jwt = await createAppJwt(env);
+  const response = await fetchWithTimeout(
+    `${GITHUB_API}/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${jwt}`,
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
+        'User-Agent': 'excalimate-feedback',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new FeedbackError(502, 'github_authentication_failed', 'GitHub authentication failed.');
+  }
+
+  const payload = (await response.json()) as InstallationTokenResponse;
+  cachedInstallationToken = {
+    key: cacheKey,
+    token: payload.token,
+    expiresAt: Date.parse(payload.expires_at),
+  };
+  return payload.token;
+}
+
+export class GitHubClient {
+  constructor(private readonly env: Cloudflare.Env) {}
+
+  async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const token = await getInstallationToken(this.env);
+    const response = await fetchWithTimeout(`${GITHUB_API}${path}`, {
+      ...init,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
+        'User-Agent': 'excalimate-feedback',
+        ...init.headers,
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new FeedbackError(404, 'feedback_not_found', 'Feedback was not found.');
+      }
+      if (response.status === 403 || response.status === 429) {
+        throw new FeedbackError(
+          503,
+          'github_rate_limited',
+          'Feedback is temporarily unavailable due to GitHub rate limits.',
+        );
+      }
+      throw new FeedbackError(502, 'github_error', 'GitHub could not process the request.');
+    }
+
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  async paginate<T>(path: string): Promise<T[]> {
+    const separator = path.includes('?') ? '&' : '?';
+    const results: T[] = [];
+    for (let page = 1; ; page += 1) {
+      const batch = await this.request<T[]>(`${path}${separator}per_page=100&page=${page}`);
+      results.push(...batch);
+      if (batch.length < 100) return results;
+    }
+  }
+}

--- a/landing-page/src/lib/feedback/identity.test.ts
+++ b/landing-page/src/lib/feedback/identity.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { createVoterToken, getAnonymousIdentity } from './identity';
+
+const SECRET = 'a-secret-value-that-is-at-least-thirty-two-characters';
+
+describe('anonymous feedback identity', () => {
+  it('sets and validates a signed first-party cookie', async () => {
+    const first = await getAnonymousIdentity(
+      new Request('https://excalimate.com/feedback'),
+      SECRET,
+    );
+    expect(first.setCookie).toContain('HttpOnly');
+    expect(first.setCookie).toContain('SameSite=Lax');
+
+    const cookie = first.setCookie?.split(';')[0] ?? '';
+    const second = await getAnonymousIdentity(
+      new Request('https://excalimate.com/feedback', {
+        headers: { Cookie: cookie },
+      }),
+      SECRET,
+    );
+    expect(second.id).toBe(first.id);
+    expect(second.setCookie).toBeUndefined();
+  });
+
+  it('creates unlinkable per-issue voter tokens', async () => {
+    const first = await createVoterToken('browser-id', 10, SECRET);
+    const second = await createVoterToken('browser-id', 11, SECRET);
+    expect(first).not.toBe(second);
+    expect(first).toBe(await createVoterToken('browser-id', 10, SECRET));
+  });
+
+  it('replaces a tampered cookie', async () => {
+    const identity = await getAnonymousIdentity(
+      new Request('https://excalimate.com/feedback', {
+        headers: { Cookie: 'excalimate_feedback_id=forged.invalid' },
+      }),
+      SECRET,
+    );
+    expect(identity.id).not.toBe('forged');
+    expect(identity.setCookie).toBeDefined();
+  });
+});

--- a/landing-page/src/lib/feedback/identity.ts
+++ b/landing-page/src/lib/feedback/identity.ts
@@ -1,0 +1,91 @@
+import { FeedbackError } from './errors';
+
+const COOKIE_NAME = 'excalimate_feedback_id';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+function encode(value: string): ArrayBuffer {
+  return new TextEncoder().encode(value).buffer;
+}
+
+async function hmac(value: string, secret: string): Promise<string> {
+  if (secret.length < 32) {
+    throw new FeedbackError(503, 'configuration_error', 'Feedback is temporarily unavailable.');
+  }
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encode(value));
+  return toBase64Url(new Uint8Array(signature));
+}
+
+function parseCookies(header: string | null): Map<string, string> {
+  const cookies = new Map<string, string>();
+  for (const pair of header?.split(';') ?? []) {
+    const separator = pair.indexOf('=');
+    if (separator === -1) continue;
+    cookies.set(pair.slice(0, separator).trim(), pair.slice(separator + 1).trim());
+  }
+  return cookies;
+}
+
+function equalStrings(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+export interface AnonymousIdentity {
+  id: string;
+  setCookie?: string;
+}
+
+export async function getAnonymousIdentity(
+  request: Request,
+  secret: string,
+): Promise<AnonymousIdentity> {
+  const cookie = parseCookies(request.headers.get('Cookie')).get(COOKIE_NAME);
+  if (cookie) {
+    const separator = cookie.lastIndexOf('.');
+    const id = separator > 0 ? cookie.slice(0, separator) : '';
+    const signature = separator > 0 ? cookie.slice(separator + 1) : '';
+    const expected = id ? await hmac(id, secret) : '';
+    if (id && signature && equalStrings(signature, expected)) return { id };
+  }
+
+  const id = crypto.randomUUID();
+  const signature = await hmac(id, secret);
+  return {
+    id,
+    setCookie: `${COOKIE_NAME}=${id}.${signature}; Path=/; Max-Age=${COOKIE_MAX_AGE}; HttpOnly; Secure; SameSite=Lax`,
+  };
+}
+
+export async function createVoterToken(
+  identityId: string,
+  issueNumber: number,
+  secret: string,
+): Promise<string> {
+  return hmac(`vote:${issueNumber}:${identityId}`, secret);
+}
+
+export async function createAuthorToken(
+  identityId: string,
+  issueNumber: number,
+  secret: string,
+): Promise<string> {
+  return hmac(`comment:${issueNumber}:${identityId}`, secret);
+}

--- a/landing-page/src/lib/feedback/metadata.test.ts
+++ b/landing-page/src/lib/feedback/metadata.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createIssueBody,
+  createPortalCommentBody,
+  createVoteBody,
+  parseIssueBody,
+  parsePortalComment,
+  parseVoteToken,
+} from './metadata';
+
+describe('feedback metadata', () => {
+  it('round-trips issue content without exposing metadata', () => {
+    const encoded = createIssueBody('A detailed animation request.', 'A *public* user');
+    const parsed = parseIssueBody(encoded);
+
+    expect(parsed.body).toBe('A detailed animation request.');
+    expect(parsed.metadata).toEqual({ displayName: 'A *public* user' });
+    expect(encoded).toContain('Submitted via');
+    expect(encoded).not.toContain('A **public** user');
+  });
+
+  it('preserves developer text appended after portal metadata', () => {
+    const encoded = `${createIssueBody('Original request.', 'Anonymous')}\n\nDeveloper note.`;
+    const parsed = parseIssueBody(encoded);
+
+    expect(parsed.metadata).toEqual({ displayName: 'Anonymous' });
+    expect(parsed.body).toBe('Original request.\n\nDeveloper note.');
+  });
+
+  it('round-trips portal comments and preserves unicode', () => {
+    const encoded = createPortalCommentBody(
+      'This would help diagram reviews.',
+      'Árvíztűrő',
+      'a'.repeat(32),
+    );
+    const parsed = parsePortalComment(encoded);
+
+    expect(parsed.body).toBe('This would help diagram reviews.');
+    expect(parsed.metadata).toEqual({
+      displayName: 'Árvíztűrő',
+      authorToken: 'a'.repeat(32),
+    });
+  });
+
+  it('identifies ballots and ignores malformed markers', () => {
+    expect(parseVoteToken(createVoteBody('v'.repeat(32)))).toBe('v'.repeat(32));
+    expect(parseVoteToken(`User content\n\n${createVoteBody('v'.repeat(32))}`)).toBeUndefined();
+    expect(parseVoteToken('<!-- excalimate-feedback-vote:v1:not-base64! -->')).toBeUndefined();
+    expect(parseIssueBody('Normal issue body').metadata).toBeUndefined();
+  });
+});

--- a/landing-page/src/lib/feedback/metadata.ts
+++ b/landing-page/src/lib/feedback/metadata.ts
@@ -1,0 +1,144 @@
+const ISSUE_MARKER = 'excalimate-feedback';
+const COMMENT_MARKER = 'excalimate-feedback-comment';
+const VOTE_MARKER = 'excalimate-feedback-vote';
+const VERSION = 'v1';
+
+export interface IssueMetadata {
+  displayName: string;
+}
+
+export interface CommentMetadata {
+  displayName: string;
+  authorToken: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function encodePayload(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+function decodePayload<T>(value: string): T | undefined {
+  try {
+    const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function createMarker(name: string, payload: unknown): string {
+  return `<!-- ${name}:${VERSION}:${encodePayload(payload)} -->`;
+}
+
+function readMarker<T>(body: string | null, name: string, wholeBody = false): T | undefined {
+  if (!body) return undefined;
+  const source = `<!--\\s*${name}:${VERSION}:([A-Za-z0-9_-]+)\\s*-->`;
+  const match = wholeBody
+    ? body.match(new RegExp(`^\\s*${source}\\s*$`, 'u'))
+    : Array.from(body.matchAll(new RegExp(source, 'gu'))).at(-1);
+  return match?.[1] ? decodePayload<T>(match[1]) : undefined;
+}
+
+function stripMarker(body: string, name: string): string {
+  return body
+    .replace(new RegExp(`\\n?<!--\\s*${name}:${VERSION}:[A-Za-z0-9_-]+\\s*-->`, 'gu'), '')
+    .trim();
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replace(/([\\`*_[\]<>])/gu, '\\$1');
+}
+
+export function createIssueBody(description: string, displayName: string): string {
+  const attribution = `Submitted via [Excalimate Feedback](https://excalimate.com/feedback) by **${escapeMarkdown(displayName)}**.`;
+  return `${description.trim()}\n\n---\n${attribution}\n\n${createMarker(ISSUE_MARKER, { displayName } satisfies IssueMetadata)}`;
+}
+
+export function parseIssueBody(body: string | null): {
+  body: string;
+  metadata?: IssueMetadata;
+} {
+  const candidate = readMarker<unknown>(body, ISSUE_MARKER);
+  const metadata =
+    isRecord(candidate) &&
+    typeof candidate.displayName === 'string' &&
+    candidate.displayName.length <= 60
+      ? { displayName: candidate.displayName }
+      : undefined;
+  let visibleBody = stripMarker(body ?? '', ISSUE_MARKER);
+  if (metadata) {
+    const attribution = `\n\n---\nSubmitted via [Excalimate Feedback](https://excalimate.com/feedback) by **${escapeMarkdown(metadata.displayName)}**.`;
+    const attributionIndex = visibleBody.indexOf(attribution);
+    if (attributionIndex !== -1) {
+      const before = visibleBody.slice(0, attributionIndex).trimEnd();
+      const after = visibleBody.slice(attributionIndex + attribution.length).trimStart();
+      visibleBody = [before, after].filter(Boolean).join('\n\n');
+    }
+  }
+  return {
+    body: visibleBody,
+    metadata,
+  };
+}
+
+export function createPortalCommentBody(
+  body: string,
+  displayName: string,
+  authorToken: string,
+): string {
+  const marker = createMarker(COMMENT_MARKER, {
+    displayName,
+    authorToken,
+  } satisfies CommentMetadata);
+  return `**${escapeMarkdown(displayName)}**\n\n${body.trim()}\n\n${marker}`;
+}
+
+export function parsePortalComment(body: string): {
+  body: string;
+  metadata?: CommentMetadata;
+} {
+  const candidate = readMarker<unknown>(body, COMMENT_MARKER);
+  const metadata =
+    isRecord(candidate) &&
+    typeof candidate.displayName === 'string' &&
+    candidate.displayName.length <= 60 &&
+    typeof candidate.authorToken === 'string' &&
+    /^[A-Za-z0-9_-]{20,128}$/u.test(candidate.authorToken)
+      ? {
+          displayName: candidate.displayName,
+          authorToken: candidate.authorToken,
+        }
+      : undefined;
+  if (!metadata) return { body };
+
+  const withoutMarker = stripMarker(body, COMMENT_MARKER);
+  const attribution = `**${escapeMarkdown(metadata.displayName)}**`;
+  return {
+    body: withoutMarker.startsWith(attribution)
+      ? withoutMarker.slice(attribution.length).trim()
+      : withoutMarker,
+    metadata,
+  };
+}
+
+export function createVoteBody(voterToken: string): string {
+  return createMarker(VOTE_MARKER, { voterToken });
+}
+
+export function parseVoteToken(body: string): string | undefined {
+  const candidate = readMarker<unknown>(body, VOTE_MARKER, true);
+  return isRecord(candidate) &&
+    typeof candidate.voterToken === 'string' &&
+    /^[A-Za-z0-9_-]{20,128}$/u.test(candidate.voterToken)
+    ? candidate.voterToken
+    : undefined;
+}

--- a/landing-page/src/lib/feedback/repository.test.ts
+++ b/landing-page/src/lib/feedback/repository.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createIssueBody, createPortalCommentBody, createVoteBody } from './metadata';
+
+const github = vi.hoisted(() => ({
+  request: vi.fn(),
+  paginate: vi.fn(),
+}));
+
+vi.mock('./github', () => ({
+  GitHubClient: class {
+    request = github.request;
+    paginate = github.paginate;
+  },
+}));
+
+import { GitHubFeedbackRepository } from './repository';
+
+const env = {
+  GITHUB_REPOSITORY_OWNER: 'excalimate',
+  GITHUB_REPOSITORY_NAME: 'excalimate',
+  GITHUB_APP_BOT_LOGIN: 'excalimate-feedback[bot]',
+} as Cloudflare.Env;
+
+function issue(number: number, title: string, labels: string[]) {
+  return {
+    number,
+    title,
+    body: createIssueBody(`${title} needs a longer description for testing.`, 'Anonymous'),
+    state: 'open',
+    labels: labels.map((name) => ({ name })),
+    created_at: `2026-07-${String(number).padStart(2, '0')}T00:00:00Z`,
+    updated_at: `2026-07-${String(number).padStart(2, '0')}T00:00:00Z`,
+    html_url: `https://github.com/excalimate/excalimate/issues/${number}`,
+    user: {
+      login: 'excalimate-feedback[bot]',
+      avatar_url: 'https://github.com/app-avatar.png',
+      html_url: 'https://github.com/apps/excalimate-feedback',
+      type: 'Bot',
+    },
+  };
+}
+
+function comment(
+  id: number,
+  body: string,
+  options: { bot?: boolean; association?: 'NONE' | 'OWNER' } = {},
+) {
+  const bot = options.bot ?? false;
+  return {
+    id,
+    body,
+    created_at: '2026-07-11T00:00:00Z',
+    html_url: `https://github.com/comment/${id}`,
+    user: {
+      login: bot ? 'excalimate-feedback[bot]' : 'maintainer',
+      avatar_url: 'https://github.com/avatar.png',
+      html_url: 'https://github.com/maintainer',
+      type: bot ? 'Bot' : 'User',
+    },
+    author_association: options.association ?? 'NONE',
+  };
+}
+
+describe('GitHubFeedbackRepository', () => {
+  beforeEach(() => {
+    github.request.mockReset();
+    github.paginate.mockReset();
+  });
+
+  it('counts exact ballots, excludes them from discussion, and sorts by votes', async () => {
+    const first = issue(1, 'First idea', ['feedback', 'feedback: feature', 'status: under review']);
+    const second = issue(2, 'Second idea', [
+      'feedback',
+      'feedback: improvement',
+      'status: planned',
+    ]);
+    github.paginate.mockImplementation((path: string) => {
+      if (path.includes('?state=all')) return Promise.resolve([first, second]);
+      if (path.includes('/issues/1/comments')) {
+        return Promise.resolve([
+          comment(11, createVoteBody('a'.repeat(32)), { bot: true }),
+          comment(12, createPortalCommentBody('Useful context', 'Visitor', 'a'.repeat(32)), {
+            bot: true,
+          }),
+        ]);
+      }
+      return Promise.resolve([
+        comment(21, createVoteBody('b'.repeat(32)), { bot: true }),
+        comment(22, createVoteBody('c'.repeat(32)), { bot: true }),
+      ]);
+    });
+
+    const result = await new GitHubFeedbackRepository(env).list({
+      search: '',
+      category: 'all',
+      status: 'all',
+      sort: 'top',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(result.items.map((item) => item.number)).toEqual([2, 1]);
+    expect(result.items[0]).toMatchObject({ voteCount: 2, commentCount: 0 });
+    expect(result.items[1]).toMatchObject({ voteCount: 1, commentCount: 1 });
+  });
+
+  it('deduplicates concurrent ballots from the same browser', async () => {
+    const target = issue(3, 'Concurrent voting', [
+      'feedback',
+      'feedback: feature',
+      'status: under review',
+    ]);
+    github.request.mockImplementation((path: string, init?: RequestInit) => {
+      if (path.endsWith('/issues/3') && !init?.method) return Promise.resolve(target);
+      return Promise.resolve(comment(31, createVoteBody('t'.repeat(32)), { bot: true }));
+    });
+    github.paginate
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        comment(31, createVoteBody('t'.repeat(32)), { bot: true }),
+        comment(32, createVoteBody('t'.repeat(32)), { bot: true }),
+        comment(33, createVoteBody('o'.repeat(32)), { bot: true }),
+      ]);
+
+    const result = await new GitHubFeedbackRepository(env).vote(3, 't'.repeat(32));
+
+    expect(result).toEqual({ voteCount: 2, viewerHasVoted: true });
+    expect(github.request).toHaveBeenCalledWith('/repos/excalimate/excalimate/issues/comments/32', {
+      method: 'DELETE',
+    });
+  });
+
+  it('does not trust portal markers posted by regular GitHub users', async () => {
+    const target = issue(5, 'Marker forgery', [
+      'feedback',
+      'feedback: feature',
+      'status: under review',
+    ]);
+    github.request.mockResolvedValue(target);
+    github.paginate.mockResolvedValue([
+      comment(51, createVoteBody('f'.repeat(32))),
+      comment(52, createPortalCommentBody('Forged identity', 'Excalimate team', 'a'.repeat(32))),
+    ]);
+
+    const result = await new GitHubFeedbackRepository(env).get(5, 'viewer-token');
+
+    expect(result).toMatchObject({ voteCount: 0, commentCount: 2 });
+    expect(result.comments.every((entry) => !entry.isDeveloper)).toBe(true);
+    expect(result.comments.every((entry) => entry.authorName === 'maintainer')).toBe(true);
+  });
+
+  it('does not expose labeled issues copied by a regular GitHub user', async () => {
+    const copied = {
+      ...issue(6, 'Copied marker', ['feedback', 'feedback: feature', 'status: under review']),
+      user: {
+        login: 'outsider',
+        avatar_url: 'https://github.com/avatar.png',
+        html_url: 'https://github.com/outsider',
+        type: 'User',
+      },
+    };
+    github.paginate.mockResolvedValue([copied]);
+
+    const result = await new GitHubFeedbackRepository(env).list({
+      search: '',
+      category: 'all',
+      status: 'all',
+      sort: 'top',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('rejects writes to terminal feedback', async () => {
+    github.request.mockResolvedValue(
+      issue(4, 'Completed idea', ['feedback', 'feedback: feature', 'status: completed']),
+    );
+
+    await expect(new GitHubFeedbackRepository(env).vote(4, 'token')).rejects.toMatchObject({
+      status: 409,
+      code: 'feedback_read_only',
+    });
+  });
+});

--- a/landing-page/src/lib/feedback/repository.ts
+++ b/landing-page/src/lib/feedback/repository.ts
@@ -1,0 +1,366 @@
+import {
+  DEFAULT_FEEDBACK_STATUS,
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_SCOPE_LABEL,
+  FEEDBACK_STATUSES,
+  getCategoryFromLabels,
+  getStatusFromLabels,
+  isTerminalStatus,
+  type FeedbackCategory,
+  type FeedbackStatus,
+} from './config';
+import { FeedbackError } from './errors';
+import { GitHubClient } from './github';
+import {
+  createIssueBody,
+  createPortalCommentBody,
+  createVoteBody,
+  parseIssueBody,
+  parsePortalComment,
+  parseVoteToken,
+} from './metadata';
+import type { CreateCommentInput, CreateFeedbackInput, ListFeedbackInput } from './schemas';
+import type {
+  FeedbackDetail,
+  FeedbackDiscussionComment,
+  FeedbackMutationResponse,
+  FeedbackSummary,
+} from './types';
+
+interface GitHubLabel {
+  name: string;
+}
+
+interface GitHubUser {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: 'open' | 'closed';
+  labels: Array<GitHubLabel | string>;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  user: GitHubUser | null;
+  pull_request?: unknown;
+}
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  created_at: string;
+  html_url: string;
+  user: GitHubUser | null;
+  author_association:
+    | 'COLLABORATOR'
+    | 'CONTRIBUTOR'
+    | 'FIRST_TIMER'
+    | 'FIRST_TIME_CONTRIBUTOR'
+    | 'MANNEQUIN'
+    | 'MEMBER'
+    | 'NONE'
+    | 'OWNER';
+}
+
+interface IssueProjection {
+  issue: GitHubIssue;
+  body: string;
+  authorName: string;
+  labels: string[];
+}
+
+function labelNames(issue: GitHubIssue): string[] {
+  return issue.labels.map((label) => (typeof label === 'string' ? label : label.name));
+}
+
+function excerpt(value: string): string {
+  const compact = value.replace(/\s+/gu, ' ').trim();
+  return compact.length > 180 ? `${compact.slice(0, 177).trimEnd()}...` : compact;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+export class GitHubFeedbackRepository {
+  private readonly client: GitHubClient;
+  private readonly repositoryPath: string;
+  private readonly appBotLogin: string;
+
+  constructor(private readonly env: Cloudflare.Env) {
+    this.client = new GitHubClient(env);
+    const owner = env.GITHUB_REPOSITORY_OWNER || 'excalimate';
+    const repository = env.GITHUB_REPOSITORY_NAME || 'excalimate';
+    this.repositoryPath = `/repos/${owner}/${repository}`;
+    if (!env.GITHUB_APP_BOT_LOGIN) {
+      throw new FeedbackError(
+        503,
+        'configuration_error',
+        'Feedback is unavailable because the GitHub App bot login is not configured.',
+      );
+    }
+    this.appBotLogin = env.GITHUB_APP_BOT_LOGIN.toLocaleLowerCase();
+  }
+
+  private isAppComment(comment: GitHubComment): boolean {
+    return (
+      comment.user?.type === 'Bot' && comment.user.login.toLocaleLowerCase() === this.appBotLogin
+    );
+  }
+
+  private projectIssue(issue: GitHubIssue): IssueProjection | undefined {
+    if (issue.pull_request) return undefined;
+    const labels = labelNames(issue);
+    const parsed = parseIssueBody(issue.body);
+    const isAppIssue =
+      issue.user?.type === 'Bot' && issue.user.login.toLocaleLowerCase() === this.appBotLogin;
+    if (!isAppIssue || !labels.includes(FEEDBACK_SCOPE_LABEL) || !parsed.metadata) {
+      return undefined;
+    }
+    return {
+      issue,
+      body: parsed.body,
+      authorName: parsed.metadata.displayName || 'Anonymous',
+      labels,
+    };
+  }
+
+  private async getIssueProjection(number: number): Promise<IssueProjection> {
+    const issue = await this.client.request<GitHubIssue>(`${this.repositoryPath}/issues/${number}`);
+    const projection = this.projectIssue(issue);
+    if (!projection) {
+      throw new FeedbackError(404, 'feedback_not_found', 'Feedback was not found.');
+    }
+    return projection;
+  }
+
+  private listComments(number: number): Promise<GitHubComment[]> {
+    return this.client.paginate<GitHubComment>(`${this.repositoryPath}/issues/${number}/comments`);
+  }
+
+  private toDiscussionComments(comments: readonly GitHubComment[]): FeedbackDiscussionComment[] {
+    return comments.flatMap((comment) => {
+      const isAppComment = this.isAppComment(comment);
+      if (isAppComment && parseVoteToken(comment.body)) return [];
+      const portalComment = isAppComment
+        ? parsePortalComment(comment.body)
+        : { body: comment.body };
+      const body = portalComment.body.trim();
+      if (!body) return [];
+      const isPortalComment = Boolean(portalComment.metadata);
+      const isDeveloper = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(comment.author_association);
+      return [
+        {
+          id: comment.id,
+          body,
+          authorName:
+            portalComment.metadata?.displayName || comment.user?.login || 'Excalimate team',
+          authorAvatarUrl: !isPortalComment ? comment.user?.avatar_url : undefined,
+          authorUrl: !isPortalComment ? comment.user?.html_url : undefined,
+          isDeveloper,
+          createdAt: comment.created_at,
+          htmlUrl: comment.html_url,
+        },
+      ];
+    });
+  }
+
+  private toSummary(
+    projection: IssueProjection,
+    comments: readonly GitHubComment[],
+  ): FeedbackSummary {
+    const discussion = this.toDiscussionComments(comments);
+    return {
+      number: projection.issue.number,
+      title: projection.issue.title,
+      excerpt: excerpt(projection.body),
+      category: getCategoryFromLabels(projection.labels),
+      status: getStatusFromLabels(projection.labels),
+      voteCount: comments.filter(
+        (comment) => this.isAppComment(comment) && parseVoteToken(comment.body),
+      ).length,
+      commentCount: discussion.length,
+      createdAt: projection.issue.created_at,
+      updatedAt: projection.issue.updated_at,
+      authorName: projection.authorName,
+      htmlUrl: projection.issue.html_url,
+    };
+  }
+
+  private assertWritable(projection: IssueProjection): void {
+    const status = getStatusFromLabels(projection.labels);
+    if (isTerminalStatus(status)) {
+      throw new FeedbackError(
+        409,
+        'feedback_read_only',
+        `${FEEDBACK_STATUSES[status].label} feedback is read-only.`,
+      );
+    }
+  }
+
+  async list(input: ListFeedbackInput): Promise<{
+    items: FeedbackSummary[];
+    total: number;
+    totalPages: number;
+  }> {
+    const issues = await this.client.paginate<GitHubIssue>(
+      `${this.repositoryPath}/issues?state=all&labels=${encodeURIComponent(FEEDBACK_SCOPE_LABEL)}`,
+    );
+    const projections = issues
+      .map((issue) => this.projectIssue(issue))
+      .filter((item): item is IssueProjection => Boolean(item));
+
+    const summaries = await mapWithConcurrency(projections, 6, async (projection) =>
+      this.toSummary(projection, await this.listComments(projection.issue.number)),
+    );
+    const query = input.search.toLocaleLowerCase();
+    const filtered = summaries.filter((item) => {
+      if (input.category !== 'all' && item.category !== input.category) return false;
+      if (input.status !== 'all' && item.status !== input.status) return false;
+      if (query && !`${item.title} ${item.excerpt}`.toLocaleLowerCase().includes(query)) {
+        return false;
+      }
+      return true;
+    });
+
+    filtered.sort((left, right) => {
+      if (input.sort === 'top') {
+        return (
+          right.voteCount - left.voteCount ||
+          right.commentCount - left.commentCount ||
+          Date.parse(right.createdAt) - Date.parse(left.createdAt)
+        );
+      }
+      return Date.parse(right.createdAt) - Date.parse(left.createdAt);
+    });
+
+    const total = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+    const start = (Math.min(input.page, totalPages) - 1) * input.pageSize;
+    return {
+      items: filtered.slice(start, start + input.pageSize),
+      total,
+      totalPages,
+    };
+  }
+
+  async get(number: number, voterToken: string): Promise<FeedbackDetail> {
+    const projection = await this.getIssueProjection(number);
+    const comments = await this.listComments(number);
+    return {
+      ...this.toSummary(projection, comments),
+      body: projection.body,
+      viewerHasVoted: comments.some(
+        (comment) => this.isAppComment(comment) && parseVoteToken(comment.body) === voterToken,
+      ),
+      comments: this.toDiscussionComments(comments),
+    };
+  }
+
+  async create(input: CreateFeedbackInput): Promise<number> {
+    const issue = await this.client.request<GitHubIssue>(`${this.repositoryPath}/issues`, {
+      method: 'POST',
+      body: JSON.stringify({
+        title: input.title,
+        body: createIssueBody(input.description, input.displayName),
+        labels: [
+          FEEDBACK_SCOPE_LABEL,
+          FEEDBACK_CATEGORIES[input.category].githubLabel,
+          FEEDBACK_STATUSES[DEFAULT_FEEDBACK_STATUS].githubLabel,
+        ],
+      }),
+    });
+    return issue.number;
+  }
+
+  async addComment(
+    number: number,
+    input: CreateCommentInput,
+    authorToken: string,
+  ): Promise<FeedbackDiscussionComment[]> {
+    const projection = await this.getIssueProjection(number);
+    this.assertWritable(projection);
+    await this.client.request<GitHubComment>(`${this.repositoryPath}/issues/${number}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({
+        body: createPortalCommentBody(input.body, input.displayName, authorToken),
+      }),
+    });
+    return this.toDiscussionComments(await this.listComments(number));
+  }
+
+  async vote(number: number, voterToken: string): Promise<FeedbackMutationResponse> {
+    const projection = await this.getIssueProjection(number);
+    this.assertWritable(projection);
+    const existing = (await this.listComments(number)).filter(
+      (comment) => this.isAppComment(comment) && parseVoteToken(comment.body) === voterToken,
+    );
+
+    if (existing.length === 0) {
+      await this.client.request<GitHubComment>(`${this.repositoryPath}/issues/${number}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ body: createVoteBody(voterToken) }),
+      });
+    }
+
+    const comments = await this.listComments(number);
+    const matching = comments.filter(
+      (comment) => this.isAppComment(comment) && parseVoteToken(comment.body) === voterToken,
+    );
+    for (const duplicate of matching.slice(1)) {
+      await this.client.request<void>(`${this.repositoryPath}/issues/comments/${duplicate.id}`, {
+        method: 'DELETE',
+      });
+    }
+    return {
+      voteCount:
+        comments.filter((comment) => this.isAppComment(comment) && parseVoteToken(comment.body))
+          .length - Math.max(0, matching.length - 1),
+      viewerHasVoted: true,
+    };
+  }
+
+  async unvote(number: number, voterToken: string): Promise<FeedbackMutationResponse> {
+    const projection = await this.getIssueProjection(number);
+    this.assertWritable(projection);
+    const comments = await this.listComments(number);
+    const matching = comments.filter(
+      (comment) => this.isAppComment(comment) && parseVoteToken(comment.body) === voterToken,
+    );
+    for (const ballot of matching) {
+      await this.client.request<void>(`${this.repositoryPath}/issues/comments/${ballot.id}`, {
+        method: 'DELETE',
+      });
+    }
+    return {
+      voteCount:
+        comments.filter((comment) => this.isAppComment(comment) && parseVoteToken(comment.body))
+          .length - matching.length,
+      viewerHasVoted: false,
+    };
+  }
+}
+
+export type { FeedbackCategory, FeedbackStatus };

--- a/landing-page/src/lib/feedback/response.test.ts
+++ b/landing-page/src/lib/feedback/response.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readJson } from './response';
+
+describe('feedback JSON requests', () => {
+  it('rejects oversized chunked bodies without Content-Length', async () => {
+    const request = new Request('https://excalimate.com/api/feedback', {
+      method: 'POST',
+      body: JSON.stringify({ value: 'x'.repeat(17_000) }),
+    });
+    request.headers.delete('Content-Length');
+
+    await expect(readJson(request)).rejects.toMatchObject({
+      status: 413,
+      code: 'request_too_large',
+    });
+  });
+
+  it('reports malformed JSON', async () => {
+    const request = new Request('https://excalimate.com/api/feedback', {
+      method: 'POST',
+      body: '{',
+    });
+    await expect(readJson(request)).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_json',
+    });
+  });
+});

--- a/landing-page/src/lib/feedback/response.ts
+++ b/landing-page/src/lib/feedback/response.ts
@@ -1,0 +1,69 @@
+import { ZodError } from 'zod';
+import { asFeedbackError, FeedbackError } from './errors';
+import type { ApiErrorResponse } from './types';
+
+const BASE_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'X-Content-Type-Options': 'nosniff',
+};
+
+export function jsonResponse<T>(
+  value: T,
+  options: {
+    status?: number;
+    cacheControl?: string;
+    setCookie?: string;
+  } = {},
+): Response {
+  const headers = new Headers(BASE_HEADERS);
+  headers.set('Cache-Control', options.cacheControl ?? 'no-store');
+  if (options.setCookie) headers.set('Set-Cookie', options.setCookie);
+  return Response.json(value, { status: options.status ?? 200, headers });
+}
+
+export function errorResponse(error: unknown): Response {
+  if (error instanceof ZodError) {
+    const fieldErrors = error.flatten().fieldErrors;
+    return jsonResponse<ApiErrorResponse>(
+      {
+        error: {
+          code: 'validation_error',
+          message: 'Please correct the highlighted fields.',
+          fieldErrors,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const feedbackError = asFeedbackError(error);
+  if (feedbackError.status >= 500) console.error(feedbackError);
+  return jsonResponse<ApiErrorResponse>(
+    {
+      error: {
+        code: feedbackError.code,
+        message: feedbackError.message,
+      },
+    },
+    { status: feedbackError.status },
+  );
+}
+
+export async function readJson(request: Request): Promise<unknown> {
+  const length = Number(request.headers.get('Content-Length') || '0');
+  if (length > 16_384) {
+    throw new FeedbackError(413, 'request_too_large', 'Request body is too large.');
+  }
+  try {
+    const body = await request.text();
+    if (new TextEncoder().encode(body).byteLength > 16_384) {
+      throw new FeedbackError(413, 'request_too_large', 'Request body is too large.');
+    }
+    return JSON.parse(body) as unknown;
+  } catch (error) {
+    if (error instanceof FeedbackError) throw error;
+    throw new FeedbackError(400, 'invalid_json', 'The request body is not valid JSON.', {
+      cause: error,
+    });
+  }
+}

--- a/landing-page/src/lib/feedback/route.ts
+++ b/landing-page/src/lib/feedback/route.ts
@@ -1,0 +1,8 @@
+import { FeedbackError } from './errors';
+
+export function parseFeedbackNumber(value: string | undefined): number {
+  if (!value || !/^[1-9]\d*$/u.test(value)) {
+    throw new FeedbackError(400, 'invalid_feedback_number', 'Invalid feedback number.');
+  }
+  return Number(value);
+}

--- a/landing-page/src/lib/feedback/schemas.ts
+++ b/landing-page/src/lib/feedback/schemas.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { FEEDBACK_CATEGORY_IDS, FEEDBACK_STATUS_IDS } from './config';
+
+const displayName = z
+  .string()
+  .trim()
+  .max(60)
+  .transform((value) => value || 'Anonymous');
+const turnstileToken = z.string().min(1).max(2048);
+
+export const createFeedbackSchema = z.object({
+  title: z.string().trim().min(5).max(120),
+  description: z.string().trim().min(20).max(5000),
+  displayName,
+  category: z.enum(FEEDBACK_CATEGORY_IDS),
+  turnstileToken,
+});
+
+export const createCommentSchema = z.object({
+  body: z.string().trim().min(2).max(2000),
+  displayName,
+  turnstileToken,
+});
+
+export const voteSchema = z.object({
+  turnstileToken,
+});
+
+export const listFeedbackSchema = z.object({
+  search: z.string().trim().max(100).default(''),
+  category: z.enum(['all', ...FEEDBACK_CATEGORY_IDS]).default('all'),
+  status: z.enum(['all', ...FEEDBACK_STATUS_IDS]).default('all'),
+  sort: z.enum(['top', 'newest']).default('top'),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export type CreateFeedbackInput = z.infer<typeof createFeedbackSchema>;
+export type CreateCommentInput = z.infer<typeof createCommentSchema>;
+export type ListFeedbackInput = z.infer<typeof listFeedbackSchema>;

--- a/landing-page/src/lib/feedback/security.test.ts
+++ b/landing-page/src/lib/feedback/security.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyMutation, type FeedbackSecurityEnv } from './security';
+
+const limit = vi.fn();
+const env = {
+  TURNSTILE_SECRET_KEY: 'turnstile-secret',
+  TURNSTILE_SITE_KEY: 'turnstile-site-key',
+  TURNSTILE_ALLOWED_HOSTNAMES: 'excalimate.com',
+  FEEDBACK_SUBMISSION_RATE_LIMITER: { limit },
+  FEEDBACK_INTERACTION_RATE_LIMITER: { limit },
+} satisfies FeedbackSecurityEnv;
+
+function mutationRequest(origin = 'https://excalimate.com') {
+  const request = new Request('https://excalimate.com/api/feedback', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+  request.headers.set('Origin', origin);
+  request.headers.set('CF-Connecting-IP', '203.0.113.10');
+  return request;
+}
+
+describe('feedback mutation security', () => {
+  beforeEach(() => {
+    limit.mockResolvedValue({ success: true });
+  });
+
+  it('accepts same-origin, rate-limited, verified mutations', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json({ success: true, hostname: 'excalimate.com' }),
+    );
+
+    await expect(
+      verifyMutation(mutationRequest(), env, 'token', 'submission'),
+    ).resolves.toBeUndefined();
+    expect(limit).toHaveBeenCalledWith({ key: 'submission:203.0.113.10' });
+  });
+
+  it('rejects cross-origin requests before verification', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    await expect(
+      verifyMutation(mutationRequest('https://attacker.example'), env, 'token', 'submission'),
+    ).rejects.toMatchObject({ status: 403, code: 'invalid_origin' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires an allowed hostname in the Turnstile response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json({ success: true }));
+    await expect(
+      verifyMutation(mutationRequest(), env, 'token', 'interaction'),
+    ).rejects.toMatchObject({ status: 400, code: 'turnstile_failed' });
+  });
+
+  it('surfaces rate limits without calling Turnstile', async () => {
+    limit.mockResolvedValue({ success: false });
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    await expect(
+      verifyMutation(mutationRequest(), env, 'token', 'interaction'),
+    ).rejects.toMatchObject({ status: 429, code: 'rate_limited' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/landing-page/src/lib/feedback/security.test.ts
+++ b/landing-page/src/lib/feedback/security.test.ts
@@ -54,6 +54,25 @@ describe('feedback mutation security', () => {
     ).rejects.toMatchObject({ status: 400, code: 'turnstile_failed' });
   });
 
+  it('accepts the synthetic hostname returned for the always-pass test secret', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json({ success: true, hostname: 'example.com' }),
+    );
+
+    await expect(
+      verifyMutation(
+        mutationRequest(),
+        {
+          ...env,
+          TURNSTILE_SECRET_KEY: '1x0000000000000000000000000000000AA',
+          TURNSTILE_ALLOWED_HOSTNAMES: 'localhost,127.0.0.1',
+        },
+        'token',
+        'submission',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it('surfaces rate limits without calling Turnstile', async () => {
     limit.mockResolvedValue({ success: false });
     const fetchMock = vi.spyOn(globalThis, 'fetch');

--- a/landing-page/src/lib/feedback/security.ts
+++ b/landing-page/src/lib/feedback/security.ts
@@ -2,6 +2,8 @@ import { FeedbackError } from './errors';
 
 type MutationKind = 'submission' | 'interaction';
 
+const TURNSTILE_ALWAYS_PASS_TEST_SECRET = '1x0000000000000000000000000000000AA';
+
 export type FeedbackSecurityEnv = Pick<
   Cloudflare.Env,
   | 'TURNSTILE_SECRET_KEY'
@@ -104,9 +106,12 @@ async function verifyTurnstile(
     .split(',')
     .map((hostname) => hostname.trim())
     .filter(Boolean);
+  const usesAlwaysPassTestSecret =
+    env.TURNSTILE_SECRET_KEY === TURNSTILE_ALWAYS_PASS_TEST_SECRET;
   if (
     !result.success ||
-    (allowedHostnames.length > 0 &&
+    (!usesAlwaysPassTestSecret &&
+      allowedHostnames.length > 0 &&
       (!result.hostname || !allowedHostnames.includes(result.hostname)))
   ) {
     throw new FeedbackError(400, 'turnstile_failed', 'Verification failed. Please try again.');

--- a/landing-page/src/lib/feedback/security.ts
+++ b/landing-page/src/lib/feedback/security.ts
@@ -1,0 +1,132 @@
+import { FeedbackError } from './errors';
+
+type MutationKind = 'submission' | 'interaction';
+
+export type FeedbackSecurityEnv = Pick<
+  Cloudflare.Env,
+  | 'TURNSTILE_SECRET_KEY'
+  | 'TURNSTILE_SITE_KEY'
+  | 'TURNSTILE_ALLOWED_HOSTNAMES'
+  | 'FEEDBACK_SUBMISSION_RATE_LIMITER'
+  | 'FEEDBACK_INTERACTION_RATE_LIMITER'
+>;
+
+interface TurnstileResult {
+  success: boolean;
+  hostname?: string;
+}
+
+function clientAddress(request: Request): string {
+  return (
+    request.headers.get('CF-Connecting-IP') ||
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    'local'
+  );
+}
+
+export function assertMutationRequest(request: Request): void {
+  const origin = request.headers.get('Origin');
+  if (!origin || origin !== new URL(request.url).origin) {
+    throw new FeedbackError(403, 'invalid_origin', 'This request did not come from Excalimate.');
+  }
+  if (!request.headers.get('Content-Type')?.toLowerCase().startsWith('application/json')) {
+    throw new FeedbackError(415, 'invalid_content_type', 'Expected a JSON request.');
+  }
+}
+
+async function enforceRateLimit(
+  request: Request,
+  env: FeedbackSecurityEnv,
+  kind: MutationKind,
+): Promise<void> {
+  const limiter =
+    kind === 'submission'
+      ? env.FEEDBACK_SUBMISSION_RATE_LIMITER
+      : env.FEEDBACK_INTERACTION_RATE_LIMITER;
+  if (!limiter) {
+    throw new FeedbackError(503, 'configuration_error', 'Feedback protection is not configured.');
+  }
+  const outcome = await limiter.limit({
+    key: `${kind}:${clientAddress(request)}`,
+  });
+  if (!outcome.success) {
+    throw new FeedbackError(
+      429,
+      'rate_limited',
+      'Too many feedback requests. Please wait and try again.',
+    );
+  }
+}
+
+async function verifyTurnstile(
+  request: Request,
+  env: FeedbackSecurityEnv,
+  token: string,
+): Promise<void> {
+  if (!env.TURNSTILE_SECRET_KEY) {
+    throw new FeedbackError(503, 'configuration_error', 'Feedback protection is not configured.');
+  }
+
+  const body = new FormData();
+  body.set('secret', env.TURNSTILE_SECRET_KEY);
+  body.set('response', token);
+  body.set('remoteip', clientAddress(request));
+  body.set('idempotency_key', crypto.randomUUID());
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  let response: Response;
+  try {
+    response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    throw new FeedbackError(
+      502,
+      'turnstile_unavailable',
+      'Verification is temporarily unavailable.',
+      { cause: error },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!response.ok) {
+    throw new FeedbackError(
+      502,
+      'turnstile_unavailable',
+      'Verification is temporarily unavailable.',
+    );
+  }
+
+  const result = (await response.json()) as TurnstileResult;
+  const allowedHostnames = (env.TURNSTILE_ALLOWED_HOSTNAMES || '')
+    .split(',')
+    .map((hostname) => hostname.trim())
+    .filter(Boolean);
+  if (
+    !result.success ||
+    (allowedHostnames.length > 0 &&
+      (!result.hostname || !allowedHostnames.includes(result.hostname)))
+  ) {
+    throw new FeedbackError(400, 'turnstile_failed', 'Verification failed. Please try again.');
+  }
+}
+
+export async function verifyMutation(
+  request: Request,
+  env: FeedbackSecurityEnv,
+  token: string,
+  kind: MutationKind,
+): Promise<void> {
+  assertMutationRequest(request);
+  await enforceRateLimit(request, env, kind);
+  await verifyTurnstile(request, env, token);
+}
+
+export function getTurnstileSiteKey(env: Pick<Cloudflare.Env, 'TURNSTILE_SITE_KEY'>): string {
+  if (!env.TURNSTILE_SITE_KEY) {
+    throw new FeedbackError(503, 'configuration_error', 'Feedback protection is not configured.');
+  }
+  return env.TURNSTILE_SITE_KEY;
+}

--- a/landing-page/src/lib/feedback/types.ts
+++ b/landing-page/src/lib/feedback/types.ts
@@ -1,0 +1,68 @@
+import type { FeedbackCategory, FeedbackStatus } from './config';
+
+export interface FeedbackSummary {
+  number: number;
+  title: string;
+  excerpt: string;
+  category: FeedbackCategory;
+  status: FeedbackStatus;
+  voteCount: number;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+  authorName: string;
+  htmlUrl: string;
+}
+
+export interface FeedbackDiscussionComment {
+  id: number;
+  body: string;
+  authorName: string;
+  authorAvatarUrl?: string;
+  authorUrl?: string;
+  isDeveloper: boolean;
+  createdAt: string;
+  htmlUrl: string;
+}
+
+export interface FeedbackDetail extends FeedbackSummary {
+  body: string;
+  viewerHasVoted: boolean;
+  comments: FeedbackDiscussionComment[];
+}
+
+export interface FeedbackListResponse {
+  items: FeedbackSummary[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  turnstileSiteKey: string;
+}
+
+export interface FeedbackDetailResponse {
+  item: FeedbackDetail;
+  turnstileSiteKey: string;
+}
+
+export interface FeedbackMutationResponse {
+  voteCount: number;
+  viewerHasVoted: boolean;
+}
+
+export interface FeedbackCreatedResponse {
+  number: number;
+  url: string;
+}
+
+export interface FeedbackCommentsResponse {
+  comments: FeedbackDiscussionComment[];
+}
+
+export interface ApiErrorResponse {
+  error: {
+    code: string;
+    message: string;
+    fieldErrors?: Record<string, string[]>;
+  };
+}

--- a/landing-page/src/pages/api/feedback/[number].ts
+++ b/landing-page/src/pages/api/feedback/[number].ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  createVoterToken,
+  getAnonymousIdentity,
+} from '../../../lib/feedback/identity';
+import { GitHubFeedbackRepository } from '../../../lib/feedback/repository';
+import { errorResponse, jsonResponse } from '../../../lib/feedback/response';
+import { parseFeedbackNumber } from '../../../lib/feedback/route';
+import { getTurnstileSiteKey } from '../../../lib/feedback/security';
+import type { FeedbackDetailResponse } from '../../../lib/feedback/types';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, request }) => {
+  try {
+    const number = parseFeedbackNumber(params.number);
+    const identity = await getAnonymousIdentity(request, env.FEEDBACK_COOKIE_SECRET);
+    const voterToken = await createVoterToken(
+      identity.id,
+      number,
+      env.FEEDBACK_COOKIE_SECRET,
+    );
+    const repository = new GitHubFeedbackRepository(env);
+    const item = await repository.get(number, voterToken);
+    return jsonResponse<FeedbackDetailResponse>(
+      { item, turnstileSiteKey: getTurnstileSiteKey(env) },
+      { setCookie: identity.setCookie },
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/landing-page/src/pages/api/feedback/[number]/comments.ts
+++ b/landing-page/src/pages/api/feedback/[number]/comments.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  createAuthorToken,
+  getAnonymousIdentity,
+} from '../../../../lib/feedback/identity';
+import { GitHubFeedbackRepository } from '../../../../lib/feedback/repository';
+import {
+  errorResponse,
+  jsonResponse,
+  readJson,
+} from '../../../../lib/feedback/response';
+import { parseFeedbackNumber } from '../../../../lib/feedback/route';
+import { createCommentSchema } from '../../../../lib/feedback/schemas';
+import {
+  assertMutationRequest,
+  verifyMutation,
+} from '../../../../lib/feedback/security';
+import type { FeedbackCommentsResponse } from '../../../../lib/feedback/types';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request }) => {
+  try {
+    const number = parseFeedbackNumber(params.number);
+    assertMutationRequest(request);
+    const input = createCommentSchema.parse(await readJson(request));
+    await verifyMutation(request, env, input.turnstileToken, 'interaction');
+    const identity = await getAnonymousIdentity(request, env.FEEDBACK_COOKIE_SECRET);
+    const authorToken = await createAuthorToken(
+      identity.id,
+      number,
+      env.FEEDBACK_COOKIE_SECRET,
+    );
+    const repository = new GitHubFeedbackRepository(env);
+    const comments = await repository.addComment(number, input, authorToken);
+    return jsonResponse<FeedbackCommentsResponse>(
+      { comments },
+      { status: 201, setCookie: identity.setCookie },
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/landing-page/src/pages/api/feedback/[number]/vote.ts
+++ b/landing-page/src/pages/api/feedback/[number]/vote.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  createVoterToken,
+  getAnonymousIdentity,
+} from '../../../../lib/feedback/identity';
+import { GitHubFeedbackRepository } from '../../../../lib/feedback/repository';
+import {
+  errorResponse,
+  jsonResponse,
+  readJson,
+} from '../../../../lib/feedback/response';
+import { parseFeedbackNumber } from '../../../../lib/feedback/route';
+import { voteSchema } from '../../../../lib/feedback/schemas';
+import {
+  assertMutationRequest,
+  verifyMutation,
+} from '../../../../lib/feedback/security';
+import type { FeedbackMutationResponse } from '../../../../lib/feedback/types';
+
+export const prerender = false;
+
+async function mutateVote(request: Request, numberValue: string | undefined, add: boolean) {
+  try {
+    const number = parseFeedbackNumber(numberValue);
+    assertMutationRequest(request);
+    const input = voteSchema.parse(await readJson(request));
+    await verifyMutation(request, env, input.turnstileToken, 'interaction');
+    const identity = await getAnonymousIdentity(request, env.FEEDBACK_COOKIE_SECRET);
+    const voterToken = await createVoterToken(
+      identity.id,
+      number,
+      env.FEEDBACK_COOKIE_SECRET,
+    );
+    const repository = new GitHubFeedbackRepository(env);
+    const result = add
+      ? await repository.vote(number, voterToken)
+      : await repository.unvote(number, voterToken);
+    return jsonResponse<FeedbackMutationResponse>(result, {
+      setCookie: identity.setCookie,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export const POST: APIRoute = ({ params, request }) =>
+  mutateVote(request, params.number, true);
+
+export const DELETE: APIRoute = ({ params, request }) =>
+  mutateVote(request, params.number, false);

--- a/landing-page/src/pages/api/feedback/index.ts
+++ b/landing-page/src/pages/api/feedback/index.ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import { getAnonymousIdentity } from '../../../lib/feedback/identity';
+import { GitHubFeedbackRepository } from '../../../lib/feedback/repository';
+import { errorResponse, jsonResponse, readJson } from '../../../lib/feedback/response';
+import { createFeedbackSchema, listFeedbackSchema } from '../../../lib/feedback/schemas';
+import {
+  assertMutationRequest,
+  getTurnstileSiteKey,
+  verifyMutation,
+} from '../../../lib/feedback/security';
+import type { FeedbackCreatedResponse, FeedbackListResponse } from '../../../lib/feedback/types';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  try {
+    const url = new URL(request.url);
+    const input = listFeedbackSchema.parse(Object.fromEntries(url.searchParams.entries()));
+    const repository = new GitHubFeedbackRepository(env);
+    const result = await repository.list(input);
+    const page = Math.min(input.page, result.totalPages);
+    return jsonResponse<FeedbackListResponse>(
+      {
+        ...result,
+        page,
+        pageSize: input.pageSize,
+        turnstileSiteKey: getTurnstileSiteKey(env),
+      },
+      {
+        cacheControl: 'public, max-age=30, s-maxage=30, stale-while-revalidate=120',
+      },
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    assertMutationRequest(request);
+    const input = createFeedbackSchema.parse(await readJson(request));
+    await verifyMutation(request, env, input.turnstileToken, 'submission');
+    const identity = await getAnonymousIdentity(request, env.FEEDBACK_COOKIE_SECRET);
+    const repository = new GitHubFeedbackRepository(env);
+    const number = await repository.create(input);
+    return jsonResponse<FeedbackCreatedResponse>(
+      { number, url: `/feedback/${number}` },
+      { status: 201, setCookie: identity.setCookie },
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/landing-page/src/pages/feedback/[number].astro
+++ b/landing-page/src/pages/feedback/[number].astro
@@ -1,0 +1,42 @@
+---
+import { env } from 'cloudflare:workers';
+import FeedbackDetail from '../../components/feedback/FeedbackDetail';
+import Footer from '../../components/Footer.astro';
+import Nav from '../../components/Nav.astro';
+import { FeedbackError } from '../../lib/feedback/errors';
+import { GitHubFeedbackRepository } from '../../lib/feedback/repository';
+import type { FeedbackDetail as FeedbackDetailType } from '../../lib/feedback/types';
+import PageLayout from '../../layouts/PageLayout.astro';
+
+export const prerender = false;
+
+const number = Number(Astro.params.number);
+let initialItem: FeedbackDetailType | undefined;
+let responseStatus = 200;
+
+if (Number.isSafeInteger(number) && number > 0) {
+  try {
+    initialItem = await new GitHubFeedbackRepository(env).get(number, '');
+  } catch (error) {
+    responseStatus = error instanceof FeedbackError && error.status === 404 ? 404 : 503;
+    if (responseStatus >= 500) console.error(error);
+  }
+} else {
+  responseStatus = 404;
+}
+
+if (!initialItem) Astro.response.status = responseStatus;
+
+const title = initialItem
+  ? `${initialItem.title} — Excalimate Feedback`
+  : 'Feedback Not Found — Excalimate';
+const description = initialItem?.excerpt ?? 'This Excalimate feedback item could not be found.';
+---
+
+<PageLayout title={title} description={description} path={`/feedback/${number}`}>
+  <Nav />
+  <main id="main">
+    <FeedbackDetail number={number} initialItem={initialItem} client:load />
+  </main>
+  <Footer />
+</PageLayout>

--- a/landing-page/src/pages/feedback/index.astro
+++ b/landing-page/src/pages/feedback/index.astro
@@ -1,0 +1,18 @@
+---
+import PageLayout from '../../layouts/PageLayout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import FeedbackBoard from '../../components/feedback/FeedbackBoard';
+---
+
+<PageLayout
+  title="Feedback — Help Shape Excalimate"
+  description="Suggest improvements, vote on product feedback, and follow what the Excalimate team is planning and building."
+  path="/feedback"
+>
+  <Nav />
+  <main id="main">
+    <FeedbackBoard client:load />
+  </main>
+  <Footer />
+</PageLayout>

--- a/landing-page/src/test/cloudflare-workers.ts
+++ b/landing-page/src/test/cloudflare-workers.ts
@@ -1,0 +1,1 @@
+export const env = {} as Cloudflare.Env;

--- a/landing-page/src/test/setup.ts
+++ b/landing-page/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/landing-page/tsconfig.json
+++ b/landing-page/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "types": ["astro/client", "@cloudflare/workers-types", "vitest/globals"]
+  }
 }

--- a/landing-page/vitest.config.ts
+++ b/landing-page/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'cloudflare:workers': fileURLToPath(
+        new URL('./src/test/cloudflare-workers.ts', import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/test/setup.ts'],
+    restoreMocks: true,
+  },
+});

--- a/landing-page/wrangler.toml
+++ b/landing-page/wrangler.toml
@@ -2,7 +2,29 @@
 
 name = "excalimate-landing"
 compatibility_date = "2026-03-22"
-pages_build_output_dir = "./dist"
+compatibility_flags = ["nodejs_compat"]
 
 [assets]
 directory = "./dist"
+binding = "ASSETS"
+
+[vars]
+GITHUB_REPOSITORY_OWNER = "excalimate"
+GITHUB_REPOSITORY_NAME = "excalimate"
+GITHUB_APP_BOT_LOGIN = "excalimate-feedback[bot]"
+TURNSTILE_ALLOWED_HOSTNAMES = "excalimate.com,www.excalimate.com"
+
+[observability]
+enabled = true
+
+[[unsafe.bindings]]
+name = "FEEDBACK_SUBMISSION_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "11001"
+simple = { limit = 5, period = 60 }
+
+[[unsafe.bindings]]
+name = "FEEDBACK_INTERACTION_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "11002"
+simple = { limit = 30, period = 60 }


### PR DESCRIPTION
## Summary
- add public `/feedback` board and shareable feedback detail pages using Mantine React islands
- use GitHub Issues, labels, comments, and a least-privilege GitHub App as the authoritative feedback backend
- support anonymous submissions, discussions, and deduplicated voting with signed browser identities
- protect mutations with Cloudflare Turnstile, same-origin validation, body limits, and rate-limit bindings
- add label provisioning, Cloudflare Worker deployment configuration, navigation links, CI checks, and focused regression coverage

## Validation
- `npm run check`
- `npm test` (24 tests)
- `npm run build`
- generated Worker smoke-tested for `/feedback` and `/api/feedback`

## Deployment setup
Create and install the GitHub App, configure its bot login, add the Turnstile widget, and set the Worker secrets listed in `landing-page/.env.example`. Repository feedback/status labels have already been provisioned.