### PR TITLE
Promote the public feedback portal

### DIFF
--- a/landing-page/.dev.vars.example
+++ b/landing-page/.dev.vars.example
@@ -1,15 +1,18 @@
-# Cloudflare Turnstile documented always-pass test keys
-TURNSTILE_SITE_KEY=1x00000000000000000000AA
-TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
-TURNSTILE_ALLOWED_HOSTNAMES=localhost,127.0.0.1
+# Local-only Cloudflare Worker runtime bindings.
+# Copy this file to .dev.vars; never commit the populated file.
+# Production values are configured as documented in wrangler.toml.
 
-# Create a GitHub App with Issues read/write and install it on the repository
+# Non-secret runtime variables
+TURNSTILE_SITE_KEY=1x00000000000000000000AA
+TURNSTILE_ALLOWED_HOSTNAMES=localhost,127.0.0.1
 GITHUB_APP_ID=
 GITHUB_APP_INSTALLATION_ID=
-GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 GITHUB_APP_BOT_LOGIN=excalimate-feedback[bot]
 GITHUB_REPOSITORY_OWNER=excalimate
 GITHUB_REPOSITORY_NAME=excalimate
 
-# Replace with at least 32 random characters
+# Local placeholders only; these are not production credentials.
+# Turnstile uses Cloudflare's documented always-pass test secret.
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 FEEDBACK_COOKIE_SECRET=replace-with-a-random-secret-at-least-32-characters

--- a/landing-page/.env.example
+++ b/landing-page/.env.example
@@ -1,17 +1,8 @@
-# PostHog Analytics (optional — leave PUBLIC_POSTHOG_KEY empty to disable analytics)
+# Astro build-time analytics (optional; leave PUBLIC_POSTHOG_KEY empty to disable)
 PUBLIC_POSTHOG_KEY=
 PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
-# Feedback portal runtime (set secrets with `wrangler secret put`)
-GITHUB_APP_ID=
-GITHUB_APP_INSTALLATION_ID=
-GITHUB_APP_PRIVATE_KEY=
-GITHUB_APP_BOT_LOGIN=excalimate-feedback[bot]
-FEEDBACK_COOKIE_SECRET=
-TURNSTILE_SECRET_KEY=
-TURNSTILE_SITE_KEY=
-
-# Non-secret Worker variables (production defaults live in wrangler.toml)
-GITHUB_REPOSITORY_OWNER=excalimate
-GITHUB_REPOSITORY_NAME=excalimate
-TURNSTILE_ALLOWED_HOSTNAMES=excalimate.com,www.excalimate.com
+# Feedback portal settings are Cloudflare Worker runtime bindings, not build-time
+# Astro variables. For local development, copy .dev.vars.example to .dev.vars.
+# For production, configure the dashboard variables and Wrangler secrets listed
+# in wrangler.toml; committed non-secret defaults also live there.

--- a/landing-page/src/components/FeedbackExitIntent.astro
+++ b/landing-page/src/components/FeedbackExitIntent.astro
@@ -87,11 +87,16 @@ const benefits = [
 
 <style>
   .feedback-exit-dialog {
-    width: min(600px, calc(100% - 32px));
+    position: fixed;
+    inset: 50% auto auto 50%;
+    z-index: 300;
+    width: min(600px, calc(100vw - 32px));
     max-width: none;
     max-height: calc(100dvh - 32px);
+    margin: 0;
     padding: 0;
     overflow: auto;
+    transform: translate(-50%, -50%);
     background: var(--card-bg);
     border: var(--border-w) solid var(--border-c);
     border-radius: var(--radius-lg);
@@ -105,6 +110,7 @@ const benefits = [
   }
 
   .feedback-exit-dialog::backdrop {
+    z-index: 299;
     background: rgba(17, 17, 21, 0.72);
   }
 
@@ -131,19 +137,35 @@ const benefits = [
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: var(--bg-alt);
-    border: var(--border-w) solid var(--border-c);
+    width: 32px;
+    height: 32px;
+    padding: 4px;
+    background: none;
+    border: 1px solid var(--border-strong);
     border-radius: var(--radius);
-    color: var(--tx);
+    color: var(--tx3);
+    line-height: 1;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease,
+      transform 0.15s ease;
   }
 
   .feedback-exit-close:hover {
+    color: var(--tx);
+    background: var(--surface-hover);
+  }
+
+  .feedback-exit-close:active {
+    transform: translate(1px, 1px);
     background: var(--accent);
   }
 
-  .feedback-exit-close:focus-visible,
+  .feedback-exit-close:focus-visible {
+    outline: 2px solid var(--p4);
+    outline-offset: 2px;
+  }
+
   .feedback-exit-cta:focus-visible {
     outline-color: var(--tx);
   }
@@ -237,6 +259,7 @@ const benefits = [
 
   @media (prefers-reduced-motion: reduce) {
     .feedback-exit-close:hover,
+    .feedback-exit-close:active,
     .feedback-exit-cta:hover {
       transform: none;
     }

--- a/landing-page/src/components/FeedbackExitIntent.astro
+++ b/landing-page/src/components/FeedbackExitIntent.astro
@@ -1,0 +1,348 @@
+---
+import {
+  IconArrowRight,
+  IconArrowUp,
+  IconBulb,
+  IconMessageCircle,
+  IconProgressCheck,
+  IconX,
+} from '@tabler/icons-react';
+
+const benefits = [
+  {
+    label: 'Submit ideas',
+    icon: IconBulb,
+    color: 'var(--p2)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    label: 'Vote on requests',
+    icon: IconArrowUp,
+    color: 'var(--p3)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    label: 'Join discussions',
+    icon: IconMessageCircle,
+    color: 'var(--p4)',
+    iconColor: '#fff',
+  },
+  {
+    label: 'Track progress',
+    icon: IconProgressCheck,
+    color: 'var(--p5)',
+    iconColor: 'var(--tx)',
+  },
+];
+---
+
+<dialog
+  id="feedback-exit-intent"
+  class="feedback-exit-dialog"
+  aria-labelledby="feedback-exit-title"
+  aria-describedby="feedback-exit-description"
+  aria-modal="true"
+>
+  <div class="feedback-exit-accent" aria-hidden="true"></div>
+  <div class="feedback-exit-content">
+    <form method="dialog">
+      <button
+        class="feedback-exit-close"
+        value="dismissed"
+        aria-label="Close feedback invitation"
+      >
+        <IconX size={20} stroke={2.2} aria-hidden="true" />
+      </button>
+    </form>
+
+    <p class="feedback-exit-eyebrow">Before you go</p>
+    <h2 id="feedback-exit-title">Help choose what we build next</h2>
+    <p id="feedback-exit-description">
+      Excalimate's public feedback portal turns your ideas and community votes into a transparent
+      roadmap.
+    </p>
+
+    <ul class="feedback-exit-benefits" aria-label="Ways to shape Excalimate">
+      {
+        benefits.map((benefit) => {
+          const Icon = benefit.icon;
+          return (
+            <li style={`--benefit-color: ${benefit.color}; --benefit-icon: ${benefit.iconColor}`}>
+              <span>
+                <Icon size={19} stroke={2.2} aria-hidden="true" />
+              </span>
+              {benefit.label}
+            </li>
+          );
+        })
+      }
+    </ul>
+
+    <a href="/feedback" class="btn btn-primary feedback-exit-cta">
+      Explore public feedback
+      <IconArrowRight size={19} stroke={2.2} aria-hidden="true" />
+    </a>
+  </div>
+</dialog>
+
+<style>
+  .feedback-exit-dialog {
+    width: min(600px, calc(100% - 32px));
+    max-width: none;
+    max-height: calc(100dvh - 32px);
+    padding: 0;
+    overflow: auto;
+    background: var(--card-bg);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius-lg);
+    box-shadow: 8px 8px 0 var(--border-c);
+    color: var(--tx);
+  }
+
+  .feedback-exit-dialog[open] {
+    display: grid;
+    grid-template-columns: 12px minmax(0, 1fr);
+  }
+
+  .feedback-exit-dialog::backdrop {
+    background: rgba(17, 17, 21, 0.72);
+  }
+
+  .feedback-exit-accent {
+    background: linear-gradient(
+      180deg,
+      var(--p2) 0 25%,
+      var(--p3) 25% 50%,
+      var(--p4) 50% 75%,
+      var(--p5) 75% 100%
+    );
+    border-right: var(--border-w) solid var(--border-c);
+  }
+
+  .feedback-exit-content {
+    position: relative;
+    padding: 38px 42px 40px;
+  }
+
+  .feedback-exit-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: var(--bg-alt);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    color: var(--tx);
+  }
+
+  .feedback-exit-close:hover {
+    background: var(--accent);
+  }
+
+  .feedback-exit-close:focus-visible,
+  .feedback-exit-cta:focus-visible {
+    outline-color: var(--tx);
+  }
+
+  .feedback-exit-eyebrow {
+    display: inline-flex;
+    padding: 6px 10px;
+    background: var(--accent);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 2px 2px 0 var(--border-c);
+    font-family: var(--f-body);
+    font-size: 0.68rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .feedback-exit-content h2 {
+    max-width: 460px;
+    margin-top: 20px;
+    font-family: var(--f-display);
+    font-size: clamp(1.8rem, 5vw, 2.45rem);
+    font-weight: 700;
+    line-height: 1.08;
+    letter-spacing: -0.025em;
+  }
+
+  #feedback-exit-description {
+    max-width: 490px;
+    margin-top: 14px;
+    font-family: var(--f-body);
+    font-size: 0.98rem;
+    line-height: 1.6;
+    color: var(--tx2);
+  }
+
+  .feedback-exit-benefits {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 24px;
+  }
+
+  .feedback-exit-benefits li {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    padding: 10px 12px;
+    background: var(--bg-alt);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    font-family: var(--f-body);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.25;
+  }
+
+  .feedback-exit-benefits li > span {
+    display: flex;
+    flex: 0 0 34px;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    background: var(--benefit-color);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    color: var(--benefit-icon);
+  }
+
+  .feedback-exit-cta {
+    margin-top: 26px;
+  }
+
+  @media (max-width: 520px) {
+    .feedback-exit-content {
+      padding: 34px 24px 30px;
+    }
+
+    .feedback-exit-benefits {
+      grid-template-columns: 1fr;
+    }
+
+    .feedback-exit-cta {
+      width: 100%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feedback-exit-close:hover,
+    .feedback-exit-cta:hover {
+      transform: none;
+    }
+  }
+</style>
+
+<script>
+  import {
+    FEEDBACK_EXIT_INTENT_DELAY_MS,
+    FEEDBACK_EXIT_INTENT_SESSION_KEY,
+    shouldShowFeedbackExitIntent,
+  } from '../lib/feedback/exitIntent';
+
+  const dialog = document.querySelector<HTMLDialogElement>('#feedback-exit-intent');
+  const cta = dialog?.querySelector<HTMLAnchorElement>('.feedback-exit-cta');
+  const finePointer = window.matchMedia(
+    '(min-width: 768px) and (hover: hover) and (pointer: fine)',
+  );
+  let armed = false;
+  let shownThisPage = false;
+
+  function hasBeenShown(): boolean {
+    if (shownThisPage) return true;
+
+    try {
+      return window.sessionStorage.getItem(FEEDBACK_EXIT_INTENT_SESSION_KEY) === 'true';
+    } catch (error) {
+      console.warn('Unable to read feedback exit-intent state.', error);
+      return false;
+    }
+  }
+
+  function markAsShown(): void {
+    shownThisPage = true;
+
+    try {
+      window.sessionStorage.setItem(FEEDBACK_EXIT_INTENT_SESSION_KEY, 'true');
+    } catch (error) {
+      console.warn('Unable to persist feedback exit-intent state.', error);
+    }
+  }
+
+  function track(eventName: string, properties: Record<string, string>): void {
+    if (typeof posthog !== 'undefined' && !posthog.has_opted_out_capturing()) {
+      posthog.capture(eventName, properties);
+    }
+  }
+
+  function removeExitListener(): void {
+    document.removeEventListener('mouseout', handleExitIntent);
+  }
+
+  function openDialog(): void {
+    if (!dialog || typeof dialog.showModal !== 'function') return;
+
+    dialog.showModal();
+    markAsShown();
+    removeExitListener();
+    track('feedback_exit_intent_shown', { location: 'landing_page' });
+  }
+
+  function handleExitIntent(event: MouseEvent): void {
+    if (!dialog || document.querySelector('.consent-overlay.open')) return;
+
+    if (
+      shouldShowFeedbackExitIntent(event, {
+        armed,
+        finePointer: finePointer.matches,
+        alreadyShown: hasBeenShown(),
+        dialogOpen: dialog.open,
+      })
+    ) {
+      openDialog();
+    }
+  }
+
+  let armTimer: number | undefined;
+
+  if (dialog && finePointer.matches && !hasBeenShown()) {
+    armTimer = window.setTimeout(() => {
+      armed = true;
+    }, FEEDBACK_EXIT_INTENT_DELAY_MS);
+    document.addEventListener('mouseout', handleExitIntent);
+  }
+
+  dialog?.addEventListener('click', (event) => {
+    if (event.target === dialog) {
+      dialog.close('backdrop');
+    }
+  });
+
+  dialog?.addEventListener('close', () => {
+    if (armTimer !== undefined) {
+      window.clearTimeout(armTimer);
+    }
+    removeExitListener();
+    track('feedback_exit_intent_closed', {
+      reason: dialog.returnValue || 'dismissed',
+    });
+  });
+
+  cta?.addEventListener('click', () => {
+    markAsShown();
+    track('cta_clicked', {
+      button_text: 'Explore public feedback',
+      location: 'feedback_exit_intent',
+    });
+  });
+</script>

--- a/landing-page/src/components/FeedbackPromo.astro
+++ b/landing-page/src/components/FeedbackPromo.astro
@@ -7,38 +7,12 @@ import {
   IconProgressCheck,
 } from '@tabler/icons-react';
 
-const participationOptions = [
-  {
-    title: 'Submit ideas',
-    description: 'Propose a feature or improvement.',
-    icon: IconBulb,
-    color: 'var(--p2)',
-    iconColor: 'var(--tx)',
-  },
-  {
-    title: 'Vote on requests',
-    description: 'Help the best ideas rise to the top.',
-    icon: IconArrowUp,
-    color: 'var(--p3)',
-    iconColor: 'var(--tx)',
-  },
-  {
-    title: 'Join discussions',
-    description: 'Add context and build on suggestions.',
-    icon: IconMessageCircle,
-    color: 'var(--p4)',
-    iconColor: '#fff',
-  },
-  {
-    title: 'Track progress',
-    description: 'See what the team is reviewing and building.',
-    icon: IconProgressCheck,
-    color: 'var(--p5)',
-    iconColor: 'var(--tx)',
-  },
+const statuses = [
+  { label: 'Under review', color: '#9ca3af' },
+  { label: 'Planned', color: 'var(--p4)' },
+  { label: 'In progress', color: 'var(--p2)' },
+  { label: 'Completed', color: 'var(--p5)' },
 ];
-
-const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
 ---
 
 <section class="feedback-promo" aria-labelledby="feedback-promo-title">
@@ -60,46 +34,74 @@ const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
         </a>
       </div>
 
-      <div class="feedback-panel">
-        <ul class="feedback-actions stagger" aria-label="Ways to participate">
-          {
-            participationOptions.map((option) => {
-              const Icon = option.icon;
-              return (
-                <li class="feedback-action reveal">
-                  <span
-                    class="feedback-action-icon"
-                    style={`--icon-background: ${option.color}; --icon-color: ${option.iconColor}`}
-                  >
-                    <Icon size={24} stroke={2.1} aria-hidden="true" />
-                  </span>
-                  <span class="feedback-action-copy">
-                    <strong>{option.title}</strong>
-                    <span>{option.description}</span>
-                  </span>
-                </li>
-              );
-            })
-          }
-        </ul>
+      <div class="feedback-panel" aria-label="Public feedback portal preview">
+        <div class="feedback-board">
+          <header class="feedback-board-header">
+            <span class="feedback-board-brand">
+              <span class="feedback-board-brand-icon">
+                <IconMessageCircle size={22} stroke={2.2} aria-hidden="true" />
+              </span>
+              <span>
+                <strong>Community roadmap</strong>
+                <small>Ideas shaped in public</small>
+              </span>
+            </span>
+            <span class="feedback-public-badge">Public</span>
+          </header>
 
-        <div
-          class="feedback-status"
-          aria-label="Feedback statuses: under review, planned, in progress, completed"
-        >
-          <p class="feedback-status-title">See every idea move forward</p>
-          <div class="feedback-status-track" aria-hidden="true">
-            {
-              statuses.map((status, index) => (
-                <>
-                  <span class="feedback-status-step">
+          <article class="feedback-idea">
+            <div class="feedback-idea-meta">
+              <span class="feedback-category">Feature request</span>
+              <span class="feedback-review-state">Under review</span>
+            </div>
+            <div class="feedback-idea-body">
+              <span class="feedback-idea-icon">
+                <IconBulb size={26} stroke={2.1} aria-hidden="true" />
+              </span>
+              <div>
+                <h3>What should Excalimate do next?</h3>
+                <p>Share your workflow idea, then let the community strengthen it.</p>
+              </div>
+            </div>
+            <div class="feedback-engagement" aria-label="Community participation">
+              <span>
+                <IconArrowUp size={18} stroke={2.2} aria-hidden="true" />
+                <span>
+                  <strong>Vote</strong>
+                  <small>Prioritize ideas</small>
+                </span>
+              </span>
+              <span>
+                <IconMessageCircle size={18} stroke={2.2} aria-hidden="true" />
+                <span>
+                  <strong>Discuss</strong>
+                  <small>Add useful context</small>
+                </span>
+              </span>
+            </div>
+          </article>
+
+          <div
+            class="feedback-status"
+            aria-label="Feedback statuses: under review, planned, in progress, completed"
+          >
+            <div class="feedback-status-heading">
+              <IconProgressCheck size={20} stroke={2.2} aria-hidden="true" />
+              <p>Follow every update</p>
+            </div>
+            <ol class="feedback-status-track">
+              {
+                statuses.map((status) => (
+                  <li
+                    class="feedback-status-step"
+                    style={`--status-color: ${status.color}`}
+                  >
                     <span class="feedback-status-dot" />
-                    <span>{status}</span>
-                  </span>
-                  {index < statuses.length - 1 && <span class="feedback-status-line" />}
-                </>
-              ))
-            }
+                    <span>{status.label}</span>
+                  </li>
+                ))
+              }
+            </ol>
           </div>
         </div>
       </div>
@@ -171,113 +173,278 @@ const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
 
   .feedback-panel {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     justify-content: center;
-    gap: 28px;
     padding: 28px;
     background: var(--tx);
   }
 
-  .feedback-actions {
-    display: grid;
-    gap: 14px;
+  .feedback-board {
+    width: 100%;
+    overflow: hidden;
+    background: var(--bg-alt);
+    border: var(--border-w) solid #fff;
+    border-radius: var(--radius);
+    box-shadow: 6px 6px 0 var(--p2);
   }
 
-  .feedback-action {
+  .feedback-board-header {
     display: flex;
     align-items: center;
-    gap: 14px;
-    min-width: 0;
-    padding: 16px;
-    background: var(--card-bg);
-    border: var(--border-w) solid var(--border-c);
-    border-radius: var(--radius);
-    box-shadow: 3px 3px 0 var(--p2);
-  }
-
-  .feedback-action-icon {
-    display: flex;
-    flex: 0 0 44px;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    background: var(--icon-background);
-    border: var(--border-w) solid var(--border-c);
-    border-radius: var(--radius);
-    color: var(--icon-color);
-  }
-
-  .feedback-action-copy {
-    display: flex;
-    min-width: 0;
-    flex-direction: column;
-    gap: 3px;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 15px 18px;
+    background: var(--accent);
+    border-bottom: var(--border-w) solid var(--border-c);
     color: var(--tx);
   }
 
-  .feedback-action-copy strong {
-    font-family: var(--f-display);
-    font-size: 1rem;
-    line-height: 1.25;
+  .feedback-board-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
   }
 
-  .feedback-action-copy > span {
-    font-family: var(--f-body);
-    font-size: 0.8rem;
-    line-height: 1.4;
-    color: var(--tx2);
-  }
-
-  .feedback-status {
-    padding: 20px;
-    border: var(--border-w) solid #fff;
+  .feedback-board-brand-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    flex: 0 0 36px;
+    background: var(--tx);
     border-radius: var(--radius);
     color: #fff;
   }
 
-  .feedback-status-title {
+  .feedback-board-brand > span:last-child {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+
+  .feedback-board-brand strong {
     font-family: var(--f-display);
-    font-size: 0.95rem;
+    font-size: 0.98rem;
+    line-height: 1.15;
+  }
+
+  .feedback-board-brand small {
+    margin-top: 2px;
+    font-family: var(--f-body);
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.2;
+    color: var(--tx2);
+  }
+
+  .feedback-public-badge {
+    flex: 0 0 auto;
+    padding: 6px 9px;
+    background: #fff;
+    border: var(--border-w) solid var(--border-c);
+    border-radius: 999px;
+    font-family: var(--f-body);
+    font-size: 0.66rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .feedback-idea {
+    margin: 18px;
+    padding: 20px;
+    background: var(--card-bg);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 4px 4px 0 var(--border-c);
+  }
+
+  .feedback-idea-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .feedback-category,
+  .feedback-review-state {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-family: var(--f-body);
+    font-size: 0.64rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .feedback-category {
+    background: color-mix(in srgb, var(--p2) 24%, #fff);
+    border: 1px solid color-mix(in srgb, var(--p2) 70%, var(--tx));
+    color: var(--tx);
+  }
+
+  .feedback-review-state {
+    background: #ececef;
+    border: 1px solid #8a8a96;
+    color: #34343c;
+  }
+
+  .feedback-idea-body {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    margin-top: 18px;
+  }
+
+  .feedback-idea-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    flex: 0 0 46px;
+    background: var(--p2);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    color: var(--tx);
+  }
+
+  .feedback-idea-body h3 {
+    font-family: var(--f-display);
+    font-size: 1.15rem;
     font-weight: 700;
+    line-height: 1.2;
+    color: var(--tx);
+  }
+
+  .feedback-idea-body p {
+    margin-top: 6px;
+    font-family: var(--f-body);
+    font-size: 0.82rem;
+    line-height: 1.45;
+    color: var(--tx2);
+  }
+
+  .feedback-engagement {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-strong);
+  }
+
+  .feedback-engagement > span {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 9px 10px;
+    background: var(--bg-alt);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    color: var(--tx);
+  }
+
+  .feedback-engagement > span > span {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+  }
+
+  .feedback-engagement strong {
+    font-family: var(--f-display);
+    font-size: 0.76rem;
+    line-height: 1.15;
+  }
+
+  .feedback-engagement small {
+    margin-top: 2px;
+    font-family: var(--f-body);
+    font-size: 0.62rem;
+    line-height: 1.2;
+    color: var(--tx2);
+  }
+
+  .feedback-status {
+    padding: 18px 18px 20px;
+    background: var(--tx);
+    border-top: var(--border-w) solid #fff;
+    color: #fff;
+  }
+
+  .feedback-status-heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .feedback-status-heading p {
+    font-family: var(--f-display);
+    font-size: 0.9rem;
+    font-weight: 600;
     line-height: 1.3;
   }
 
   .feedback-status-track {
-    display: flex;
-    align-items: flex-start;
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     margin-top: 18px;
   }
 
+  .feedback-status-track::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 7px;
+    right: 11%;
+    left: 11%;
+    height: 4px;
+    background: linear-gradient(
+      90deg,
+      #9ca3af 0%,
+      #9ca3af 24%,
+      var(--p4) 27%,
+      var(--p4) 48%,
+      var(--p2) 52%,
+      var(--p2) 73%,
+      var(--p5) 77%,
+      var(--p5) 100%
+    );
+    border-radius: 999px;
+  }
+
   .feedback-status-step {
+    position: relative;
+    z-index: 1;
     display: flex;
-    flex: 0 0 auto;
-    width: 56px;
+    min-width: 0;
     flex-direction: column;
     align-items: center;
     gap: 8px;
     font-family: var(--f-body);
-    font-size: 0.62rem;
-    font-weight: 600;
-    line-height: 1.2;
+    font-size: 0.6rem;
+    font-weight: 700;
+    line-height: 1.15;
     text-align: center;
     color: #fff;
   }
 
   .feedback-status-dot {
-    width: 13px;
-    height: 13px;
-    background: var(--accent);
+    width: 18px;
+    height: 18px;
+    background: var(--status-color);
     border: 2px solid #fff;
     border-radius: 50%;
-  }
-
-  .feedback-status-line {
-    flex: 1 1 20px;
-    min-width: 10px;
-    height: 2px;
-    margin: 6px -5px 0;
-    background: #fff;
+    box-shadow: 0 0 0 3px var(--tx);
   }
 
   @media (min-width: 640px) {
@@ -287,10 +454,6 @@ const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
 
     .feedback-panel {
       padding: 40px;
-    }
-
-    .feedback-actions {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
@@ -313,13 +476,25 @@ const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
       padding: 20px;
     }
 
+    .feedback-idea {
+      margin: 12px;
+      padding: 16px;
+    }
+
+    .feedback-idea-body {
+      gap: 10px;
+    }
+
+    .feedback-engagement {
+      grid-template-columns: 1fr;
+    }
+
     .feedback-status {
       padding-inline: 12px;
     }
 
     .feedback-status-step {
-      width: 44px;
-      font-size: 0.55rem;
+      font-size: 0.54rem;
     }
   }
 

--- a/landing-page/src/components/FeedbackPromo.astro
+++ b/landing-page/src/components/FeedbackPromo.astro
@@ -7,8 +7,39 @@ import {
   IconProgressCheck,
 } from '@tabler/icons-react';
 
+const participationOptions = [
+  {
+    title: 'Submit ideas',
+    description: 'Propose a feature or improvement.',
+    icon: IconBulb,
+    color: 'var(--p2)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    title: 'Vote on requests',
+    description: 'Help the best ideas rise to the top.',
+    icon: IconArrowUp,
+    color: 'var(--p3)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    title: 'Join discussions',
+    description: 'Add context and build on suggestions.',
+    icon: IconMessageCircle,
+    color: 'var(--p4)',
+    iconColor: '#fff',
+  },
+  {
+    title: 'Track progress',
+    description: 'See what the team is reviewing and building.',
+    icon: IconProgressCheck,
+    color: 'var(--p5)',
+    iconColor: 'var(--tx)',
+  },
+];
+
 const statuses = [
-  { label: 'Under review', color: '#9ca3af' },
+  { label: 'Under review', color: '#656570' },
   { label: 'Planned', color: 'var(--p4)' },
   { label: 'In progress', color: 'var(--p2)' },
   { label: 'Completed', color: 'var(--p5)' },
@@ -34,75 +65,44 @@ const statuses = [
         </a>
       </div>
 
-      <div class="feedback-panel" aria-label="Public feedback portal preview">
-        <div class="feedback-board">
-          <header class="feedback-board-header">
-            <span class="feedback-board-brand">
-              <span class="feedback-board-brand-icon">
-                <IconMessageCircle size={22} stroke={2.2} aria-hidden="true" />
-              </span>
-              <span>
-                <strong>Community roadmap</strong>
-                <small>Ideas shaped in public</small>
-              </span>
-            </span>
-            <span class="feedback-public-badge">Public</span>
-          </header>
-
-          <article class="feedback-idea">
-            <div class="feedback-idea-meta">
-              <span class="feedback-category">Feature request</span>
-              <span class="feedback-review-state">Under review</span>
-            </div>
-            <div class="feedback-idea-body">
-              <span class="feedback-idea-icon">
-                <IconBulb size={26} stroke={2.1} aria-hidden="true" />
-              </span>
-              <div>
-                <h3>What should Excalimate do next?</h3>
-                <p>Share your workflow idea, then let the community strengthen it.</p>
-              </div>
-            </div>
-            <div class="feedback-engagement" aria-label="Community participation">
-              <span>
-                <IconArrowUp size={18} stroke={2.2} aria-hidden="true" />
-                <span>
-                  <strong>Vote</strong>
-                  <small>Prioritize ideas</small>
-                </span>
-              </span>
-              <span>
-                <IconMessageCircle size={18} stroke={2.2} aria-hidden="true" />
-                <span>
-                  <strong>Discuss</strong>
-                  <small>Add useful context</small>
-                </span>
-              </span>
-            </div>
-          </article>
-
-          <div
-            class="feedback-status"
-            aria-label="Feedback statuses: under review, planned, in progress, completed"
-          >
-            <div class="feedback-status-heading">
-              <IconProgressCheck size={20} stroke={2.2} aria-hidden="true" />
-              <p>Follow every update</p>
-            </div>
-            <ol class="feedback-status-track">
-              {
-                statuses.map((status) => (
-                  <li
-                    class="feedback-status-step"
-                    style={`--status-color: ${status.color}`}
+      <div class="feedback-panel">
+        <ul class="feedback-actions stagger" aria-label="Ways to participate">
+          {
+            participationOptions.map((option) => {
+              const Icon = option.icon;
+              return (
+                <li class="feedback-action reveal">
+                  <span
+                    class="feedback-action-icon"
+                    style={`--icon-background: ${option.color}; --icon-color: ${option.iconColor}`}
                   >
-                    <span class="feedback-status-dot" />
-                    <span>{status.label}</span>
-                  </li>
-                ))
-              }
-            </ol>
-          </div>
+                    <Icon size={24} stroke={2.1} aria-hidden="true" />
+                  </span>
+                  <span class="feedback-action-copy">
+                    <strong>{option.title}</strong>
+                    <span>{option.description}</span>
+                  </span>
+                </li>
+              );
+            })
+          }
+        </ul>
+
+        <div
+          class="feedback-status"
+          aria-label="Feedback statuses: under review, planned, in progress, completed"
+        >
+          <p class="feedback-status-title">See every idea move forward</p>
+          <ol class="feedback-status-track">
+            {
+              statuses.map((status) => (
+                <li class="feedback-status-step" style={`--status-color: ${status.color}`}>
+                  <span class="feedback-status-dot" />
+                  <span>{status.label}</span>
+                </li>
+              ))
+            }
+          </ol>
         </div>
       </div>
     </div>
@@ -173,223 +173,77 @@ const statuses = [
 
   .feedback-panel {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 28px;
-    background: var(--tx);
-  }
-
-  .feedback-board {
-    width: 100%;
-    overflow: hidden;
-    background: var(--bg-alt);
-    border: var(--border-w) solid #fff;
-    border-radius: var(--radius);
-    box-shadow: 6px 6px 0 var(--p2);
-  }
-
-  .feedback-board-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 15px 18px;
-    background: var(--accent);
-    border-bottom: var(--border-w) solid var(--border-c);
-    color: var(--tx);
-  }
-
-  .feedback-board-brand {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-  }
-
-  .feedback-board-brand-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    flex: 0 0 36px;
-    background: var(--tx);
-    border-radius: var(--radius);
-    color: #fff;
-  }
-
-  .feedback-board-brand > span:last-child {
-    display: flex;
-    min-width: 0;
     flex-direction: column;
+    justify-content: center;
+    gap: 24px;
+    padding: 28px;
+    background: var(--accent);
   }
 
-  .feedback-board-brand strong {
-    font-family: var(--f-display);
-    font-size: 0.98rem;
-    line-height: 1.15;
+  .feedback-actions {
+    display: grid;
+    gap: 14px;
   }
 
-  .feedback-board-brand small {
-    margin-top: 2px;
-    font-family: var(--f-body);
-    font-size: 0.7rem;
-    font-weight: 600;
-    line-height: 1.2;
-    color: var(--tx2);
-  }
-
-  .feedback-public-badge {
-    flex: 0 0 auto;
-    padding: 6px 9px;
-    background: #fff;
-    border: var(--border-w) solid var(--border-c);
-    border-radius: 999px;
-    font-family: var(--f-body);
-    font-size: 0.66rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-  }
-
-  .feedback-idea {
-    margin: 18px;
-    padding: 20px;
+  .feedback-action {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+    padding: 16px;
     background: var(--card-bg);
     border: var(--border-w) solid var(--border-c);
     border-radius: var(--radius);
     box-shadow: 4px 4px 0 var(--border-c);
   }
 
-  .feedback-idea-meta {
+  .feedback-action-icon {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-  }
-
-  .feedback-category,
-  .feedback-review-state {
-    display: inline-flex;
-    align-items: center;
-    min-height: 24px;
-    padding: 4px 8px;
-    border-radius: 999px;
-    font-family: var(--f-body);
-    font-size: 0.64rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  .feedback-category {
-    background: color-mix(in srgb, var(--p2) 24%, #fff);
-    border: 1px solid color-mix(in srgb, var(--p2) 70%, var(--tx));
-    color: var(--tx);
-  }
-
-  .feedback-review-state {
-    background: #ececef;
-    border: 1px solid #8a8a96;
-    color: #34343c;
-  }
-
-  .feedback-idea-body {
-    display: flex;
-    align-items: flex-start;
-    gap: 14px;
-    margin-top: 18px;
-  }
-
-  .feedback-idea-icon {
-    display: flex;
+    flex: 0 0 44px;
     align-items: center;
     justify-content: center;
-    width: 46px;
-    height: 46px;
-    flex: 0 0 46px;
-    background: var(--p2);
+    width: 44px;
+    height: 44px;
+    background: var(--icon-background);
     border: var(--border-w) solid var(--border-c);
     border-radius: var(--radius);
-    color: var(--tx);
+    color: var(--icon-color);
   }
 
-  .feedback-idea-body h3 {
-    font-family: var(--f-display);
-    font-size: 1.15rem;
-    font-weight: 700;
-    line-height: 1.2;
-    color: var(--tx);
-  }
-
-  .feedback-idea-body p {
-    margin-top: 6px;
-    font-family: var(--f-body);
-    font-size: 0.82rem;
-    line-height: 1.45;
-    color: var(--tx2);
-  }
-
-  .feedback-engagement {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
-    margin-top: 18px;
-    padding-top: 16px;
-    border-top: 1px solid var(--border-strong);
-  }
-
-  .feedback-engagement > span {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
-    padding: 9px 10px;
-    background: var(--bg-alt);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius);
-    color: var(--tx);
-  }
-
-  .feedback-engagement > span > span {
+  .feedback-action-copy {
     display: flex;
     min-width: 0;
     flex-direction: column;
+    gap: 3px;
+    color: var(--tx);
   }
 
-  .feedback-engagement strong {
+  .feedback-action-copy strong {
     font-family: var(--f-display);
-    font-size: 0.76rem;
-    line-height: 1.15;
+    font-size: 1rem;
+    line-height: 1.25;
   }
 
-  .feedback-engagement small {
-    margin-top: 2px;
+  .feedback-action-copy > span {
     font-family: var(--f-body);
-    font-size: 0.62rem;
-    line-height: 1.2;
+    font-size: 0.8rem;
+    line-height: 1.4;
     color: var(--tx2);
   }
 
   .feedback-status {
-    padding: 18px 18px 20px;
-    background: var(--tx);
-    border-top: var(--border-w) solid #fff;
-    color: #fff;
+    padding: 20px;
+    background: var(--card-bg);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 4px 4px 0 var(--border-c);
+    color: var(--tx);
   }
 
-  .feedback-status-heading {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .feedback-status-heading p {
+  .feedback-status-title {
     font-family: var(--f-display);
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: 0.95rem;
+    font-weight: 700;
     line-height: 1.3;
   }
 
@@ -407,18 +261,8 @@ const statuses = [
     top: 7px;
     right: 11%;
     left: 11%;
-    height: 4px;
-    background: linear-gradient(
-      90deg,
-      #9ca3af 0%,
-      #9ca3af 24%,
-      var(--p4) 27%,
-      var(--p4) 48%,
-      var(--p2) 52%,
-      var(--p2) 73%,
-      var(--p5) 77%,
-      var(--p5) 100%
-    );
+    height: 3px;
+    background: var(--tx3);
     border-radius: 999px;
   }
 
@@ -435,16 +279,16 @@ const statuses = [
     font-weight: 700;
     line-height: 1.15;
     text-align: center;
-    color: #fff;
+    color: var(--tx2);
   }
 
   .feedback-status-dot {
-    width: 18px;
-    height: 18px;
+    width: 17px;
+    height: 17px;
     background: var(--status-color);
-    border: 2px solid #fff;
+    border: 2px solid var(--border-c);
     border-radius: 50%;
-    box-shadow: 0 0 0 3px var(--tx);
+    box-shadow: 0 0 0 3px var(--card-bg);
   }
 
   @media (min-width: 640px) {
@@ -454,6 +298,10 @@ const statuses = [
 
     .feedback-panel {
       padding: 40px;
+    }
+
+    .feedback-actions {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
@@ -474,19 +322,6 @@ const statuses = [
   @media (max-width: 420px) {
     .feedback-panel {
       padding: 20px;
-    }
-
-    .feedback-idea {
-      margin: 12px;
-      padding: 16px;
-    }
-
-    .feedback-idea-body {
-      gap: 10px;
-    }
-
-    .feedback-engagement {
-      grid-template-columns: 1fr;
     }
 
     .feedback-status {

--- a/landing-page/src/components/FeedbackPromo.astro
+++ b/landing-page/src/components/FeedbackPromo.astro
@@ -1,0 +1,342 @@
+---
+import {
+  IconArrowRight,
+  IconArrowUp,
+  IconBulb,
+  IconMessageCircle,
+  IconProgressCheck,
+} from '@tabler/icons-react';
+
+const participationOptions = [
+  {
+    title: 'Submit ideas',
+    description: 'Propose a feature or improvement.',
+    icon: IconBulb,
+    color: 'var(--p2)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    title: 'Vote on requests',
+    description: 'Help the best ideas rise to the top.',
+    icon: IconArrowUp,
+    color: 'var(--p3)',
+    iconColor: 'var(--tx)',
+  },
+  {
+    title: 'Join discussions',
+    description: 'Add context and build on suggestions.',
+    icon: IconMessageCircle,
+    color: 'var(--p4)',
+    iconColor: '#fff',
+  },
+  {
+    title: 'Track progress',
+    description: 'See what the team is reviewing and building.',
+    icon: IconProgressCheck,
+    color: 'var(--p5)',
+    iconColor: 'var(--tx)',
+  },
+];
+
+const statuses = ['Under review', 'Planned', 'In progress', 'Completed'];
+---
+
+<section class="feedback-promo" aria-labelledby="feedback-promo-title">
+  <div class="container">
+    <div class="feedback-shell reveal">
+      <div class="feedback-copy">
+        <p class="feedback-eyebrow">Public feedback portal</p>
+        <h2 id="feedback-promo-title" class="feedback-title">
+          Help shape what Excalimate becomes next
+        </h2>
+        <p class="feedback-description">
+          Share what would make Excalimate better, support ideas from other creators, and talk
+          directly with the community. Follow requests from under review to planned, in progress,
+          and completed.
+        </p>
+        <a href="/feedback" class="btn btn-primary btn-lg feedback-cta">
+          Open the feedback portal
+          <IconArrowRight size={20} stroke={2.25} aria-hidden="true" />
+        </a>
+      </div>
+
+      <div class="feedback-panel">
+        <ul class="feedback-actions stagger" aria-label="Ways to participate">
+          {
+            participationOptions.map((option) => {
+              const Icon = option.icon;
+              return (
+                <li class="feedback-action reveal">
+                  <span
+                    class="feedback-action-icon"
+                    style={`--icon-background: ${option.color}; --icon-color: ${option.iconColor}`}
+                  >
+                    <Icon size={24} stroke={2.1} aria-hidden="true" />
+                  </span>
+                  <span class="feedback-action-copy">
+                    <strong>{option.title}</strong>
+                    <span>{option.description}</span>
+                  </span>
+                </li>
+              );
+            })
+          }
+        </ul>
+
+        <div
+          class="feedback-status"
+          aria-label="Feedback statuses: under review, planned, in progress, completed"
+        >
+          <p class="feedback-status-title">See every idea move forward</p>
+          <div class="feedback-status-track" aria-hidden="true">
+            {
+              statuses.map((status, index) => (
+                <>
+                  <span class="feedback-status-step">
+                    <span class="feedback-status-dot" />
+                    <span>{status}</span>
+                  </span>
+                  {index < statuses.length - 1 && <span class="feedback-status-line" />}
+                </>
+              ))
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .feedback-promo {
+    padding: 120px 0;
+  }
+
+  .feedback-shell {
+    display: grid;
+    overflow: hidden;
+    background: var(--card-bg);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius-lg);
+    box-shadow: 7px 7px 0 var(--border-c);
+  }
+
+  .feedback-copy {
+    padding: 48px 28px;
+  }
+
+  .feedback-eyebrow {
+    display: inline-flex;
+    padding: 7px 12px;
+    background: var(--accent);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 2px 2px 0 var(--border-c);
+    font-family: var(--f-body);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-text);
+  }
+
+  .feedback-title {
+    max-width: 560px;
+    margin-top: 24px;
+    font-family: var(--f-display);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    line-height: 1.08;
+    letter-spacing: -0.025em;
+    color: var(--tx);
+  }
+
+  .feedback-description {
+    max-width: 580px;
+    margin-top: 20px;
+    font-family: var(--f-body);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--tx2);
+  }
+
+  .feedback-cta {
+    margin-top: 32px;
+  }
+
+  .feedback-cta:focus-visible {
+    outline-color: var(--tx);
+  }
+
+  .feedback-panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 28px;
+    padding: 28px;
+    background: var(--tx);
+  }
+
+  .feedback-actions {
+    display: grid;
+    gap: 14px;
+  }
+
+  .feedback-action {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+    padding: 16px;
+    background: var(--card-bg);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 3px 3px 0 var(--p2);
+  }
+
+  .feedback-action-icon {
+    display: flex;
+    flex: 0 0 44px;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    background: var(--icon-background);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    color: var(--icon-color);
+  }
+
+  .feedback-action-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 3px;
+    color: var(--tx);
+  }
+
+  .feedback-action-copy strong {
+    font-family: var(--f-display);
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+
+  .feedback-action-copy > span {
+    font-family: var(--f-body);
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--tx2);
+  }
+
+  .feedback-status {
+    padding: 20px;
+    border: var(--border-w) solid #fff;
+    border-radius: var(--radius);
+    color: #fff;
+  }
+
+  .feedback-status-title {
+    font-family: var(--f-display);
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  .feedback-status-track {
+    display: flex;
+    align-items: flex-start;
+    margin-top: 18px;
+  }
+
+  .feedback-status-step {
+    display: flex;
+    flex: 0 0 auto;
+    width: 56px;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--f-body);
+    font-size: 0.62rem;
+    font-weight: 600;
+    line-height: 1.2;
+    text-align: center;
+    color: #fff;
+  }
+
+  .feedback-status-dot {
+    width: 13px;
+    height: 13px;
+    background: var(--accent);
+    border: 2px solid #fff;
+    border-radius: 50%;
+  }
+
+  .feedback-status-line {
+    flex: 1 1 20px;
+    min-width: 10px;
+    height: 2px;
+    margin: 6px -5px 0;
+    background: #fff;
+  }
+
+  @media (min-width: 640px) {
+    .feedback-copy {
+      padding: 56px 48px;
+    }
+
+    .feedback-panel {
+      padding: 40px;
+    }
+
+    .feedback-actions {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .feedback-shell {
+      grid-template-columns: minmax(0, 1.05fr) minmax(460px, 0.95fr);
+    }
+
+    .feedback-copy {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+      padding: 64px 56px;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .feedback-panel {
+      padding: 20px;
+    }
+
+    .feedback-status {
+      padding-inline: 12px;
+    }
+
+    .feedback-status-step {
+      width: 44px;
+      font-size: 0.55rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feedback-cta:hover {
+      transform: none;
+    }
+  }
+</style>
+
+<script>
+  document.querySelector('.feedback-cta')?.addEventListener('click', () => {
+    if (typeof posthog !== 'undefined' && !posthog.has_opted_out_capturing()) {
+      posthog.capture('cta_clicked', {
+        button_text: 'Open the feedback portal',
+        location: 'feedback_promo',
+      });
+    }
+  });
+</script>

--- a/landing-page/src/lib/feedback/exitIntent.test.ts
+++ b/landing-page/src/lib/feedback/exitIntent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { isTopEdgeExitIntent, shouldShowFeedbackExitIntent } from './exitIntent';
+
+const exitEvent = {
+  clientY: 0,
+  relatedTarget: null,
+};
+
+describe('isTopEdgeExitIntent', () => {
+  it('detects the pointer leaving through the top edge', () => {
+    expect(isTopEdgeExitIntent(exitEvent)).toBe(true);
+  });
+
+  it('ignores pointer movement within the document', () => {
+    expect(isTopEdgeExitIntent({ clientY: 0, relatedTarget: document.body })).toBe(false);
+  });
+
+  it('ignores exits away from the top edge', () => {
+    expect(isTopEdgeExitIntent({ clientY: 80, relatedTarget: null })).toBe(false);
+  });
+});
+
+describe('shouldShowFeedbackExitIntent', () => {
+  const readyContext = {
+    armed: true,
+    finePointer: true,
+    alreadyShown: false,
+    dialogOpen: false,
+  };
+
+  it('shows for an armed first-time desktop exit', () => {
+    expect(shouldShowFeedbackExitIntent(exitEvent, readyContext)).toBe(true);
+  });
+
+  it.each([
+    ['before arming', { armed: false }],
+    ['on a coarse pointer', { finePointer: false }],
+    ['after it was already shown', { alreadyShown: true }],
+    ['while the dialog is open', { dialogOpen: true }],
+  ])('does not show %s', (_label, contextOverride) => {
+    expect(
+      shouldShowFeedbackExitIntent(exitEvent, {
+        ...readyContext,
+        ...contextOverride,
+      }),
+    ).toBe(false);
+  });
+});

--- a/landing-page/src/lib/feedback/exitIntent.test.ts
+++ b/landing-page/src/lib/feedback/exitIntent.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isTopEdgeExitIntent, shouldShowFeedbackExitIntent } from './exitIntent';
+import componentSource from '../../components/FeedbackExitIntent.astro?raw';
+import {
+  FEEDBACK_EXIT_INTENT_DELAY_MS,
+  isTopEdgeExitIntent,
+  shouldShowFeedbackExitIntent,
+} from './exitIntent';
 
 const exitEvent = {
   clientY: 0,
@@ -44,5 +49,32 @@ describe('shouldShowFeedbackExitIntent', () => {
         ...contextOverride,
       }),
     ).toBe(false);
+  });
+});
+
+describe('feedback exit-intent presentation', () => {
+  it('uses a short guard window before arming', () => {
+    expect(FEEDBACK_EXIT_INTENT_DELAY_MS).toBeGreaterThanOrEqual(1500);
+    expect(FEEDBACK_EXIT_INTENT_DELAY_MS).toBeLessThanOrEqual(2000);
+  });
+
+  it('centers the fixed dialog within responsive viewport gutters', () => {
+    expect(componentSource).toContain('position: fixed;');
+    expect(componentSource).toContain('inset: 50% auto auto 50%;');
+    expect(componentSource).toContain('width: min(600px, calc(100vw - 32px));');
+    expect(componentSource).toContain('max-height: calc(100dvh - 32px);');
+    expect(componentSource).toContain('transform: translate(-50%, -50%);');
+    expect(componentSource).toContain('z-index: 300;');
+    expect(componentSource).toContain('z-index: 299;');
+  });
+
+  it('uses native close semantics and a single-border close control', () => {
+    expect(componentSource).toContain('<form method="dialog">');
+    expect(componentSource).toContain('aria-label="Close feedback invitation"');
+    expect(componentSource).toContain('<IconX size={20}');
+    expect(componentSource).toContain('width: 32px;');
+    expect(componentSource).toContain('height: 32px;');
+    expect(componentSource).toContain('border: 1px solid var(--border-strong);');
+    expect(componentSource).toContain('.feedback-exit-close:focus-visible');
   });
 });

--- a/landing-page/src/lib/feedback/exitIntent.ts
+++ b/landing-page/src/lib/feedback/exitIntent.ts
@@ -1,5 +1,5 @@
 export const FEEDBACK_EXIT_INTENT_SESSION_KEY = 'excalimate-feedback-exit-intent-shown';
-export const FEEDBACK_EXIT_INTENT_DELAY_MS = 3000;
+export const FEEDBACK_EXIT_INTENT_DELAY_MS = 1750;
 
 const EXIT_INTENT_TOP_EDGE_PX = 12;
 

--- a/landing-page/src/lib/feedback/exitIntent.ts
+++ b/landing-page/src/lib/feedback/exitIntent.ts
@@ -1,0 +1,30 @@
+export const FEEDBACK_EXIT_INTENT_SESSION_KEY = 'excalimate-feedback-exit-intent-shown';
+export const FEEDBACK_EXIT_INTENT_DELAY_MS = 3000;
+
+const EXIT_INTENT_TOP_EDGE_PX = 12;
+
+type ExitIntentPointerEvent = Pick<MouseEvent, 'clientY' | 'relatedTarget'>;
+
+interface ExitIntentContext {
+  armed: boolean;
+  finePointer: boolean;
+  alreadyShown: boolean;
+  dialogOpen: boolean;
+}
+
+export function isTopEdgeExitIntent(event: ExitIntentPointerEvent): boolean {
+  return event.relatedTarget === null && event.clientY <= EXIT_INTENT_TOP_EDGE_PX;
+}
+
+export function shouldShowFeedbackExitIntent(
+  event: ExitIntentPointerEvent,
+  context: ExitIntentContext,
+): boolean {
+  return (
+    context.armed &&
+    context.finePointer &&
+    !context.alreadyShown &&
+    !context.dialogOpen &&
+    isTopEdgeExitIntent(event)
+  );
+}

--- a/landing-page/src/pages/index.astro
+++ b/landing-page/src/pages/index.astro
@@ -9,6 +9,7 @@ import ExportShowcase from '../components/ExportShowcase.astro';
 import HowItWorks from '../components/HowItWorks.astro';
 import HomeFAQ from '../components/HomeFAQ.astro';
 import OpenSource from '../components/OpenSource.astro';
+import FeedbackPromo from '../components/FeedbackPromo.astro';
 import FinalCTA from '../components/FinalCTA.astro';
 import Footer from '../components/Footer.astro';
 
@@ -60,6 +61,7 @@ const faqPageSchema = {
     <HowItWorks />
     <HomeFAQ items={faqItems} />
     <OpenSource />
+    <FeedbackPromo />
     <FinalCTA />
   </main>
   <Footer />

--- a/landing-page/src/pages/index.astro
+++ b/landing-page/src/pages/index.astro
@@ -10,6 +10,7 @@ import HowItWorks from '../components/HowItWorks.astro';
 import HomeFAQ from '../components/HomeFAQ.astro';
 import OpenSource from '../components/OpenSource.astro';
 import FeedbackPromo from '../components/FeedbackPromo.astro';
+import FeedbackExitIntent from '../components/FeedbackExitIntent.astro';
 import FinalCTA from '../components/FinalCTA.astro';
 import Footer from '../components/Footer.astro';
 
@@ -64,6 +65,7 @@ const faqPageSchema = {
     <FeedbackPromo />
     <FinalCTA />
   </main>
+  <FeedbackExitIntent />
   <Footer />
   <script type="application/ld+json" set:html={JSON.stringify(faqPageSchema)} />
 </BaseLayout>

--- a/landing-page/wrangler.toml
+++ b/landing-page/wrangler.toml
@@ -3,11 +3,25 @@
 name = "excalimate-landing"
 compatibility_date = "2026-03-22"
 compatibility_flags = ["nodejs_compat"]
+keep_vars = true
+
+# Dashboard-managed runtime variables (do not commit values):
+# - GITHUB_APP_ID
+# - GITHUB_APP_INSTALLATION_ID
+# - TURNSTILE_SITE_KEY
+#
+# Dashboard-managed Wrangler secrets (Secret type; never commit values):
+# - GITHUB_APP_PRIVATE_KEY
+# - FEEDBACK_COOKIE_SECRET
+# - TURNSTILE_SECRET_KEY
+#
+# keep_vars preserves these dashboard-managed bindings when deploying this config.
 
 [assets]
 directory = "./dist"
 binding = "ASSETS"
 
+# Non-secret runtime values that are safe to commit.
 [vars]
 GITHUB_REPOSITORY_OWNER = "excalimate"
 GITHUB_REPOSITORY_NAME = "excalimate"


### PR DESCRIPTION
## Summary
- add a polished, responsive landing-page section inviting visitors to submit ideas, vote, discuss requests, and track progress in the public feedback portal
- use the requested 2x2 white feature-card composition on a primary-yellow panel, plus a separate white progress card with neutral connectors and distinct status-dot colors
- add an accessible desktop exit-intent dialog that arms after a short 1.75-second guard, stays centered within responsive viewport gutters, supports native dismissal/focus behavior, and appears only once per session
- preserve dashboard-managed Worker variables with `keep_vars`, document every required runtime variable and secret, and clarify build-time versus runtime environment setup

## Validation
- `npm run check`
- `npm test` (40 tests)
- `npm run build`