### PR TITLE
Add privacy-safe telemetry controls and disclosures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ VITE_MCP_SERVER_URL=http://localhost:3001
 # Share service URL (optional — defaults to https://share.excalimate.com)
 # VITE_SHARE_API_URL=http://localhost:8787
 
-# PostHog Analytics (optional — leave empty to disable analytics)
+# Optional PostHog analytics. The client loads only after consent.
+# Production must use PostHog Cloud EU, disable IP capture, autocapture,
+# session replay, surveys and feature flags, and cap retention at 12 months.
 VITE_PUBLIC_POSTHOG_KEY=
 VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ npm run lint         # ESLint
 
 The privacy notice depends on production configuration as well as source code:
 
+- Configure the landing-page Cloudflare Workers build with root directory
+  `landing-page`, build command `npm run build`, and deploy command
+  `npx wrangler deploy --config wrangler.toml`. The Astro static build does not
+  produce `dist/server/wrangler.json`.
 - Use only Cloudflare edge/zone aggregate traffic analytics. Do not enable the
   Cloudflare Web Analytics browser beacon or export request logs for analytics.
 - Do not describe or use Cloudflare's IP-derived unique-visitor metric as

--- a/README.md
+++ b/README.md
@@ -203,6 +203,26 @@ npm run test         # Run tests
 npm run lint         # ESLint
 ```
 
+### Privacy-sensitive deployment settings
+
+The privacy notice depends on production configuration as well as source code:
+
+- Use only Cloudflare edge/zone aggregate traffic analytics. Do not enable the
+  Cloudflare Web Analytics browser beacon or export request logs for analytics.
+- Do not describe or use Cloudflare's IP-derived unique-visitor metric as
+  anonymous. Delete raw/exported Cloudflare reports within 30 days; aggregate
+  trend reports may be retained without a fixed limit.
+- Keep PostHog on Cloud EU with IP capture, autocapture, session replay, surveys,
+  product tours, web experiments, and feature flags disabled. Set event retention
+  to no more than 12 months and review the DPA and subprocessors before release.
+- Retain the legitimate-interest and ePrivacy assessments for Cloudflare,
+  GitHub's star-count request, and the pinned unpkg dotLottie runtime. Review the
+  DPIA screening, Article 30 record, and any transfer assessment when a data flow
+  changes.
+- Obtain legal approval for the deployed notice and account settings. If the
+  GitHub or unpkg request cannot rely on the documented ePrivacy position in a
+  target jurisdiction, self-host/proxy it or gate it before release.
+
 MCP server:
 
 ```bash

--- a/landing-page/.env.example
+++ b/landing-page/.env.example
@@ -1,3 +1,4 @@
-# PostHog Analytics (optional — leave PUBLIC_POSTHOG_KEY empty to disable analytics)
+# Optional PostHog analytics. The client loads only after consent.
+# Production must disable IP capture and cap retention at 12 months.
 PUBLIC_POSTHOG_KEY=
 PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "deploy": "astro build && wrangler versions upload"
+    "deploy": "astro build && wrangler deploy --config wrangler.toml"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",

--- a/landing-page/src/components/CookieConsent.astro
+++ b/landing-page/src/components/CookieConsent.astro
@@ -1,67 +1,126 @@
 ---
 /**
- * CookieConsent.astro — Fixed-bottom consent bar + modal preferences dialog.
- * Uses localStorage (not cookies) since this is a static site.
- * Three categories: Necessary (always on), Preferences (toggleable), Analytics (toggleable).
- * PostHog JS is only loaded after the user grants analytics consent.
+ * Fixed-bottom privacy bar and settings dialog.
+ * Cloudflare service processing is always disclosed; PostHog remains opt-in.
  */
+import {
+  ANALYTICS_EVENT_DEFINITIONS,
+  BROWSER_STORAGE_ITEMS,
+  CONSENT_SCHEMA_VERSION,
+  CONSENT_STORAGE_KEY,
+  DATA_PRACTICES,
+  EXCLUDED_ANALYTICS_DATA,
+} from '../../../src/services/privacy/dataInventory';
 ---
 
 <!-- Compact banner (bottom bar) -->
-<div class="consent-bar" id="consent-bar" role="dialog" aria-label="Cookie consent">
+<div
+  class="consent-bar"
+  id="consent-bar"
+  role="dialog"
+  aria-label="Privacy choices"
+  data-consent-key={CONSENT_STORAGE_KEY}
+  data-consent-version={CONSENT_SCHEMA_VERSION}
+>
   <div class="consent-inner container">
     <p class="consent-text">
-      We use <strong>anonymous analytics</strong> to improve our site. <a href="/privacy"
-        >Privacy Policy</a
-      >
+      Cloudflare processes requests for delivery, security, and aggregate traffic statistics.
+      Optional PostHog analytics starts only if you accept. <a href="/privacy#data-inventory"
+        >Full data list</a
+      >.
     </p>
     <div class="consent-actions">
       <button id="consent-manage" class="btn btn-secondary btn-sm">Manage</button>
-      <button id="consent-reject" class="btn btn-secondary">Decline</button>
-      <button id="consent-accept" class="btn btn-primary">Accept All</button>
+      <button id="consent-reject" class="btn btn-secondary">Use required only</button>
+      <button id="consent-accept" class="btn btn-primary">Accept optional</button>
     </div>
   </div>
 </div>
 
-<!-- Preferences modal -->
+<!-- Privacy settings modal -->
 <div class="consent-overlay" id="consent-overlay">
-  <div class="consent-modal" role="dialog" aria-label="Cookie preferences" aria-modal="true">
+  <div class="consent-modal" role="dialog" aria-label="Privacy and data settings" aria-modal="true">
     <button class="modal-close" id="modal-close" aria-label="Close">&times;</button>
-    <h3 class="modal-title">Cookie Preferences</h3>
-    <p class="modal-subtitle">Manage your cookie preferences. You can update these at any time.</p>
+    <h3 class="modal-title">Privacy and data settings</h3>
+    <p class="modal-subtitle">
+      Required service processing is separate from optional analytics. You can change optional
+      analytics at any time.
+    </p>
 
     <div class="prefs-list">
       <div class="pref-row">
         <div class="pref-info">
-          <span class="pref-name">Necessary</span>
-          <span class="pref-desc">Essential for the site to function. Cannot be disabled.</span>
+          <span class="pref-name">Required service processing</span>
+          <span class="pref-desc"
+            >Cloudflare handles ordinary request metadata for delivery, security, reliability, and
+            aggregate traffic reports. No client analytics beacon is added for this.</span
+          >
         </div>
         <input type="checkbox" checked disabled class="pref-check" />
       </div>
       <div class="pref-row">
         <div class="pref-info">
-          <span class="pref-name">Preferences</span>
+          <span class="pref-name">Optional product analytics</span>
           <span class="pref-desc"
-            >Remembers your settings, theme, and other choices across sessions.</span
-          >
-        </div>
-        <input type="checkbox" id="preferences-check" class="pref-check" />
-      </div>
-      <div class="pref-row">
-        <div class="pref-info">
-          <span class="pref-name">Analytics</span>
-          <span class="pref-desc"
-            >Anonymous usage statistics via PostHog. No personal data collected.</span
+            >Declared, pseudonymous events through PostHog Cloud EU. No full URLs, referrers,
+            autocapture, session replay, or advertising profiles.</span
           >
         </div>
         <input type="checkbox" id="analytics-check" class="pref-check" />
       </div>
     </div>
 
+    <details class="data-details">
+      <summary>See the exact data list</summary>
+      <div class="data-details-body">
+        <h4>Processing and recipients</h4>
+        {
+          DATA_PRACTICES.map((practice) => (
+            <article class="data-practice">
+              <strong>{practice.title}</strong>
+              <span>{practice.condition}</span>
+              <p><b>Data:</b> {practice.data}</p>
+              <p><b>Why:</b> {practice.purpose}</p>
+              <p><b>Basis:</b> {practice.legalBasis}</p>
+              <p><b>Recipient:</b> {practice.recipient}</p>
+              <p><b>Retention:</b> {practice.retention}</p>
+            </article>
+          ))
+        }
+
+        <h4>Optional analytics events</h4>
+        <ul>
+          {
+            Object.entries(ANALYTICS_EVENT_DEFINITIONS).map(([name, definition]) => (
+              <li>
+                <code>{name}</code>: {definition.purpose}
+                {Object.keys(definition.properties).length > 0
+                  ? ` Properties: ${Object.keys(definition.properties).join(', ')}.`
+                  : ' No custom properties.'}
+              </li>
+            ))
+          }
+        </ul>
+
+        <h4>Browser storage</h4>
+        <ul>
+          {
+            BROWSER_STORAGE_ITEMS.map((item) => (
+              <li><code>{item.key}</code>: {item.contents} {item.purpose} ({item.category})</li>
+            ))
+          }
+        </ul>
+
+        <h4>Never included in analytics</h4>
+        <ul>{EXCLUDED_ANALYTICS_DATA.map((item) => <li>{item}</li>)}</ul>
+        <a href="/privacy#data-inventory">Read the complete privacy notice</a>
+      </div>
+    </details>
+
     <div class="modal-actions">
-      <button id="modal-reject" class="btn btn-secondary">Reject All</button>
-      <button id="modal-save" class="btn btn-secondary">Save Preferences</button>
-      <button id="modal-accept" class="btn btn-primary">Accept All</button>
+      <button id="modal-reject" class="btn btn-secondary">Use required only</button>
+      <button id="modal-save" class="btn btn-secondary">Save choice</button>
+      <button id="modal-accept" class="btn btn-primary">Accept optional</button>
     </div>
   </div>
 </div>
@@ -173,6 +232,8 @@
     width: calc(100% - 40px);
     padding: 28px;
     position: relative;
+    max-height: min(760px, calc(100vh - 40px));
+    overflow-y: auto;
   }
 
   .modal-close {
@@ -275,15 +336,85 @@
     font-size: 13px;
     padding: 10px 18px;
   }
+
+  .data-details {
+    margin-top: 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    color: var(--tx2);
+    font-family: var(--f-body);
+    font-size: 0.82rem;
+  }
+
+  .data-details summary {
+    cursor: pointer;
+    color: var(--tx);
+    font-weight: 600;
+  }
+
+  .data-details-body {
+    margin-top: 14px;
+  }
+
+  .data-details h4 {
+    color: var(--tx);
+    font-size: 0.88rem;
+    margin: 18px 0 8px;
+  }
+
+  .data-details ul {
+    margin: 8px 0;
+    padding-left: 20px;
+  }
+
+  .data-practice {
+    border-top: 1px solid var(--border);
+    padding: 10px 0;
+  }
+
+  .data-practice > span {
+    display: block;
+    color: var(--tx3);
+    margin-top: 2px;
+  }
+
+  .data-practice p {
+    margin: 4px 0;
+  }
 </style>
 
 <script>
-  const CONSENT_KEY = 'excalimate-consent';
   const bar = document.getElementById('consent-bar')!;
+  const CONSENT_KEY = bar.dataset.consentKey!;
+  const CONSENT_VERSION = bar.dataset.consentVersion!;
   const overlay = document.getElementById('consent-overlay')!;
   const analyticsCheck = document.getElementById('analytics-check') as HTMLInputElement;
-  const preferencesCheck = document.getElementById('preferences-check') as HTMLInputElement;
-  const stored = localStorage.getItem(CONSENT_KEY);
+  const closeButton = document.getElementById('modal-close') as HTMLButtonElement;
+  let previouslyFocused: HTMLElement | null = null;
+
+  localStorage.removeItem('excalimate-consent');
+
+  interface LandingAnalytics {
+    enable: () => void;
+    disable: () => void;
+  }
+
+  function analyticsClient(): LandingAnalytics | undefined {
+    return (window as Window & { excalimateAnalytics?: LandingAnalytics }).excalimateAnalytics;
+  }
+
+  function readChoice(): boolean | null {
+    try {
+      const raw = localStorage.getItem(CONSENT_KEY);
+      if (!raw) return null;
+      const value = JSON.parse(raw);
+      if (value.version !== CONSENT_VERSION || typeof value.state?.analytics !== 'boolean') return null;
+      return value.state.analytics;
+    } catch {
+      return null;
+    }
+  }
 
   function showBar() {
     bar.style.display = 'block';
@@ -292,68 +423,51 @@
     bar.style.display = 'none';
   }
   function openModal() {
-    // Sync checkboxes with stored consent state
-    try {
-      const raw = localStorage.getItem(CONSENT_KEY);
-      if (raw) {
-        const current = JSON.parse(raw);
-        analyticsCheck.checked = !!current.analytics;
-        preferencesCheck.checked = !!current.preferences;
-      } else {
-        analyticsCheck.checked = false;
-        preferencesCheck.checked = false;
-      }
-    } catch {
-      analyticsCheck.checked = false;
-      preferencesCheck.checked = false;
-    }
+    analyticsCheck.checked = readChoice() === true;
+    previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     overlay.classList.add('open');
+    closeButton.focus();
   }
   function closeModal() {
     overlay.classList.remove('open');
+    previouslyFocused?.focus();
+    previouslyFocused = null;
   }
 
-  function saveAndClose(analytics: boolean, preferences: boolean) {
-    localStorage.setItem(CONSENT_KEY, JSON.stringify({ analytics, preferences, ts: Date.now() }));
-    if (typeof (window as any).posthog !== 'undefined') {
-      (window as any).posthog.capture('consent_decision', { analytics: analytics, preferences: preferences, action: 'save' });
-    }
+  function saveAndClose(analytics: boolean) {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify({
+      version: CONSENT_VERSION,
+      state: { analytics, preferences: false },
+      timestamp: new Date().toISOString(),
+    }));
     hideBar();
     closeModal();
-    // PostHog is already loaded (opted-out) via PostHog.astro — just toggle capturing
-    if (typeof (window as any).posthog !== 'undefined') {
-      if (analytics) {
-        (window as any).posthog.opt_in_capturing();
-      } else {
-        (window as any).posthog.opt_out_capturing();
-      }
-    }
+    if (analytics) analyticsClient()?.enable();
+    else analyticsClient()?.disable();
   }
 
-  if (!stored) showBar();
+  if (readChoice() === null) showBar();
 
   // Compact banner buttons
   document.getElementById('consent-manage')!.addEventListener('click', openModal);
   document
     .getElementById('consent-accept')!
-    .addEventListener('click', () => saveAndClose(true, true));
+    .addEventListener('click', () => saveAndClose(true));
   document
     .getElementById('consent-reject')!
-    .addEventListener('click', () => saveAndClose(false, false));
+    .addEventListener('click', () => saveAndClose(false));
 
   // Modal buttons
   document.getElementById('modal-close')!.addEventListener('click', closeModal);
   document
     .getElementById('modal-accept')!
-    .addEventListener('click', () => saveAndClose(true, true));
+    .addEventListener('click', () => saveAndClose(true));
   document
     .getElementById('modal-reject')!
-    .addEventListener('click', () => saveAndClose(false, false));
+    .addEventListener('click', () => saveAndClose(false));
   document
     .getElementById('modal-save')!
-    .addEventListener('click', () =>
-      saveAndClose(analyticsCheck.checked, preferencesCheck.checked),
-    );
+    .addEventListener('click', () => saveAndClose(analyticsCheck.checked));
 
   // Close overlay on backdrop click
   overlay.addEventListener('click', (e) => {
@@ -362,10 +476,31 @@
 
   // Close on Escape
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && overlay.classList.contains('open')) closeModal();
+    if (!overlay.classList.contains('open')) return;
+    if (e.key === 'Escape') {
+      closeModal();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+
+    const focusable = Array.from(
+      overlay.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), summary, a[href]',
+      ),
+    );
+    const first = focusable[0];
+    const last = focusable.at(-1);
+    if (!first || !last) return;
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
   });
 
-  // Footer "Cookie Settings" link — open modal directly, no banner
+  // Footer privacy link: open the settings directly without showing the banner.
   document.querySelectorAll('a[href="#manage-consent"]').forEach((link) => {
     link.addEventListener('click', (e) => {
       e.preventDefault();
@@ -373,14 +508,4 @@
     });
   });
 
-  // Utility for other scripts to check preference consent
-  (window as any).excalimateCanStorePreferences = function () {
-    try {
-      const raw = localStorage.getItem(CONSENT_KEY);
-      if (!raw) return false;
-      return JSON.parse(raw).preferences === true;
-    } catch {
-      return false;
-    }
-  };
 </script>

--- a/landing-page/src/components/Footer.astro
+++ b/landing-page/src/components/Footer.astro
@@ -45,7 +45,7 @@ const columns: FooterColumn[] = [
     heading: 'Legal',
     links: [
       { label: 'Privacy', href: '/privacy' },
-      { label: 'Cookie Settings', href: '#manage-consent' },
+      { label: 'Privacy choices', href: '#manage-consent' },
       { label: 'License (MIT)', href: 'https://github.com/excalimate/excalimate/blob/main/LICENSE' },
       { label: 'Security', href: 'https://github.com/excalimate/excalimate/blob/main/SECURITY.md' },
     ],
@@ -246,12 +246,25 @@ const columns: FooterColumn[] = [
 </style>
 
 <script>
+  function destinationCategory(href: string): string {
+    try {
+      const url = new URL(href);
+      if (url.hostname === 'github.com') return 'github';
+      if (url.hostname === 'app.excalimate.com') return 'app';
+      if (url.hostname === 'x.com') return 'x';
+      if (url.hostname === 'bsky.app') return 'bluesky';
+      return 'external_other';
+    } catch {
+      return 'invalid';
+    }
+  }
+
   document.querySelectorAll('.footer-link[target="_blank"]').forEach(link => {
     link.addEventListener('click', () => {
-      const text = link.textContent?.trim() || '';
-      if (typeof posthog !== 'undefined' && !posthog.has_opted_out_capturing()) {
-        posthog.capture('external_link_clicked', { link_text: text, href: link.getAttribute('href') });
-      }
+      const href = link.getAttribute('href') ?? '';
+      window.excalimateAnalytics?.capture('landing_external_link_clicked', {
+        destination: destinationCategory(href),
+      });
     });
   });
 </script>

--- a/landing-page/src/components/PostHog.astro
+++ b/landing-page/src/components/PostHog.astro
@@ -1,80 +1,186 @@
 ---
-// src/components/PostHog.astro
-// PostHog analytics — loaded on every page per Astro best practice (is:inline).
-// Starts opted-out by default. Only captures if user has granted analytics consent.
-// Configure via env vars: PUBLIC_POSTHOG_KEY and PUBLIC_POSTHOG_HOST
+import {
+  ANALYTICS_EVENT_DEFINITIONS,
+  CONSENT_SCHEMA_VERSION,
+  CONSENT_STORAGE_KEY,
+  POSTHOG_TECHNICAL_PROPERTIES,
+} from '../../../src/services/privacy/dataInventory';
+
 const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY ?? '';
 const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST ?? 'https://eu.i.posthog.com';
+const landingEventProperties = Object.fromEntries(
+  (['landing_page_viewed', 'landing_external_link_clicked'] as const).map((event) => [
+    event,
+    Object.keys(ANALYTICS_EVENT_DEFINITIONS[event].properties),
+  ]),
+);
 ---
 
 {posthogKey && (
-<script is:inline define:vars={{ posthogKey, posthogHost }}>
-  var POSTHOG_KEY = posthogKey;
-  var POSTHOG_HOST = posthogHost;
-  var CONSENT_KEY = 'excalimate-consent';
+  <script
+    is:inline
+    define:vars={{
+      posthogKey,
+      posthogHost,
+      consentKey: CONSENT_STORAGE_KEY,
+      consentVersion: CONSENT_SCHEMA_VERSION,
+      landingEventProperties,
+      technicalProperties: POSTHOG_TECHNICAL_PROPERTIES,
+    }}
+  >
+    (function () {
+      var initialized = false;
+      var enabled = false;
+      var pageCaptured = false;
 
-  !(function (t, e) {
-    var o, n, p, r;
-    e.__SV ||
-      ((window.posthog = e),
-      (e._i = []),
-      (e.init = function (i, s, a) {
-        function g(t, e) {
-          var o = e.split('.');
-          (2 == o.length && ((t = t[o[0]]), (e = o[1])),
-            (t[e] = function () {
-              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-            }));
+      function hasConsent() {
+        try {
+          var raw = localStorage.getItem(consentKey);
+          if (!raw) return false;
+          var value = JSON.parse(raw);
+          return value.version === consentVersion && value.state && value.state.analytics === true;
+        } catch (_) {
+          return false;
         }
-        (((p = t.createElement('script')).type = 'text/javascript'),
-          (p.async = !0),
-          (p.src =
-            s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-          (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r));
-        var u = e;
-        for (
-          void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-            u.people = u.people || [],
-            u.toString = function (t) {
-              var e = 'posthog';
-              return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e);
-            },
-            u.people.toString = function () {
-              return u.toString(1) + '.people (stub)';
-            },
-            o =
-              'init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep'.split(
-                ' ',
-              ),
-            n = 0;
-          n < o.length;
-          n++
-        )
-          g(u, o[n]);
-        e._i.push([i, s, a]);
-      }),
-      (e.__SV = 1));
-  })(document, window.posthog || []);
+      }
 
-  // Check if user has granted analytics consent
-  var hasConsent = false;
-  try {
-    var raw = localStorage.getItem(CONSENT_KEY);
-    if (raw) hasConsent = JSON.parse(raw).analytics === true;
-  } catch (e) {}
+      function clearPersistence() {
+        [localStorage, sessionStorage].forEach(function (storage) {
+          for (var index = storage.length - 1; index >= 0; index -= 1) {
+            var key = storage.key(index);
+            if (key && key.indexOf('ph_') === 0) storage.removeItem(key);
+          }
+        });
+        document.cookie.split(';').forEach(function (entry) {
+          var name = entry.split('=')[0].trim();
+          if (name.indexOf('ph_') === 0) {
+            document.cookie = name + '=; Max-Age=0; path=/; SameSite=Lax';
+          }
+        });
+      }
 
-  // Initialize PostHog — opted out by default, opted in only if consented
-  posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
-    person_profiles: 'identified_only',
-    capture_pageview: hasConsent,
-    capture_pageleave: hasConsent,
-    autocapture: false,
-    opt_out_capturing_by_default: !hasConsent,
-  });
+      function pageCategory(path) {
+        if (path === '/') return 'home';
+        if (path === '/privacy') return 'privacy';
+        if (path.indexOf('/guides/') === 0) return 'guide';
+        if (path === '/guides') return 'guides_index';
+        if (path.indexOf('/compare/') === 0) return 'comparison';
+        if (path === '/compare') return 'comparisons_index';
+        return 'other_public_page';
+      }
 
-  if (!hasConsent) {
-    posthog.opt_out_capturing();
-  }
-</script>
+      function sanitize(capture) {
+        if (!capture || !landingEventProperties[capture.event]) return null;
+        var allowed = technicalProperties.concat(landingEventProperties[capture.event]);
+        var properties = {};
+        Object.keys(capture.properties || {}).forEach(function (key) {
+          if (allowed.indexOf(key) !== -1) properties[key] = capture.properties[key];
+        });
+        capture.properties = properties;
+        delete capture.$set;
+        delete capture.$set_once;
+        delete capture.$unset;
+        return capture;
+      }
+
+      function bootstrap() {
+        if (initialized || !enabled) return;
+        initialized = true;
+
+        !(function (t, e) {
+          var o, n, p, r;
+          e.__SV ||
+            ((window.posthog = e),
+            (e._i = []),
+            (e.init = function (i, s, a) {
+              function g(target, method) {
+                var parts = method.split('.');
+                if (parts.length === 2) {
+                  target = target[parts[0]];
+                  method = parts[1];
+                }
+                target[method] = function () {
+                  target.push([method].concat(Array.prototype.slice.call(arguments, 0)));
+                };
+              }
+              p = t.createElement('script');
+              p.type = 'text/javascript';
+              p.async = true;
+              p.src = s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js';
+              r = t.getElementsByTagName('script')[0];
+              r.parentNode.insertBefore(p, r);
+              var u = e;
+              if (a !== undefined) u = e[a] = [];
+              else a = 'posthog';
+              u.people = u.people || [];
+              o = 'init capture opt_out_capturing opt_in_capturing has_opted_out_capturing reset'.split(' ');
+              for (n = 0; n < o.length; n += 1) g(u, o[n]);
+              e._i.push([i, s, a]);
+            }),
+            (e.__SV = 1));
+        })(document, window.posthog || []);
+
+        window.posthog.init(posthogKey, {
+          api_host: posthogHost,
+          person_profiles: 'never',
+          autocapture: false,
+          rageclick: false,
+          capture_pageview: false,
+          capture_pageleave: false,
+          capture_performance: false,
+          disable_session_recording: true,
+          disable_surveys: true,
+          disable_surveys_automatic_display: true,
+          disable_product_tours: true,
+          disable_web_experiments: true,
+          advanced_disable_flags: true,
+          advanced_disable_feature_flags: true,
+          advanced_disable_feature_flags_on_first_load: true,
+          disableDeviceModel: true,
+          disable_capture_url_hashes: true,
+          save_referrer: false,
+          save_campaign_params: false,
+          persistence: 'memory',
+          disable_persistence: true,
+          respect_dnt: true,
+          before_send: sanitize,
+        });
+      }
+
+      function capture(event, properties) {
+        if (!enabled || !landingEventProperties[event]) return;
+        bootstrap();
+        window.posthog.capture(event, properties || {});
+      }
+
+      function capturePage() {
+        if (pageCaptured) return;
+        pageCaptured = true;
+        capture('landing_page_viewed', { page: pageCategory(window.location.pathname) });
+      }
+
+      window.excalimateAnalytics = {
+        enable: function () {
+          enabled = true;
+          bootstrap();
+          if (window.posthog && window.posthog.has_opted_out_capturing()) {
+            window.posthog.opt_in_capturing();
+          }
+          capturePage();
+        },
+        disable: function () {
+          enabled = false;
+          if (window.posthog) {
+            window.posthog.opt_out_capturing();
+            window.posthog.reset(true);
+          }
+          clearPersistence();
+        },
+        capture: capture,
+      };
+
+      if (hasConsent()) window.excalimateAnalytics.enable();
+      else clearPersistence();
+    })();
+  </script>
 )}

--- a/landing-page/src/layouts/BaseLayout.astro
+++ b/landing-page/src/layouts/BaseLayout.astro
@@ -91,9 +91,12 @@ const ogImage = `${siteUrl}/og-image.png`;
     <!-- Lottie player -->
     <script
       src="https://unpkg.com/@lottiefiles/dotlottie-wc@0.4.2/dist/dotlottie-wc.js"
-      type="module"></script>
+      type="module"
+      integrity="sha384-Z09hxXS8gnck1yI78B6VRUj0ztY/6G3Nc3zPu6sj13EVGNj4M3mFfl8lPVP2cApy"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"></script>
 
-    <!-- Analytics (consent-gated) -->
+    <!-- Optional analytics loader; it contacts PostHog only after consent. -->
     <PostHog />
   </head>
   <body>

--- a/landing-page/src/layouts/PageLayout.astro
+++ b/landing-page/src/layouts/PageLayout.astro
@@ -64,7 +64,7 @@ const breadcrumbs = [
     "itemListElement": breadcrumbs
   })} />
 
-  <!-- Analytics (consent-gated) -->
+  <!-- Optional analytics loader; it contacts PostHog only after consent. -->
   <PostHog />
 </head>
 <body>
@@ -72,10 +72,5 @@ const breadcrumbs = [
   <div class="grain" aria-hidden="true"></div>
   <slot/>
   <CookieConsent />
-  <script>
-    if (typeof posthog !== 'undefined' && !posthog.has_opted_out_capturing()) {
-      posthog.capture('guide_viewed', { path: window.location.pathname });
-    }
-  </script>
 </body>
 </html>

--- a/landing-page/src/pages/privacy.astro
+++ b/landing-page/src/pages/privacy.astro
@@ -2,10 +2,19 @@
 import PageLayout from '../layouts/PageLayout.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import {
+  ANALYTICS_EVENT_DEFINITIONS,
+  BROWSER_STORAGE_ITEMS,
+  DATA_PRACTICES,
+  EXCLUDED_ANALYTICS_DATA,
+  POSTHOG_TECHNICAL_PROPERTIES,
+} from '../../../src/services/privacy/dataInventory';
 
-const title = 'Privacy Policy & Data Practices — Excalimate';
-const description = 'Learn how Excalimate handles analytics, data collection, and your privacy. We use anonymous analytics only with your consent.';
+const title = 'Privacy Notice & Exact Data Practices - Excalimate';
+const description =
+  'The exact data Excalimate and its service providers process, why it is used, how long it is retained, and the controls available to you.';
 const siteUrl = 'https://excalimate.com';
+const lastUpdated = '12 July 2026';
 ---
 
 <PageLayout title={title} description={description} path="/privacy">
@@ -14,99 +23,252 @@ const siteUrl = 'https://excalimate.com';
   <main id="main" class="guide">
     <div class="guide-container">
       <header class="guide-header">
-        <a href="/" class="guide-back">← Back to home</a>
-        <h1 class="guide-title">Privacy Policy</h1>
-        <p class="guide-subtitle">How Excalimate handles your data</p>
+        <a href="/" class="guide-back">Back to home</a>
+        <h1 class="guide-title">Privacy Notice</h1>
+        <p class="guide-subtitle">Exact data practices for excalimate.com and app.excalimate.com</p>
+        <p class="updated">Last updated: {lastUpdated}</p>
       </header>
 
       <div class="guide-body">
         <section class="step">
-          <div class="step-header">
-            <span class="step-num">1</span>
-            <h2 class="step-title">What We Collect</h2>
-          </div>
+          <h2 class="step-title">Controller and scope</h2>
           <p class="step-text">
-            When you consent to analytics, we collect <strong>anonymous page-view data</strong> — which
-            pages are visited, how long visitors stay, and general usage patterns. We do <strong>not</strong>
-            collect any personally identifiable information (PII) such as names, email addresses, IP
-            addresses, or device fingerprints.
+            <strong>excalimate</strong>, the owner of the
+            <a href="https://github.com/excalimate/excalimate" target="_blank" rel="noopener">
+              excalimate/excalimate repository
+            </a>, is the controller for the processing described here. This notice covers the public
+            landing site, the browser application, aggregate service analytics, and the optional
+            encrypted-sharing service.
           </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">2</span>
-            <h2 class="step-title">Analytics Provider</h2>
-          </div>
           <p class="step-text">
-            We use <a href="https://posthog.com" target="_blank" rel="noopener">PostHog</a>, an
-            open-source product analytics platform, to process anonymous usage data. PostHog is
-            configured with <code>autocapture</code> disabled and <code>person_profiles</code> set to
-            <code>identified_only</code> — meaning no individual user profiles are created for
-            anonymous visitors.
-          </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">3</span>
-            <h2 class="step-title">Your Consent</h2>
-          </div>
-          <p class="step-text">
-            Analytics scripts are <strong>never loaded</strong> unless you explicitly click
-            "Accept" on the consent banner. Your choice is stored in your browser's
-            <code>localStorage</code> under the key <code>excalimate-consent</code>. No cookies are
-            set by Excalimate.
-          </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">4</span>
-            <h2 class="step-title">How to Opt Out</h2>
-          </div>
-          <p class="step-text">
-            You can opt out of analytics at any time by clearing your browser's localStorage for this
-            site. Open your browser's developer tools, go to the <strong>Application</strong> (or
-            <strong>Storage</strong>) tab, find <code>localStorage</code> for
-            <code>excalimate.com</code>, and delete the <code>excalimate-consent</code> key. On your
-            next visit, the consent banner will appear again and you can click "Decline".
-          </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">5</span>
-            <h2 class="step-title">Third-Party Sharing</h2>
-          </div>
-          <p class="step-text">
-            We do <strong>not</strong> sell, rent, or share any data with third parties. Anonymous
-            analytics data is used solely to understand site usage and improve Excalimate.
-          </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">6</span>
-            <h2 class="step-title">The Excalimate Application</h2>
-          </div>
-          <p class="step-text">
-            The Excalimate application itself runs entirely in your browser. Your diagrams,
-            animations, and project data never leave your device unless you explicitly use the
-            share feature, which uses end-to-end encryption. This privacy policy applies only to
-            the <a href="https://excalimate.com">excalimate.com</a> marketing site.
-          </p>
-        </section>
-
-        <section class="step">
-          <div class="step-header">
-            <span class="step-num">7</span>
-            <h2 class="step-title">Contact</h2>
-          </div>
-          <p class="step-text">
-            If you have questions about this privacy policy, please
+            Privacy questions and rights requests can be raised through
             <a href="https://github.com/excalimate/excalimate/discussions" target="_blank" rel="noopener">
-            open a discussion on GitHub</a>.
+              GitHub Discussions
+            </a>. Discussions are public, so do not include sensitive or identifying information in
+            the initial post.
+          </p>
+        </section>
+
+        <section class="notice">
+          <h2>Important distinction</h2>
+          <p>
+            Excalimate does not run consentless client-side product analytics. Cloudflare necessarily
+            processes IP addresses and HTTP metadata to deliver and secure the service and provides
+            aggregate edge traffic reports. Optional PostHog product analytics is separate,
+            pseudonymous rather than legally anonymous, and starts only after consent.
+          </p>
+        </section>
+
+        <section class="step" id="data-inventory">
+          <h2 class="step-title">Exact processing inventory</h2>
+          <p class="step-text">
+            The entries below are generated from the same inventory that restricts application
+            analytics. Adding a new PostHog event requires adding it to this public list.
+          </p>
+
+          <div class="inventory-grid">
+            {
+              DATA_PRACTICES.map((practice) => (
+                <article class="inventory-card" id={practice.id}>
+                  <header>
+                    <h3>{practice.title}</h3>
+                    <span>{practice.condition}</span>
+                  </header>
+                  <dl>
+                    <dt>Exact data</dt><dd>{practice.data}</dd>
+                    <dt>Purpose</dt><dd>{practice.purpose}</dd>
+                    <dt>Legal basis</dt><dd>{practice.legalBasis}</dd>
+                    <dt>Recipient</dt><dd>{practice.recipient}</dd>
+                    <dt>Retention</dt><dd>{practice.retention}</dd>
+                  </dl>
+                </article>
+              ))
+            }
+          </div>
+        </section>
+
+        <section class="step" id="analytics-events">
+          <h2 class="step-title">Optional PostHog event catalogue</h2>
+          <p class="step-text">
+            These events are sent only after an affirmative analytics choice. The SDK allowlist
+            discards undeclared events and properties before transmission.
+          </p>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Purpose</th>
+                  <th>Allowed custom properties</th>
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  Object.entries(ANALYTICS_EVENT_DEFINITIONS).map(([name, definition]) => (
+                    <tr>
+                      <td><code>{name}</code><span class="event-label">{definition.label}</span></td>
+                      <td>{definition.purpose}</td>
+                      <td>
+                        {Object.entries(definition.properties).length === 0
+                          ? 'None'
+                          : (
+                            <ul>
+                              {Object.entries(definition.properties).map(([property, detail]) => (
+                                <li><code>{property}</code>: {detail}</li>
+                              ))}
+                            </ul>
+                          )}
+                      </td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+          <p class="step-text">
+            PostHog also attaches only these technical fields:
+            {POSTHOG_TECHNICAL_PROPERTIES.map((property, index) => (
+              <><code>{property}</code>{index < POSTHOG_TECHNICAL_PROPERTIES.length - 1 ? ', ' : '.'}</>
+            ))}
+            The random identifiers exist only in memory for the current page session. PostHog also
+            receives the event timestamp, event UUID, SDK transport request, and therefore transient
+            network metadata. PostHog project settings must keep IP capture disabled.
+          </p>
+        </section>
+
+        <section class="step" id="browser-storage">
+          <h2 class="step-title">Browser storage</h2>
+          <p class="step-text">
+            Local project data remains on your device unless you explicitly use encrypted sharing.
+            Optional preference keys are written only after preference-storage consent.
+          </p>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Exact contents</th><th>Purpose</th><th>Category</th></tr>
+              </thead>
+              <tbody>
+                {
+                  BROWSER_STORAGE_ITEMS.map((item) => (
+                    <tr>
+                      <td><code>{item.key}</code></td>
+                      <td>{item.contents}</td>
+                      <td>{item.purpose}</td>
+                      <td>{item.category}</td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+          <p class="step-text">
+            Rejecting or withdrawing optional choices removes PostHog persistence and optional
+            preference keys. Required local project/autosave data can be removed by clearing this
+            site's storage in your browser.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Data excluded from analytics</h2>
+          <ul class="policy-list">
+            {EXCLUDED_ANALYTICS_DATA.map((item) => <li>{item}</li>)}
+          </ul>
+          <p class="step-text">
+            Excalimate does not sell analytics data, run advertising analytics, create marketing
+            profiles, or use analytics for cross-site tracking.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Consent and objection controls</h2>
+          <p class="step-text">
+            Optional PostHog analytics and optional preference storage are off until selected. You can
+            withdraw either choice at any time through <strong>Privacy and data</strong> in the app
+            toolbar or <strong>Privacy choices</strong> in the landing-page footer. Withdrawal does not
+            affect processing that occurred while consent was valid.
+          </p>
+          <p class="step-text">
+            Service delivery, security, reliability, and aggregate Cloudflare reporting rely on
+            legitimate interests under Article 6(1)(f) GDPR. You may object to legitimate-interest
+            processing. Some network processing is required to provide a site you request; if an
+            aggregate report can no longer be linked to a person, it cannot be located or deleted as
+            an individual record.
+          </p>
+          <p class="step-text">
+            The automatic GitHub star-count and pinned unpkg runtime requests are not categorized as
+            analytics, but GitHub and unpkg/Cloudflare receive ordinary network metadata before an
+            analytics choice. Excalimate relies on legitimate interests for these limited requests
+            and assesses ePrivacy requirements separately.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Processors, recipients, and transfers</h2>
+          <ul class="policy-list">
+            <li>
+              <strong>Cloudflare</strong> provides CDN, security, hosting, Workers, R2, and aggregate
+              traffic analytics. Its global network may process data outside your country under its
+              data-processing terms and transfer safeguards.
+            </li>
+            <li>
+              <strong>PostHog Cloud EU</strong> processes optional analytics as a processor. Excalimate
+              requires an up-to-date DPA, subprocessor review, EU project region, disabled IP capture,
+              and a 12-month retention ceiling.
+            </li>
+            <li>
+              <strong>GitHub</strong> receives the public repository metadata request and ordinary
+              network metadata. It may act as an independent recipient for its service logs.
+            </li>
+            <li>
+              <strong>unpkg/Cloudflare</strong> delivers the pinned dotLottie runtime and receives the
+              ordinary resource-request metadata described above.
+            </li>
+          </ul>
+          <p class="step-text">
+            Current provider terms, subprocessors, adequacy decisions, and contractual safeguards are
+            reviewed as part of release operations. Links:
+            <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Cloudflare privacy</a>,
+            <a href="https://posthog.com/privacy" target="_blank" rel="noopener">PostHog privacy</a>, and
+            <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub privacy</a>.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Encrypted sharing and MCP</h2>
+          <p class="step-text">
+            Sharing is user-triggered. Encryption happens in your browser; only the encrypted blob,
+            random share ID, object metadata, and expiry are sent to Cloudflare. The decryption key is
+            placed after <code>#</code> in the share URL, which browsers do not send in the HTTP
+            request. Shared blobs expire after 30 days.
+          </p>
+          <p class="step-text">
+            MCP live mode connects only when requested. The selected MCP endpoint receives the
+            requests and scene updates needed for that connection. If you configure a third-party MCP
+            endpoint, its operator controls its own processing and retention.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Your EEA and UK rights</h2>
+          <p class="step-text">
+            Depending on the processing, you may request access, correction, deletion, restriction,
+            portability, or objection, and may withdraw consent at any time. You also have the right
+            to complain to your local data-protection authority; UK users can contact the
+            <a href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener">
+              Information Commissioner's Office
+            </a>.
+          </p>
+          <p class="step-text">
+            Excalimate may need enough information to verify and fulfill a request. Do not publish
+            sensitive verification material in a public GitHub Discussion.
+          </p>
+        </section>
+
+        <section class="step">
+          <h2 class="step-title">Changes to this notice</h2>
+          <p class="step-text">
+            Material changes to optional analytics invalidate the stored consent version and present
+            the choices again. The updated date on this page records notice revisions.
           </p>
         </section>
       </div>
@@ -118,11 +280,11 @@ const siteUrl = 'https://excalimate.com';
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "Privacy Policy",
+    "name": "Excalimate Privacy Notice",
     "description": description,
     "url": `${siteUrl}/privacy`,
     "datePublished": "2026-03-22",
-    "dateModified": "2026-03-22",
+    "dateModified": "2026-07-12",
     "inLanguage": "en",
     "isPartOf": {
       "@type": "WebSite",
@@ -138,7 +300,7 @@ const siteUrl = 'https://excalimate.com';
   }
 
   .guide-container {
-    max-width: 860px;
+    max-width: 980px;
     margin-inline: auto;
     padding-inline: 20px;
   }
@@ -162,10 +324,11 @@ const siteUrl = 'https://excalimate.com';
     font-weight: 500;
     color: var(--tx3);
     margin-bottom: 20px;
-    transition: color 0.2s ease;
   }
 
-  .guide-back:hover {
+  .guide-back:hover,
+  .step-text a:hover,
+  .data-details a:hover {
     color: var(--tx);
   }
 
@@ -178,18 +341,28 @@ const siteUrl = 'https://excalimate.com';
     margin: 0 0 12px;
   }
 
-  .guide-subtitle {
+  .guide-subtitle,
+  .updated {
     font-family: var(--f-body);
-    font-size: 1.1rem;
     color: var(--tx2);
     margin: 0;
     line-height: 1.5;
   }
 
+  .guide-subtitle {
+    font-size: 1.1rem;
+  }
+
+  .updated {
+    color: var(--tx3);
+    font-size: 0.88rem;
+    margin-top: 8px;
+  }
+
   .guide-body {
     display: flex;
     flex-direction: column;
-    gap: 40px;
+    gap: 48px;
   }
 
   .step {
@@ -198,39 +371,17 @@ const siteUrl = 'https://excalimate.com';
     gap: 16px;
   }
 
-  .step-header {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-  }
-
-  .step-num {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    background: var(--accent);
-    color: var(--accent-text);
-    font-family: var(--f-display);
-    font-weight: 700;
-    font-size: 14px;
-    border: var(--border-w) solid var(--border-c);
-    box-shadow: 2px 2px 0 var(--border-c);
-    flex-shrink: 0;
-  }
-
   .step-title {
     font-family: var(--f-display);
-    font-size: 1.3rem;
+    font-size: 1.45rem;
     font-weight: 700;
     color: var(--tx);
     margin: 0;
     line-height: 1.2;
   }
 
-  .step-text {
+  .step-text,
+  .policy-list {
     font-family: var(--f-body);
     font-size: 1rem;
     color: var(--tx2);
@@ -238,19 +389,17 @@ const siteUrl = 'https://excalimate.com';
     margin: 0;
   }
 
-  .step-text a {
+  .step-text a,
+  .notice a,
+  .data-details a {
     color: var(--p4);
     text-decoration: underline;
     text-underline-offset: 2px;
     font-weight: 500;
   }
 
-  .step-text a:hover {
-    color: var(--tx);
-  }
-
-  .step-text code {
-    font-size: 0.9em;
+  code {
+    font-size: 0.88em;
     background: var(--bg-alt);
     padding: 2px 6px;
     border-radius: 4px;
@@ -258,8 +407,138 @@ const siteUrl = 'https://excalimate.com';
     color: var(--tx);
   }
 
-  .step-text strong {
+  strong {
     color: var(--tx);
     font-weight: 600;
+  }
+
+  .notice {
+    background: var(--bg-alt);
+    border: var(--border-w) solid var(--border-c);
+    border-radius: var(--radius);
+    box-shadow: 4px 4px 0 var(--border-c);
+    padding: 24px;
+    font-family: var(--f-body);
+    color: var(--tx2);
+    line-height: 1.65;
+  }
+
+  .notice h2 {
+    color: var(--tx);
+    font-family: var(--f-display);
+    font-size: 1.2rem;
+    margin: 0 0 8px;
+  }
+
+  .notice p {
+    margin: 0;
+  }
+
+  .inventory-grid {
+    display: grid;
+    gap: 18px;
+  }
+
+  .inventory-card {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 20px;
+    background: var(--bg);
+  }
+
+  .inventory-card header {
+    margin-bottom: 14px;
+  }
+
+  .inventory-card h3 {
+    color: var(--tx);
+    font-family: var(--f-display);
+    font-size: 1.05rem;
+    margin: 0;
+  }
+
+  .inventory-card header span,
+  .event-label {
+    display: block;
+    color: var(--tx3);
+    font-family: var(--f-body);
+    font-size: 0.8rem;
+    margin-top: 3px;
+  }
+
+  .inventory-card dl {
+    display: grid;
+    grid-template-columns: minmax(100px, 130px) 1fr;
+    gap: 8px 14px;
+    margin: 0;
+    font-family: var(--f-body);
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+
+  .inventory-card dt {
+    color: var(--tx);
+    font-weight: 600;
+  }
+
+  .inventory-card dd {
+    color: var(--tx2);
+    margin: 0;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+    font-family: var(--f-body);
+    font-size: 0.86rem;
+    color: var(--tx2);
+  }
+
+  th,
+  td {
+    padding: 12px 14px;
+    text-align: left;
+    vertical-align: top;
+    border-bottom: 1px solid var(--border);
+  }
+
+  th {
+    color: var(--tx);
+    background: var(--bg-alt);
+    font-weight: 600;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  td ul {
+    margin: 0;
+    padding-left: 18px;
+  }
+
+  .policy-list {
+    padding-left: 24px;
+  }
+
+  .policy-list li + li {
+    margin-top: 8px;
+  }
+
+  @media (max-width: 639px) {
+    .inventory-card dl {
+      grid-template-columns: 1fr;
+    }
+
+    .inventory-card dt {
+      margin-top: 6px;
+    }
   }
 </style>

--- a/landing-page/wrangler.toml
+++ b/landing-page/wrangler.toml
@@ -2,7 +2,9 @@
 
 name = "excalimate-landing"
 compatibility_date = "2026-03-22"
-pages_build_output_dir = "./dist"
 
 [assets]
 directory = "./dist"
+
+[observability]
+enabled = false

--- a/src/components/ConsentBanner.test.tsx
+++ b/src/components/ConsentBanner.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ConsentBanner } from './ConsentBanner';
+import { useConsentStore } from '../stores/consentStore';
+
+describe('ConsentBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConsentStore.setState({
+      decided: false,
+      analytics: false,
+      preferences: false,
+      showBanner: true,
+      showModal: false,
+    });
+  });
+
+  it('distinguishes required processing from optional analytics', () => {
+    render(
+      <MantineProvider>
+        <ConsentBanner />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByText(/Cloudflare processes requests for delivery/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use required only' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accept optional' })).toBeInTheDocument();
+  });
+
+  it('shows the exact inventory from the persistent settings entry point', () => {
+    useConsentStore.setState({ showBanner: false, showModal: true });
+    render(
+      <MantineProvider>
+        <ConsentBanner />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Privacy and data settings' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Optional analytics event catalogue'));
+    expect(screen.getByText('animation_exported')).toBeInTheDocument();
+    expect(
+      screen.getByText(/PostHog also receives a random in-memory session identifier/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -1,46 +1,210 @@
-import { useState } from 'react';
-import { Box, Group, Stack, Text, Button, Switch, Anchor, Divider, Modal } from '@mantine/core';
-import { IconShieldCheck, IconSettings, IconLock, IconAdjustments, IconChartBar } from '@tabler/icons-react';
+import {
+  Accordion,
+  Anchor,
+  Box,
+  Button,
+  Code,
+  Divider,
+  Group,
+  List,
+  Modal,
+  ScrollArea,
+  Stack,
+  Switch,
+  Table,
+  Text,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAdjustments,
+  IconChartBar,
+  IconDatabase,
+  IconExternalLink,
+  IconLock,
+  IconServer,
+  IconSettings,
+  IconShieldCheck,
+} from '@tabler/icons-react';
 import { useConsentStore } from '../stores/consentStore';
-import { CONSENT_KEY, type StoredConsent } from '../services/analytics/consent';
+import { readStoredConsent } from '../services/analytics/consent';
+import {
+  ANALYTICS_EVENT_DEFINITIONS,
+  BROWSER_STORAGE_ITEMS,
+  DATA_PRACTICES,
+  EXCLUDED_ANALYTICS_DATA,
+  PRIVACY_POLICY_URL,
+} from '../services/privacy/dataInventory';
 
-function readStoredConsent(): { analytics: boolean; preferences: boolean } {
-  const fallback = { analytics: false, preferences: false };
-  const raw = localStorage.getItem(CONSENT_KEY);
-  if (!raw) return fallback;
+function getChoices(): { analytics: boolean; preferences: boolean } {
+  return readStoredConsent()?.state ?? { analytics: false, preferences: false };
+}
 
-  try {
-    const parsed: StoredConsent = JSON.parse(raw);
-    return { analytics: !!parsed.state?.analytics, preferences: !!parsed.state?.preferences };
-  } catch {
-    return fallback;
-  }
+function DataInventory() {
+  return (
+    <Accordion variant="separated">
+      <Accordion.Item value="processing">
+        <Accordion.Control icon={<IconServer size={16} />}>
+          Processing and recipients
+        </Accordion.Control>
+        <Accordion.Panel>
+          <Stack gap="md">
+            {DATA_PRACTICES.map((practice) => (
+              <Box key={practice.id}>
+                <Text size="sm" fw={600}>
+                  {practice.title}
+                </Text>
+                <Text size="xs" c="dimmed" mb={4}>
+                  {practice.condition}
+                </Text>
+                <Table withRowBorders={false} verticalSpacing={4}>
+                  <Table.Tbody>
+                    <Table.Tr>
+                      <Table.Th w={90}>Data</Table.Th>
+                      <Table.Td>{practice.data}</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Th>Why</Table.Th>
+                      <Table.Td>{practice.purpose}</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Th>Basis</Table.Th>
+                      <Table.Td>{practice.legalBasis}</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Th>Recipient</Table.Th>
+                      <Table.Td>{practice.recipient}</Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Th>Retention</Table.Th>
+                      <Table.Td>{practice.retention}</Table.Td>
+                    </Table.Tr>
+                  </Table.Tbody>
+                </Table>
+              </Box>
+            ))}
+          </Stack>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item value="events">
+        <Accordion.Control icon={<IconChartBar size={16} />}>
+          Optional analytics event catalogue
+        </Accordion.Control>
+        <Accordion.Panel>
+          <Stack gap="sm">
+            <Text size="xs" c="dimmed">
+              These events are sent only after analytics consent. PostHog also receives a random
+              in-memory session identifier, event timestamp, SDK name/version, and transient request
+              network metadata.
+            </Text>
+            {Object.entries(ANALYTICS_EVENT_DEFINITIONS).map(([name, definition]) => (
+              <Box key={name}>
+                <Text size="sm" fw={600}>
+                  {definition.label}
+                </Text>
+                <Text size="xs">
+                  <Code>{name}</Code> - {definition.purpose}
+                </Text>
+                {Object.entries(definition.properties).length > 0 && (
+                  <List size="xs" mt={4}>
+                    {Object.entries(definition.properties).map(([property, description]) => (
+                      <List.Item key={property}>
+                        <Code>{property}</Code>: {description}
+                      </List.Item>
+                    ))}
+                  </List>
+                )}
+              </Box>
+            ))}
+          </Stack>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item value="storage">
+        <Accordion.Control icon={<IconDatabase size={16} />}>Browser storage</Accordion.Control>
+        <Accordion.Panel>
+          <ScrollArea>
+            <Table striped withTableBorder miw={620}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Key</Table.Th>
+                  <Table.Th>Contents and purpose</Table.Th>
+                  <Table.Th>Category</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {BROWSER_STORAGE_ITEMS.map((item) => (
+                  <Table.Tr key={item.key}>
+                    <Table.Td>
+                      <Code>{item.key}</Code>
+                    </Table.Td>
+                    <Table.Td>
+                      {item.contents} {item.purpose}
+                    </Table.Td>
+                    <Table.Td>{item.category}</Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </ScrollArea>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item value="excluded">
+        <Accordion.Control icon={<IconLock size={16} />}>
+          Never included in analytics
+        </Accordion.Control>
+        <Accordion.Panel>
+          <List size="sm">
+            {EXCLUDED_ANALYTICS_DATA.map((item) => (
+              <List.Item key={item}>{item}</List.Item>
+            ))}
+          </List>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  );
 }
 
 export function ConsentBanner() {
-  const { showBanner, showModal, acceptAll, rejectAll, saveConsent, openSettings } = useConsentStore();
-  const [analyticsOn, setAnalyticsOn] = useState(() => readStoredConsent().analytics);
-  const [preferencesOn, setPreferencesOn] = useState(() => readStoredConsent().preferences);
+  const {
+    showBanner,
+    showModal,
+    analytics,
+    preferences,
+    acceptAll,
+    rejectAll,
+    saveConsent,
+    openSettings,
+  } = useConsentStore();
 
   if (!showBanner && !showModal) return null;
 
-  const handleCloseModal = () => useConsentStore.setState({ showModal: false });
-  const handleOpenSettings = () => {
-    const stored = readStoredConsent();
-    setAnalyticsOn(stored.analytics);
-    setPreferencesOn(stored.preferences);
-    openSettings();
+  const handleCloseModal = () => {
+    const choices = getChoices();
+    useConsentStore.setState({
+      showModal: false,
+      analytics: choices.analytics,
+      preferences: choices.preferences,
+    });
   };
-  const handleAcceptAll = () => { acceptAll(); };
-  const handleRejectAll = () => { rejectAll(); };
-  const handleSavePrefs = () => {
-    saveConsent({ analytics: analyticsOn, preferences: preferencesOn });
+  const handleSave = (analytics: boolean, preferences: boolean) => {
+    saveConsent({ analytics, preferences });
+    notifications.show({
+      title: 'Privacy choices saved',
+      message: analytics
+        ? 'Optional product analytics is enabled.'
+        : 'Only required service processing remains active.',
+      color: 'blue',
+    });
   };
 
   return (
     <>
       {showBanner && (
         <Box
+          role="dialog"
+          aria-label="Privacy choices"
           style={{
             position: 'fixed',
             bottom: 0,
@@ -52,74 +216,136 @@ export function ConsentBanner() {
             padding: '12px 24px',
           }}
         >
-          <Group justify="space-between" wrap="wrap" gap="sm" maw={900} mx="auto">
-            <Group gap="xs" style={{ flex: 1, minWidth: 200 }} wrap="nowrap" align="center">
-              <IconShieldCheck size={18} style={{ color: 'var(--color-text-muted)', flexShrink: 0 }} />
+          <Group justify="space-between" wrap="wrap" gap="sm" maw={980} mx="auto">
+            <Group gap="xs" style={{ flex: 1, minWidth: 240 }} wrap="nowrap" align="center">
+              <IconShieldCheck
+                size={18}
+                style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+              />
               <Text size="sm" c="dimmed" style={{ lineHeight: 1.4 }}>
-                We use anonymous analytics to improve Excalimate.{' '}
-                <Anchor href="https://excalimate.com/privacy" target="_blank" size="sm">
-                  Privacy Policy
+                Cloudflare processes requests for delivery, security, and aggregate traffic
+                statistics. Optional PostHog product analytics starts only if you accept.{' '}
+                <Anchor href={PRIVACY_POLICY_URL} target="_blank" size="sm">
+                  Full data list
                 </Anchor>
               </Text>
             </Group>
             <Group gap={8} wrap="nowrap">
-              <Button variant="subtle" size="xs" onClick={handleOpenSettings} leftSection={<IconSettings size={14} />}>
-                Manage
+              <Button
+                variant="subtle"
+                size="xs"
+                onClick={openSettings}
+                leftSection={<IconSettings size={14} />}
+              >
+                Details
               </Button>
-              <Button variant="default" size="xs" onClick={rejectAll}>Decline</Button>
-              <Button size="xs" onClick={acceptAll}>Accept All</Button>
+              <Button variant="default" size="xs" onClick={rejectAll}>
+                Use required only
+              </Button>
+              <Button size="xs" onClick={acceptAll}>
+                Accept optional
+              </Button>
             </Group>
           </Group>
         </Box>
       )}
 
-      <Modal opened={showModal} onClose={handleCloseModal} title="Cookie Preferences" size="lg" centered>
-        <Stack gap="xs">
+      <Modal
+        opened={showModal}
+        onClose={handleCloseModal}
+        title="Privacy and data settings"
+        size="xl"
+        centered
+      >
+        <Stack gap="sm">
           <Text size="sm" c="dimmed">
-            Manage your cookie preferences. You can update these at any time.
+            Optional choices can be changed at any time. Required service processing and aggregate
+            edge statistics are not controlled by the optional analytics switch.
           </Text>
 
-          <Divider my="xs" />
+          <Divider />
 
-          <Group justify="space-between" wrap="nowrap" py={8}>
-            <div>
+          <Group justify="space-between" wrap="nowrap" py={6}>
+            <Box>
               <Group gap={8} wrap="nowrap">
-                <IconLock size={16} style={{ color: 'var(--color-text-muted)' }} />
-                <Text size="sm" fw={500}>Necessary</Text>
+                <IconServer size={16} />
+                <Text size="sm" fw={500}>
+                  Required service processing
+                </Text>
               </Group>
-              <Text size="xs" c="dimmed" mt={2}>Essential for the app to function. Cannot be disabled.</Text>
-            </div>
-            <Switch checked disabled size="md" />
+              <Text size="xs" c="dimmed" mt={2}>
+                Cloudflare handles ordinary request metadata for delivery, security, reliability,
+                and aggregate traffic reports. Excalimate does not add a client analytics beacon for
+                this.
+              </Text>
+            </Box>
+            <Switch checked disabled size="md" aria-label="Required service processing is active" />
           </Group>
 
-          <Group justify="space-between" wrap="nowrap" py={8}>
-            <div>
+          <Group justify="space-between" wrap="nowrap" py={6}>
+            <Box>
               <Group gap={8} wrap="nowrap">
-                <IconAdjustments size={16} style={{ color: 'var(--color-text-muted)' }} />
-                <Text size="sm" fw={500}>Preferences</Text>
+                <IconAdjustments size={16} />
+                <Text size="sm" fw={500}>
+                  Preference storage
+                </Text>
               </Group>
-              <Text size="xs" c="dimmed" mt={2}>Remembers your settings, theme, and other choices across sessions.</Text>
-            </div>
-            <Switch checked={preferencesOn} onChange={(e) => setPreferencesOn(e.currentTarget.checked)} size="md" />
+              <Text size="xs" c="dimmed" mt={2}>
+                Remembers theme, MCP URL, and the short GitHub star cache.
+              </Text>
+            </Box>
+            <Switch
+              checked={preferences}
+              onChange={(event) =>
+                useConsentStore.setState({ preferences: event.currentTarget.checked })
+              }
+              size="md"
+              aria-label="Preference storage"
+            />
           </Group>
 
-          <Group justify="space-between" wrap="nowrap" py={8}>
-            <div>
+          <Group justify="space-between" wrap="nowrap" py={6}>
+            <Box>
               <Group gap={8} wrap="nowrap">
-                <IconChartBar size={16} style={{ color: 'var(--color-text-muted)' }} />
-                <Text size="sm" fw={500}>Analytics</Text>
+                <IconChartBar size={16} />
+                <Text size="sm" fw={500}>
+                  Optional product analytics
+                </Text>
               </Group>
-              <Text size="xs" c="dimmed" mt={2}>Anonymous usage statistics via PostHog. No personal data collected.</Text>
-            </div>
-            <Switch checked={analyticsOn} onChange={(e) => setAnalyticsOn(e.currentTarget.checked)} size="md" />
+              <Text size="xs" c="dimmed" mt={2}>
+                Declared, pseudonymous usage events via PostHog Cloud EU. No project content, full
+                URLs, referrers, autocapture, or session replay.
+              </Text>
+            </Box>
+            <Switch
+              checked={analytics}
+              onChange={(event) =>
+                useConsentStore.setState({ analytics: event.currentTarget.checked })
+              }
+              size="md"
+              aria-label="Optional product analytics"
+            />
           </Group>
 
-          <Divider my="xs" />
+          <Divider />
+          <DataInventory />
 
-          <Group justify="flex-end" gap={8}>
-            <Button variant="default" size="sm" onClick={handleRejectAll}>Reject All</Button>
-            <Button variant="light" size="sm" onClick={handleSavePrefs}>Save Preferences</Button>
-            <Button size="sm" onClick={handleAcceptAll}>Accept All</Button>
+          <Group justify="space-between" mt="xs">
+            <Anchor href={PRIVACY_POLICY_URL} target="_blank" size="sm">
+              Complete privacy notice{' '}
+              <IconExternalLink size={13} style={{ verticalAlign: 'text-bottom' }} />
+            </Anchor>
+            <Group gap={8}>
+              <Button variant="default" size="sm" onClick={() => handleSave(false, false)}>
+                Use required only
+              </Button>
+              <Button variant="light" size="sm" onClick={() => handleSave(analytics, preferences)}>
+                Save choices
+              </Button>
+              <Button size="sm" onClick={() => handleSave(true, true)}>
+                Accept optional
+              </Button>
+            </Group>
           </Group>
         </Stack>
       </Modal>

--- a/src/components/Toolbar/FileControls.tsx
+++ b/src/components/Toolbar/FileControls.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { Menu, Button, Modal, Select, Divider, TextInput } from '@mantine/core';
 import {
-  IconFilePlus, IconFolderOpen, IconDeviceFloppy,
-  IconFileImport, IconShare, IconChevronDown, IconSettings, IconMaximize, IconServer, IconCheck,
-  IconCookie,
+  IconFilePlus,
+  IconFolderOpen,
+  IconDeviceFloppy,
+  IconFileImport,
+  IconShare,
+  IconChevronDown,
+  IconSettings,
+  IconMaximize,
+  IconServer,
+  IconCheck,
+  IconShieldLock,
 } from '@tabler/icons-react';
 import { ImportExcalidrawModal } from './ImportExcalidrawModal';
 import { LoadAnimationModal } from './LoadAnimationModal';
@@ -13,14 +21,19 @@ import { useShareOperations } from './useShareOperations';
 import { useProjectStore, getExportResolution } from '../../stores/projectStore';
 import type { AspectRatio } from '../../stores/projectStore';
 import { useMcpLive } from '../../hooks/useMcpLive';
+import { useConsentStore } from '../../stores/consentStore';
 
 const RATIOS: AspectRatio[] = ['16:9', '4:3', '1:1', '3:2'];
 
 export function FileControls() {
   const {
-    handleNew, handleSave,
-    handleImportFile, handleImportUrl,
-    handleLoadProjectFile, handleLoadCheckpointFile, handleLoadShareUrl,
+    handleNew,
+    handleSave,
+    handleImportFile,
+    handleImportUrl,
+    handleLoadProjectFile,
+    handleLoadCheckpointFile,
+    handleLoadShareUrl,
   } = useFileOperations();
   const { loading, handleShare } = useShareOperations();
 
@@ -30,12 +43,18 @@ export function FileControls() {
   const [prefsOpen, setPrefsOpen] = useState(false);
   const aspectRatio = useProjectStore((s) => s.cameraFrame.aspectRatio);
   const { liveUrl, setLiveUrl } = useMcpLive();
+  const openPrivacySettings = useConsentStore((state) => state.openSettings);
 
   return (
     <>
       <Menu shadow="md" width={220} position="bottom-start">
         <Menu.Target>
-          <Button variant="subtle" color="gray" size="compact-sm" rightSection={<IconChevronDown size={12} />}>
+          <Button
+            variant="subtle"
+            color="gray"
+            size="compact-sm"
+            rightSection={<IconChevronDown size={12} />}
+          >
             File
           </Button>
         </Menu.Target>
@@ -68,17 +87,13 @@ export function FileControls() {
           <Menu.Item leftSection={<IconSettings size={16} />} onClick={() => setPrefsOpen(true)}>
             Preferences
           </Menu.Item>
-          <Menu.Item leftSection={<IconCookie size={16} />} onClick={() => { import('../../stores/consentStore').then(m => m.useConsentStore.getState().openSettings()); }}>
-            Cookie Settings
+          <Menu.Item leftSection={<IconShieldLock size={16} />} onClick={openPrivacySettings}>
+            Privacy and data
           </Menu.Item>
         </Menu.Dropdown>
       </Menu>
 
-      <NewProjectModal
-        opened={newOpen}
-        onClose={() => setNewOpen(false)}
-        onCreate={handleNew}
-      />
+      <NewProjectModal opened={newOpen} onClose={() => setNewOpen(false)} onCreate={handleNew} />
 
       <ImportExcalidrawModal
         opened={importOpen}
@@ -100,7 +115,9 @@ export function FileControls() {
           <Select
             label="Camera aspect ratio"
             value={aspectRatio}
-            onChange={(v) => { if (v) useProjectStore.getState().setCameraAspectRatio(v as AspectRatio); }}
+            onChange={(v) => {
+              if (v) useProjectStore.getState().setCameraAspectRatio(v as AspectRatio);
+            }}
             data={RATIOS.map((r) => {
               const res = getExportResolution(r);
               return { value: r, label: `${r}  (${res.width}×${res.height})` };
@@ -123,7 +140,13 @@ export function FileControls() {
 }
 
 /** MCP URL input with a checkmark that appears briefly after the value is persisted. */
-function McpUrlInput({ liveUrl, setLiveUrl }: { liveUrl: string; setLiveUrl: (url: string) => void }) {
+function McpUrlInput({
+  liveUrl,
+  setLiveUrl,
+}: {
+  liveUrl: string;
+  setLiveUrl: (url: string) => void;
+}) {
   const [saved, setSaved] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -135,7 +158,9 @@ function McpUrlInput({ liveUrl, setLiveUrl }: { liveUrl: string; setLiveUrl: (ur
   };
 
   useEffect(() => {
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
   }, []);
 
   return (
@@ -146,7 +171,9 @@ function McpUrlInput({ liveUrl, setLiveUrl }: { liveUrl: string; setLiveUrl: (ur
       value={liveUrl}
       onChange={(e) => handleChange(e.currentTarget.value)}
       leftSection={<IconServer size={14} />}
-      rightSection={saved ? <IconCheck size={14} color="var(--mantine-color-green-6)" /> : undefined}
+      rightSection={
+        saved ? <IconCheck size={14} color="var(--mantine-color-green-6)" /> : undefined
+      }
     />
   );
 }

--- a/src/components/Toolbar/InfoLinks.tsx
+++ b/src/components/Toolbar/InfoLinks.tsx
@@ -5,44 +5,51 @@ import {
   IconBrandX,
   IconBrandBluesky,
   IconHeart,
+  IconShieldLock,
 } from '@tabler/icons-react';
+import { readPreference, storePreference } from '../../services/analytics/consent';
+import { OPTIONAL_STORAGE_KEYS } from '../../services/privacy/dataInventory';
+import { useConsentStore } from '../../stores/consentStore';
 
 const REPO = 'excalimate/excalimate';
 const GITHUB_URL = `https://github.com/${REPO}`;
-const STARS_KEY = 'excalimate-gh-stars';
+const STARS_KEY = OPTIONAL_STORAGE_KEYS.githubStars;
 
 function getCachedStars(): number | null {
   try {
-    const raw = localStorage.getItem(STARS_KEY);
+    const raw = readPreference(STARS_KEY);
     if (!raw) return null;
     const { count, ts } = JSON.parse(raw);
     // Cache for 1 hour
     if (Date.now() - ts < 3600000) return count;
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
   return null;
 }
 
 function cacheStars(count: number): void {
-  try {
-    localStorage.setItem(STARS_KEY, JSON.stringify({ count, ts: Date.now() }));
-  } catch { /* ignore */ }
+  storePreference(STARS_KEY, JSON.stringify({ count, ts: Date.now() }));
 }
 
 export function InfoLinks() {
   const [stars, setStars] = useState<number | null>(getCachedStars);
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const openPrivacySettings = useConsentStore((state) => state.openSettings);
 
   useEffect(() => {
     if (stars !== null) return;
     fetch(`https://api.github.com/repos/${REPO}`, { signal: AbortSignal.timeout(5000) })
-      .then((r) => r.ok ? r.json() : null)
+      .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.stargazers_count != null) {
           setStars(data.stargazers_count);
           cacheStars(data.stargazers_count);
         }
       })
-      .catch(() => { /* best effort */ });
+      .catch(() => {
+        /* best effort */
+      });
   }, [stars]);
 
   return (
@@ -64,6 +71,18 @@ export function InfoLinks() {
             </span>
           )}
         </a>
+      </Tooltip>
+
+      <Tooltip label="Privacy and data">
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          size="sm"
+          onClick={openPrivacySettings}
+          aria-label="Privacy and data"
+        >
+          <IconShieldLock size={15} />
+        </ActionIcon>
       </Tooltip>
 
       {/* Credits popover */}
@@ -89,7 +108,7 @@ export function InfoLinks() {
         <Popover.Dropdown>
           <Stack gap="sm">
             <Text size="xs" ta="center" c="dimmed">
-              Made with ❤️ by David Szakacs
+              Made by David Szakacs
             </Text>
             <Group justify="center" gap="xs">
               <Tooltip label="X / Twitter">

--- a/src/hooks/useMcpLive.ts
+++ b/src/hooks/useMcpLive.ts
@@ -13,8 +13,10 @@ import { useUIStore } from '../stores/uiStore';
 import { extractTargets } from '../components/Canvas/extractTargets';
 import { computeFrameAtTime } from '../core/engine/playbackSingleton';
 import { trackMcpAction } from '../services/analytics/posthog';
+import { readPreference, storePreference } from '../services/analytics/consent';
+import { OPTIONAL_STORAGE_KEYS } from '../services/privacy/dataInventory';
 
-const STORAGE_KEY = 'excalimate-mcp-url';
+const STORAGE_KEY = OPTIONAL_STORAGE_KEYS.mcpUrl;
 
 /** Decompress a gzip+base64 encoded string using the browser's DecompressionStream API. */
 async function decompressGzBase64(b64: string): Promise<string> {
@@ -47,19 +49,13 @@ async function decompressGzBase64(b64: string): Promise<string> {
 }
 
 function getPersistedMcpUrl(): string {
-  try {
-    return localStorage.getItem(STORAGE_KEY) || import.meta.env.VITE_MCP_SERVER_URL || 'http://localhost:3001';
-  } catch {
-    return import.meta.env.VITE_MCP_SERVER_URL || 'http://localhost:3001';
-  }
+  return (
+    readPreference(STORAGE_KEY) || import.meta.env.VITE_MCP_SERVER_URL || 'http://localhost:3001'
+  );
 }
 
 function persistMcpUrl(url: string): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, url);
-  } catch {
-    // Best effort persistence.
-  }
+  storePreference(STORAGE_KEY, url);
 }
 
 export function getMcpUrl(): string {
@@ -129,89 +125,94 @@ export function useMcpLive() {
     return Math.max(0, base + jitter);
   }
 
-  const connect = useCallback((url: string = getMcpUrl()) => {
-    // Clean up any existing connection/timers
-    if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
-    reconnectTimerRef.current = null;
-    abortRef.current?.abort();
-    eventSourceRef.current?.close();
-    intentionalDisconnectRef.current = false;
-    reconnectAttemptRef.current = 0;
-    setLastError(null);
+  const connect = useCallback(
+    (url: string = getMcpUrl()) => {
+      // Clean up any existing connection/timers
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+      abortRef.current?.abort();
+      eventSourceRef.current?.close();
+      intentionalDisconnectRef.current = false;
+      reconnectAttemptRef.current = 0;
+      setLastError(null);
 
-    function openConnection(isReconnect = false) {
-      setStatus(isReconnect ? 'reconnecting' : 'connecting');
+      function openConnection(isReconnect = false) {
+        setStatus(isReconnect ? 'reconnecting' : 'connecting');
 
-      const es = new EventSource(`${url}/live`);
-      eventSourceRef.current = es;
-      let hasConnected = false;
+        const es = new EventSource(`${url}/live`);
+        eventSourceRef.current = es;
+        let hasConnected = false;
 
-      es.onopen = () => {
-        if (import.meta.env.DEV) console.log('[MCP Live] Connected to', url);
-        hasConnected = true;
-        reconnectAttemptRef.current = 0;
-        setStatus('connected');
-        useUIStore.getState().setLiveMode(true);
-        trackMcpAction('connect');
+        es.onopen = () => {
+          if (import.meta.env.DEV) console.log('[MCP Live] Connected to', url);
+          hasConnected = true;
+          reconnectAttemptRef.current = 0;
+          setStatus('connected');
+          useUIStore.getState().setLiveMode(true);
+          trackMcpAction('connect');
 
-        // Re-sync full state on every (re)connect to recover from missed SSE messages
-        syncState(url);
-      };
+          // Re-sync full state on every (re)connect to recover from missed SSE messages
+          syncState(url);
+        };
 
-      es.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          if (data.type === 'state' && data.state) {
-            applyState(data.state);
-          } else if (data.type === 'gz' && data.data) {
-            // Decompress gzipped SSE payload
-            decompressGzBase64(data.data).then(
-              (json) => {
-                try {
-                  const parsed = JSON.parse(json);
-                  if (parsed.type === 'state' && parsed.state) {
-                    applyState(parsed.state);
+        es.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            if (data.type === 'state' && data.state) {
+              applyState(data.state);
+            } else if (data.type === 'gz' && data.data) {
+              // Decompress gzipped SSE payload
+              decompressGzBase64(data.data).then(
+                (json) => {
+                  try {
+                    const parsed = JSON.parse(json);
+                    if (parsed.type === 'state' && parsed.state) {
+                      applyState(parsed.state);
+                    }
+                  } catch (e) {
+                    console.error('[MCP Live] Parse error after decompress:', e);
                   }
-                } catch (e) {
-                  console.error('[MCP Live] Parse error after decompress:', e);
-                }
-              },
-              (err) => console.error('[MCP Live] Decompress error:', err),
+                },
+                (err) => console.error('[MCP Live] Decompress error:', err),
+              );
+            }
+          } catch (e) {
+            console.error('[MCP Live] Parse error:', e);
+          }
+        };
+
+        es.onerror = () => {
+          es.close();
+          eventSourceRef.current = null;
+
+          if (intentionalDisconnectRef.current) {
+            setStatus('disconnected');
+            return;
+          }
+
+          if (!hasConnected) {
+            setStatus('disconnected');
+            setLastError('connection_failed');
+            return;
+          }
+
+          // Schedule reconnect with backoff
+          const delay = getReconnectDelay();
+          reconnectAttemptRef.current++;
+          if (import.meta.env.DEV) {
+            console.log(
+              `[MCP Live] Connection lost. Reconnecting in ${Math.round(delay)}ms (attempt ${reconnectAttemptRef.current})`,
             );
           }
-        } catch (e) {
-          console.error('[MCP Live] Parse error:', e);
-        }
-      };
+          reconnectTimerRef.current = setTimeout(() => openConnection(true), delay);
+        };
+      }
 
-      es.onerror = () => {
-        es.close();
-        eventSourceRef.current = null;
-
-        if (intentionalDisconnectRef.current) {
-          setStatus('disconnected');
-          return;
-        }
-
-        if (!hasConnected) {
-          setStatus('disconnected');
-          setLastError('connection_failed');
-          return;
-        }
-
-        // Schedule reconnect with backoff
-        const delay = getReconnectDelay();
-        reconnectAttemptRef.current++;
-        if (import.meta.env.DEV) {
-          console.log(`[MCP Live] Connection lost. Reconnecting in ${Math.round(delay)}ms (attempt ${reconnectAttemptRef.current})`);
-        }
-        reconnectTimerRef.current = setTimeout(() => openConnection(true), delay);
-      };
-    }
-
-    openConnection();
-    setLiveUrl(url);
-  }, [setLiveUrl]);
+      openConnection();
+      setLiveUrl(url);
+    },
+    [setLiveUrl],
+  );
 
   const disconnect = useCallback(() => {
     intentionalDisconnectRef.current = true;
@@ -262,10 +263,11 @@ function applyState(state: any) {
 
         // Remove deleted elements
         const removedSet = new Set<string>(state.scene.removed ?? []);
-        let elements = removedSet.size > 0
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ? currentElements.filter((el: any) => !removedSet.has(el.id))
-          : currentElements;
+        let elements =
+          removedSet.size > 0
+            ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              currentElements.filter((el: any) => !removedSet.has(el.id))
+            : currentElements;
 
         // Upsert (add or replace) elements
         if (state.scene.upsert?.length > 0) {
@@ -331,7 +333,10 @@ function applyState(state: any) {
     const animStore = useAnimationStore.getState();
 
     // Detect delta format (has upsertedTracks/removedTrackIds) vs full format (has tracks array)
-    if (Array.isArray(state.timeline.upsertedTracks) || Array.isArray(state.timeline.removedTrackIds)) {
+    if (
+      Array.isArray(state.timeline.upsertedTracks) ||
+      Array.isArray(state.timeline.removedTrackIds)
+    ) {
       // ── Delta timeline update ──
       const currentTimeline = animStore.timeline;
       let tracks = [...currentTimeline.tracks];
@@ -339,15 +344,16 @@ function applyState(state: any) {
       // Remove deleted tracks
       if (state.timeline.removedTrackIds?.length > 0) {
         const removedSet = new Set<string>(state.timeline.removedTrackIds);
-        tracks = tracks.filter(t => !removedSet.has(t.id));
+        tracks = tracks.filter((t) => !removedSet.has(t.id));
       }
 
       // Upsert tracks
       if (state.timeline.upsertedTracks?.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const upsertMap = new Map<string, any>(state.timeline.upsertedTracks.map((t: any) => [t.id, t]));
-        tracks = tracks.map(t => upsertMap.get(t.id) ?? t) as typeof tracks;
-        const existingIds = new Set(tracks.map(t => t.id));
+        const upsertMap = new Map<string, (typeof tracks)[number]>(
+          state.timeline.upsertedTracks.map((track: (typeof tracks)[number]) => [track.id, track]),
+        );
+        tracks = tracks.map((track) => upsertMap.get(track.id) ?? track);
+        const existingIds = new Set(tracks.map((t) => t.id));
         for (const t of state.timeline.upsertedTracks) {
           if (!existingIds.has(t.id)) tracks.push(t);
         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,19 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import { App } from './components/App/App';
-import { PostHogProvider } from 'posthog-js/react';
-import { getPostHogClient, isPostHogConfigured } from './services/analytics/posthog';
+import { initializeAnalyticsFromConsent } from './services/analytics/posthog';
 
-const posthogClient = isPostHogConfigured() ? getPostHogClient() : undefined;
+initializeAnalyticsFromConsent();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {posthogClient ? (
-      <PostHogProvider client={posthogClient}>
-        <App />
-      </PostHogProvider>
-    ) : (
-      <App />
-    )}
+    <App />
   </StrictMode>,
 );

--- a/src/services/analytics/analytics.test.ts
+++ b/src/services/analytics/analytics.test.ts
@@ -1,0 +1,126 @@
+import type { CaptureResult } from 'posthog-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CONSENT_KEY,
+  CONSENT_VERSION,
+  canStorePreferences,
+  clearOptionalPreferences,
+  readStoredConsent,
+  storePreference,
+} from './consent';
+import { OPTIONAL_STORAGE_KEYS } from '../privacy/dataInventory';
+
+const posthogMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  reset: vi.fn(),
+  has_opted_out_capturing: vi.fn(() => false),
+}));
+
+vi.mock('posthog-js', () => ({ default: posthogMock }));
+
+function storeConsent(analytics: boolean, preferences: boolean, version = CONSENT_VERSION): void {
+  localStorage.setItem(
+    CONSENT_KEY,
+    JSON.stringify({
+      version,
+      state: { analytics, preferences },
+      timestamp: '2026-07-12T00:00:00.000Z',
+    }),
+  );
+}
+
+describe('privacy consent storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('accepts only the current, complete consent schema', () => {
+    storeConsent(true, false);
+    expect(readStoredConsent()?.state).toEqual({ analytics: true, preferences: false });
+
+    storeConsent(true, true, '1.1');
+    expect(readStoredConsent()).toBeNull();
+
+    localStorage.setItem(CONSENT_KEY, '{"version":"2.0","state":{}}');
+    expect(readStoredConsent()).toBeNull();
+  });
+
+  it('writes optional preferences only after preference consent', () => {
+    expect(storePreference(OPTIONAL_STORAGE_KEYS.theme, 'dark')).toBe(false);
+    expect(localStorage.getItem(OPTIONAL_STORAGE_KEYS.theme)).toBeNull();
+
+    storeConsent(false, true);
+    expect(canStorePreferences()).toBe(true);
+    expect(storePreference(OPTIONAL_STORAGE_KEYS.theme, 'dark')).toBe(true);
+    expect(localStorage.getItem(OPTIONAL_STORAGE_KEYS.theme)).toBe('dark');
+  });
+
+  it('removes every optional preference key on withdrawal', () => {
+    for (const key of Object.values(OPTIONAL_STORAGE_KEYS)) localStorage.setItem(key, 'value');
+    clearOptionalPreferences();
+    for (const key of Object.values(OPTIONAL_STORAGE_KEYS))
+      expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe('PostHog privacy boundary', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_KEY', 'phc_test');
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_HOST', 'https://eu.i.posthog.com');
+  });
+
+  it('does not initialize PostHog without current analytics consent', async () => {
+    const analytics = await import('./posthog');
+    analytics.initializeAnalyticsFromConsent();
+    await Promise.resolve();
+    expect(posthogMock.init).not.toHaveBeenCalled();
+  });
+
+  it('initializes only after consent and stops captures after withdrawal', async () => {
+    storeConsent(true, false);
+    const analytics = await import('./posthog');
+
+    analytics.initializeAnalyticsFromConsent();
+    await vi.waitFor(() => expect(posthogMock.init).toHaveBeenCalledOnce());
+    analytics.trackSaveProject();
+    expect(posthogMock.capture).toHaveBeenCalledWith('project_saved', {});
+
+    analytics.disableCapture();
+    analytics.trackSaveProject();
+    expect(posthogMock.capture).toHaveBeenCalledTimes(1);
+    expect(posthogMock.opt_out_capturing).toHaveBeenCalledOnce();
+    expect(posthogMock.reset).toHaveBeenCalledWith(true);
+  });
+
+  it('rejects undeclared events and strips undeclared properties', async () => {
+    const { filterAnalyticsCapture } = await import('./posthog');
+    const base: CaptureResult = {
+      uuid: '00000000-0000-4000-8000-000000000000',
+      event: 'animation_exported',
+      properties: {
+        format: 'mp4',
+        distinct_id: 'session-only',
+        $current_url: 'https://app.excalimate.com/#share=secret',
+        project_name: 'Private project',
+      },
+      $set: { email: 'visitor@example.com' },
+    };
+
+    expect(filterAnalyticsCapture(base)).toEqual({
+      ...base,
+      properties: { format: 'mp4', distinct_id: 'session-only' },
+      $set: undefined,
+      $set_once: undefined,
+      $unset: undefined,
+    });
+    expect(filterAnalyticsCapture({ ...base, event: '$pageview' })).toBeNull();
+    expect(filterAnalyticsCapture(null)).toBeNull();
+  });
+});

--- a/src/services/analytics/consent.ts
+++ b/src/services/analytics/consent.ts
@@ -1,5 +1,11 @@
-export const CONSENT_KEY = 'excalimate-analytics-consent';
-export const CONSENT_VERSION = '1.1';
+import {
+  CONSENT_SCHEMA_VERSION,
+  CONSENT_STORAGE_KEY,
+  OPTIONAL_STORAGE_KEYS,
+} from '../privacy/dataInventory';
+
+export const CONSENT_KEY = CONSENT_STORAGE_KEY;
+export const CONSENT_VERSION = CONSENT_SCHEMA_VERSION;
 
 export interface ConsentState {
   analytics: boolean;
@@ -12,20 +18,35 @@ export interface StoredConsent {
   timestamp: string;
 }
 
+export function readStoredConsent(): StoredConsent | null {
+  try {
+    const raw = localStorage.getItem(CONSENT_KEY);
+    if (!raw) return null;
+    const parsed: StoredConsent = JSON.parse(raw);
+    if (parsed.version !== CONSENT_VERSION) return null;
+    if (typeof parsed.timestamp !== 'string') return null;
+    if (
+      typeof parsed.state?.analytics !== 'boolean' ||
+      typeof parsed.state?.preferences !== 'boolean'
+    )
+      return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function hasAnalyticsConsent(): boolean {
+  return readStoredConsent()?.state.analytics === true;
+}
+
 /**
  * Check if the user has granted preference storage consent.
  * Use this before storing any user preference in localStorage.
  * Returns true if consent was granted, false otherwise.
  */
 export function canStorePreferences(): boolean {
-  try {
-    const raw = localStorage.getItem(CONSENT_KEY);
-    if (!raw) return false;
-    const parsed: StoredConsent = JSON.parse(raw);
-    return parsed.state?.preferences === true;
-  } catch {
-    return false;
-  }
+  return readStoredConsent()?.state.preferences === true;
 }
 
 /**
@@ -34,8 +55,13 @@ export function canStorePreferences(): boolean {
  */
 export function storePreference(key: string, value: string): boolean {
   if (!canStorePreferences()) return false;
-  localStorage.setItem(key, value);
-  return true;
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (error) {
+    console.warn(`Could not store preference "${key}".`, error);
+    return false;
+  }
 }
 
 /**
@@ -44,5 +70,20 @@ export function storePreference(key: string, value: string): boolean {
  */
 export function readPreference(key: string): string | null {
   if (!canStorePreferences()) return null;
-  return localStorage.getItem(key);
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Could not read preference "${key}".`, error);
+    return null;
+  }
+}
+
+export function clearOptionalPreferences(): void {
+  for (const key of Object.values(OPTIONAL_STORAGE_KEYS)) {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.warn(`Could not remove preference "${key}".`, error);
+    }
+  }
 }

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -1,2 +1,18 @@
-export { getPostHogClient, isPostHogConfigured, enableCapture, disableCapture, trackEvent, trackExport, trackMcpConnection, trackSceneCreated, trackShare } from './posthog';
-export { CONSENT_KEY, CONSENT_VERSION, type ConsentState, type StoredConsent, canStorePreferences, storePreference, readPreference } from './consent';
+export {
+  isPostHogConfigured,
+  enableCapture,
+  disableCapture,
+  initializeAnalyticsFromConsent,
+  trackExport,
+  trackShare,
+} from './posthog';
+export {
+  CONSENT_KEY,
+  CONSENT_VERSION,
+  type ConsentState,
+  type StoredConsent,
+  canStorePreferences,
+  storePreference,
+  readPreference,
+  readStoredConsent,
+} from './consent';

--- a/src/services/analytics/posthog.ts
+++ b/src/services/analytics/posthog.ts
@@ -1,69 +1,133 @@
-import posthog, { type PostHog } from 'posthog-js';
-import { CONSENT_KEY, type StoredConsent } from './consent';
+import type { CaptureResult, PostHog } from 'posthog-js';
+import type { ExportFormat } from '../export/types';
+import type { AspectRatio } from '../../stores/projectStore';
+import type { Theme } from '../../stores/uiStore';
+import {
+  ANALYTICS_EVENT_DEFINITIONS,
+  POSTHOG_TECHNICAL_PROPERTIES,
+  type AnalyticsEventName,
+} from '../privacy/dataInventory';
+import { hasAnalyticsConsent } from './consent';
 
 /**
  * PostHog configuration — reads from Vite env vars.
  * Leave VITE_PUBLIC_POSTHOG_KEY empty to disable analytics entirely.
  */
 const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY ?? '';
-const POSTHOG_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+const POSTHOG_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST ?? 'https://eu.i.posthog.com';
+
+let client: PostHog | null = null;
+let initialization: Promise<PostHog | null> | null = null;
+let captureEnabled = false;
+let consentGeneration = 0;
 
 /** Whether PostHog is configured (key is set) */
 export const isPostHogConfigured = (): boolean => POSTHOG_KEY.length > 0;
 
-/** Get the PostHog client instance (for the provider) */
-export function getPostHogClient(): PostHog | undefined {
-  if (!isPostHogConfigured()) return undefined;
+function isDeclaredEvent(event: string): event is AnalyticsEventName {
+  return Object.hasOwn(ANALYTICS_EVENT_DEFINITIONS, event);
+}
 
-  const consent = getStoredConsent();
-  const hasConsent = consent?.state.analytics === true;
+export function filterAnalyticsCapture(capture: CaptureResult | null): CaptureResult | null {
+  if (!capture) return null;
+  if (!isDeclaredEvent(capture.event)) return null;
 
-  posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
-    person_profiles: 'identified_only',
-    capture_pageview: true,
-    capture_pageleave: true,
-    autocapture: false,
-    persistence: 'localStorage',
-    opt_out_capturing_by_default: !hasConsent,
-    loaded: (ph) => {
-      if (!hasConsent) {
-        ph.opt_out_capturing();
+  const declaredProperties = Object.keys(ANALYTICS_EVENT_DEFINITIONS[capture.event].properties);
+  const permitted = new Set<string>([...POSTHOG_TECHNICAL_PROPERTIES, ...declaredProperties]);
+  const properties = Object.fromEntries(
+    Object.entries(capture.properties).filter(([key]) => permitted.has(key)),
+  );
+
+  return { ...capture, properties, $set: undefined, $set_once: undefined, $unset: undefined };
+}
+
+async function initializeClient(): Promise<PostHog | null> {
+  if (!isPostHogConfigured()) return null;
+  if (client) return client;
+  if (initialization) return initialization;
+
+  const generation = consentGeneration;
+  initialization = import('posthog-js')
+    .then(({ default: posthog }) => {
+      posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        person_profiles: 'never',
+        autocapture: false,
+        rageclick: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        capture_performance: false,
+        disable_session_recording: true,
+        disable_surveys: true,
+        disable_surveys_automatic_display: true,
+        disable_product_tours: true,
+        disable_web_experiments: true,
+        advanced_disable_flags: true,
+        advanced_disable_feature_flags: true,
+        advanced_disable_feature_flags_on_first_load: true,
+        disableDeviceModel: true,
+        disable_capture_url_hashes: true,
+        save_referrer: false,
+        save_campaign_params: false,
+        persistence: 'memory',
+        disable_persistence: true,
+        respect_dnt: true,
+        opt_out_capturing_by_default: false,
+        before_send: filterAnalyticsCapture,
+      });
+      client = posthog;
+
+      if (!captureEnabled || generation !== consentGeneration) {
+        posthog.opt_out_capturing();
+        posthog.reset(true);
+        return null;
       }
-    },
-  });
 
-  return posthog;
+      return posthog;
+    })
+    .finally(() => {
+      initialization = null;
+    });
+
+  return initialization;
 }
 
-/** Call after user grants consent — opts PostHog in */
-export function enableCapture(): void {
-  if (!isPostHogConfigured()) return;
-  posthog.opt_in_capturing();
+export async function enableCapture(): Promise<void> {
+  captureEnabled = true;
+  await initializeClient();
+  if (captureEnabled && client?.has_opted_out_capturing()) {
+    client.opt_in_capturing();
+  }
 }
 
-/** Call after user revokes consent — opts PostHog out */
 export function disableCapture(): void {
-  if (!isPostHogConfigured()) return;
-  posthog.opt_out_capturing();
+  captureEnabled = false;
+  consentGeneration += 1;
+  if (client) {
+    client.opt_out_capturing();
+    client.reset(true);
+  }
+  clearPostHogPersistence();
 }
 
-/** Track a custom event (only fires if opted in) */
-export function trackEvent(event: string, properties?: Record<string, unknown>): void {
-  if (!isPostHogConfigured() || posthog.has_opted_out_capturing()) return;
-  posthog.capture(event, properties);
+export function initializeAnalyticsFromConsent(): void {
+  if (hasAnalyticsConsent()) {
+    void enableCapture();
+  } else {
+    clearPostHogPersistence();
+  }
 }
 
-export function trackExport(format: string): void {
+function trackEvent(
+  event: AnalyticsEventName,
+  properties: Record<string, string | boolean> = {},
+): void {
+  if (!captureEnabled || !client || client.has_opted_out_capturing()) return;
+  client.capture(event, properties);
+}
+
+export function trackExport(format: ExportFormat): void {
   trackEvent('animation_exported', { format });
-}
-
-export function trackMcpConnection(): void {
-  trackEvent('mcp_connected');
-}
-
-export function trackSceneCreated(elementCount: number): void {
-  trackEvent('scene_created', { element_count: elementCount });
 }
 
 export function trackShare(): void {
@@ -71,7 +135,7 @@ export function trackShare(): void {
 }
 
 // File operations
-export function trackNewProject(aspectRatio: string): void {
+export function trackNewProject(aspectRatio: AspectRatio): void {
   trackEvent('project_created', { aspect_ratio: aspectRatio });
 }
 
@@ -111,22 +175,24 @@ export function trackSequenceAction(action: 'create' | 'update' | 'delete'): voi
 }
 
 // Camera
-export function trackCameraAction(action: 'change_aspect_ratio' | 'fit_to_scene', ratio?: string): void {
+export function trackCameraAction(
+  action: 'change_aspect_ratio' | 'fit_to_scene',
+  ratio?: AspectRatio,
+): void {
   trackEvent('camera_action', { action, ...(ratio ? { ratio } : {}) });
 }
 
 // UI
-export function trackThemeToggle(theme: string): void {
+export function trackThemeToggle(theme: Theme): void {
   trackEvent('theme_toggled', { theme });
-}
-
-export function trackPanelToggle(panel: string, open: boolean): void {
-  trackEvent('panel_toggled', { panel, open });
 }
 
 // Grouping
 export function trackGroupAction(action: 'group' | 'ungroup', elementCount?: number): void {
-  trackEvent('group_action', { action, ...(elementCount ? { element_count: elementCount } : {}) });
+  trackEvent('group_action', {
+    action,
+    ...(elementCount ? { element_count_bucket: bucketCount(elementCount) } : {}),
+  });
 }
 
 // MCP
@@ -134,17 +200,25 @@ export function trackMcpAction(action: 'connect' | 'disconnect' | 'set_url'): vo
   trackEvent('mcp_action', { action });
 }
 
-// Page navigation
-export function trackPageView(page: string): void {
-  trackEvent('page_viewed', { page });
+function bucketCount(count: number): '1' | '2-5' | '6-20' | '21+' {
+  if (count <= 1) return '1';
+  if (count <= 5) return '2-5';
+  if (count <= 20) return '6-20';
+  return '21+';
 }
 
-function getStoredConsent(): StoredConsent | null {
-  try {
-    const raw = localStorage.getItem(CONSENT_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw);
-  } catch {
-    return null;
+function clearPostHogPersistence(): void {
+  for (const storage of [localStorage, sessionStorage]) {
+    for (let index = storage.length - 1; index >= 0; index -= 1) {
+      const key = storage.key(index);
+      if (key?.startsWith('ph_')) storage.removeItem(key);
+    }
+  }
+
+  for (const entry of document.cookie.split(';')) {
+    const name = entry.split('=')[0]?.trim();
+    if (name?.startsWith('ph_')) {
+      document.cookie = `${name}=; Max-Age=0; path=/; SameSite=Lax`;
+    }
   }
 }

--- a/src/services/privacy/dataInventory.ts
+++ b/src/services/privacy/dataInventory.ts
@@ -1,0 +1,264 @@
+export const PRIVACY_POLICY_URL = 'https://excalimate.com/privacy';
+export const CONSENT_STORAGE_KEY = 'excalimate-analytics-consent';
+export const CONSENT_SCHEMA_VERSION = '2.0';
+
+export const OPTIONAL_STORAGE_KEYS = {
+  theme: 'excalimate-theme',
+  mcpUrl: 'excalimate-mcp-url',
+  githubStars: 'excalimate-gh-stars',
+} as const;
+
+export const ANALYTICS_EVENT_DEFINITIONS = {
+  animation_exported: {
+    label: 'Animation exported',
+    purpose: 'Understand which export formats need the most support.',
+    properties: {
+      format: 'One of: mp4, webm, gif, svg, lottie, dotlottie.',
+    },
+  },
+  project_shared: {
+    label: 'Project shared',
+    purpose: 'Measure use of encrypted sharing.',
+    properties: {},
+  },
+  project_created: {
+    label: 'Project created',
+    purpose: 'Understand common canvas formats.',
+    properties: {
+      aspect_ratio: 'One of: 16:9, 4:3, 1:1, 3:2.',
+    },
+  },
+  project_saved: {
+    label: 'Project saved',
+    purpose: 'Measure use of local project saving.',
+    properties: {},
+  },
+  project_loaded: {
+    label: 'Project loaded',
+    purpose: 'Understand how projects are reopened.',
+    properties: {
+      source: 'One of: file, checkpoint, share_url.',
+    },
+  },
+  excalidraw_imported: {
+    label: 'Excalidraw imported',
+    purpose: 'Measure import workflows.',
+    properties: {
+      source: 'One of: file, url.',
+    },
+  },
+  mode_switched: {
+    label: 'Editor mode switched',
+    purpose: 'Understand use of editing and animation modes.',
+    properties: {
+      mode: 'One of: edit, animate.',
+    },
+  },
+  playback_action: {
+    label: 'Playback action',
+    purpose: 'Improve animation-preview controls.',
+    properties: {
+      action: 'One of: play, pause, stop.',
+    },
+  },
+  keyframe_action: {
+    label: 'Keyframe action',
+    purpose: 'Improve keyframe editing.',
+    properties: {
+      action: 'One of: add, move, delete, update.',
+    },
+  },
+  track_action: {
+    label: 'Timeline track action',
+    purpose: 'Improve timeline-track controls.',
+    properties: {
+      action: 'One of: add, remove, toggle.',
+    },
+  },
+  sequence_action: {
+    label: 'Sequence action',
+    purpose: 'Improve sequence-reveal workflows.',
+    properties: {
+      action: 'One of: create, update, delete.',
+    },
+  },
+  camera_action: {
+    label: 'Camera action',
+    purpose: 'Improve camera framing controls.',
+    properties: {
+      action: 'One of: change_aspect_ratio, fit_to_scene.',
+      ratio: 'For aspect-ratio changes only; one of: 16:9, 4:3, 1:1, 3:2.',
+    },
+  },
+  theme_toggled: {
+    label: 'Theme changed',
+    purpose: 'Understand light and dark theme use.',
+    properties: {
+      theme: 'One of: light, dark.',
+    },
+  },
+  group_action: {
+    label: 'Grouping action',
+    purpose: 'Improve grouping workflows without recording project contents.',
+    properties: {
+      action: 'One of: group, ungroup.',
+      element_count_bucket: 'One of: 1, 2-5, 6-20, 21+.',
+    },
+  },
+  mcp_action: {
+    label: 'MCP action',
+    purpose: 'Improve optional MCP live-mode setup.',
+    properties: {
+      action: 'One of: connect, disconnect, set_url.',
+    },
+  },
+  landing_page_viewed: {
+    label: 'Landing page viewed',
+    purpose: 'Understand which public documentation sections are useful.',
+    properties: {
+      page: 'A fixed public page category; never a full URL, query string, or hash.',
+    },
+  },
+  landing_external_link_clicked: {
+    label: 'Landing external link selected',
+    purpose: 'Understand which public resources visitors choose to open.',
+    properties: {
+      destination: 'A fixed destination category; never link text or a full URL.',
+    },
+  },
+} as const;
+
+export type AnalyticsEventName = keyof typeof ANALYTICS_EVENT_DEFINITIONS;
+
+export const POSTHOG_TECHNICAL_PROPERTIES = [
+  'distinct_id',
+  '$session_id',
+  '$window_id',
+  '$lib',
+  '$lib_version',
+  '$process_person_profile',
+] as const;
+
+export const DATA_PRACTICES = [
+  {
+    id: 'cloudflare-delivery',
+    title: 'Service delivery and security',
+    condition: 'Every request',
+    data: 'Source IP address, requested host/path, HTTP method and headers, timestamp, response status, and transfer size are processed by Cloudflare to deliver and secure the service.',
+    purpose: 'Deliver pages and app assets, prevent abuse, and maintain availability.',
+    legalBasis: 'Legitimate interests in operating a secure and reliable service.',
+    recipient: 'Cloudflare, acting primarily as hosting/CDN processor.',
+    retention:
+      'Cloudflare service-log retention follows the contracted service settings; Excalimate does not export these logs for analytics.',
+  },
+  {
+    id: 'cloudflare-aggregate',
+    title: 'Aggregate traffic statistics',
+    condition: 'Every request; no client analytics beacon',
+    data: 'Aggregate request counts, bandwidth, HTTP status/error counts, cache performance, and country-level traffic. Excalimate does not use IP-derived unique-visitor counts as anonymous analytics.',
+    purpose: 'Capacity planning, reliability monitoring, and service improvement.',
+    legalBasis: 'Legitimate interests; retained reports no longer identify a visitor.',
+    recipient: 'Cloudflare edge/zone analytics.',
+    retention:
+      'Raw or exported reports: up to 30 days. Non-identifying aggregate trend reports: indefinitely.',
+  },
+  {
+    id: 'posthog',
+    title: 'Optional product analytics',
+    condition: 'Only after analytics consent',
+    data: 'Only the events and bounded properties listed in the event catalogue, plus a random in-memory session identifier, event timestamp, SDK name/version, and transient network metadata.',
+    purpose: 'Understand feature use and prioritize product improvements.',
+    legalBasis: 'Consent.',
+    recipient: 'PostHog Cloud EU as processor. IP capture must be disabled in project settings.',
+    retention: 'Up to 12 months.',
+  },
+  {
+    id: 'github-stars',
+    title: 'GitHub repository star count',
+    condition: 'When the app toolbar loads',
+    data: 'GitHub receives ordinary request network metadata such as IP address, User-Agent, and Origin. Excalimate requests only public repository metadata.',
+    purpose: 'Display the public repository star count.',
+    legalBasis: 'Legitimate interests, subject to the documented ePrivacy assessment.',
+    recipient: 'GitHub.',
+    retention:
+      'Determined by GitHub for its network logs. A local one-hour cache is used only with preference-storage consent.',
+  },
+  {
+    id: 'unpkg-runtime',
+    title: 'dotLottie runtime',
+    condition: 'When the landing home page loads its animation examples',
+    data: 'unpkg/Cloudflare receives ordinary resource-request metadata such as IP address, User-Agent, requested pinned asset, and Origin. Referrer transmission is disabled.',
+    purpose: 'Render the animation examples on the landing site.',
+    legalBasis: 'Legitimate interests, subject to the documented ePrivacy assessment.',
+    recipient: 'unpkg, delivered through Cloudflare.',
+    retention: 'Determined by the recipient for its network logs.',
+  },
+  {
+    id: 'encrypted-sharing',
+    title: 'Encrypted project sharing',
+    condition: 'Only when the user selects Share',
+    data: 'An end-to-end encrypted project blob, random share ID, content length/type, and expiry timestamp. The encryption key remains in the URL hash and is not sent to the server.',
+    purpose: 'Provide a user-requested share link.',
+    legalBasis: 'Performance of the requested service.',
+    recipient: 'Cloudflare Worker and R2.',
+    retention: 'Up to 30 days.',
+  },
+  {
+    id: 'mcp',
+    title: 'MCP live connection',
+    condition: 'Only when the user connects',
+    data: 'The configured MCP endpoint receives the live-mode requests and scene updates needed for that connection.',
+    purpose: 'Provide the user-requested MCP live workflow.',
+    legalBasis: 'Performance of the requested service.',
+    recipient: 'The MCP endpoint selected by the user.',
+    retention:
+      'Controlled by that endpoint; Excalimate does not centrally store the connection contents.',
+  },
+] as const;
+
+export const BROWSER_STORAGE_ITEMS = [
+  {
+    key: CONSENT_STORAGE_KEY,
+    contents: 'Versioned analytics and preference choices with a decision timestamp.',
+    purpose: 'Remember privacy choices.',
+    category: 'Required',
+  },
+  {
+    key: 'excalidraw-animate-autosave',
+    contents: 'The current project and animation timeline.',
+    purpose: 'Recover the locally edited project.',
+    category: 'Required local app data',
+  },
+  {
+    key: 'excalidraw-animate-recent',
+    contents: 'Up to ten recent local projects.',
+    purpose: 'Show the user their recent projects.',
+    category: 'Required local app data',
+  },
+  {
+    key: OPTIONAL_STORAGE_KEYS.theme,
+    contents: 'light or dark.',
+    purpose: 'Remember the selected theme.',
+    category: 'Optional preference',
+  },
+  {
+    key: OPTIONAL_STORAGE_KEYS.mcpUrl,
+    contents: 'The MCP endpoint entered by the user.',
+    purpose: 'Remember the optional live-mode endpoint.',
+    category: 'Optional preference',
+  },
+  {
+    key: OPTIONAL_STORAGE_KEYS.githubStars,
+    contents: 'Public GitHub star count and one-hour cache timestamp.',
+    purpose: 'Avoid repeated GitHub API requests.',
+    category: 'Optional preference',
+  },
+] as const;
+
+export const EXCLUDED_ANALYTICS_DATA = [
+  'Names, email addresses, account identifiers, or advertising identifiers',
+  'Diagram/project text, shapes, files, names, or encryption keys',
+  'Full URLs, query strings, URL hashes, or referrers',
+  'Typed input, clipboard contents, screenshots, or session replay',
+  'Precise location, cross-site activity, or device fingerprints',
+] as const;

--- a/src/stores/consentStore.ts
+++ b/src/stores/consentStore.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand';
-import { CONSENT_KEY, CONSENT_VERSION, type ConsentState, type StoredConsent } from '../services/analytics/consent';
+import {
+  CONSENT_KEY,
+  CONSENT_VERSION,
+  clearOptionalPreferences,
+  readStoredConsent,
+  type ConsentState,
+  type StoredConsent,
+} from '../services/analytics/consent';
 import { enableCapture, disableCapture } from '../services/analytics/posthog';
 
 interface ConsentStore {
@@ -15,18 +22,6 @@ interface ConsentStore {
   openSettings: () => void;
 }
 
-function loadConsent(): StoredConsent | null {
-  try {
-    const raw = localStorage.getItem(CONSENT_KEY);
-    if (!raw) return null;
-    const parsed: StoredConsent = JSON.parse(raw);
-    if (parsed.version !== CONSENT_VERSION) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
 function persistConsent(state: ConsentState): void {
   const data: StoredConsent = {
     version: CONSENT_VERSION,
@@ -36,7 +31,7 @@ function persistConsent(state: ConsentState): void {
   localStorage.setItem(CONSENT_KEY, JSON.stringify(data));
 }
 
-const stored = loadConsent();
+const stored = readStoredConsent();
 
 export const useConsentStore = create<ConsentStore>((set) => ({
   decided: stored !== null,
@@ -47,14 +42,22 @@ export const useConsentStore = create<ConsentStore>((set) => ({
 
   saveConsent: (state: ConsentState) => {
     persistConsent(state);
-    if (state.analytics) enableCapture(); else disableCapture();
-    set({ decided: true, analytics: state.analytics, preferences: state.preferences, showBanner: false, showModal: false });
+    if (state.analytics) void enableCapture();
+    else disableCapture();
+    if (!state.preferences) clearOptionalPreferences();
+    set({
+      decided: true,
+      analytics: state.analytics,
+      preferences: state.preferences,
+      showBanner: false,
+      showModal: false,
+    });
   },
 
   acceptAll: () => {
     const state: ConsentState = { analytics: true, preferences: true };
     persistConsent(state);
-    enableCapture();
+    void enableCapture();
     set({ decided: true, analytics: true, preferences: true, showBanner: false, showModal: false });
   },
 
@@ -62,7 +65,14 @@ export const useConsentStore = create<ConsentStore>((set) => ({
     const state: ConsentState = { analytics: false, preferences: false };
     persistConsent(state);
     disableCapture();
-    set({ decided: true, analytics: false, preferences: false, showBanner: false, showModal: false });
+    clearOptionalPreferences();
+    set({
+      decided: true,
+      analytics: false,
+      preferences: false,
+      showBanner: false,
+      showModal: false,
+    });
   },
 
   openSettings: () => {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,16 +1,14 @@
 import { create } from 'zustand';
-import type {
-  AppMode,
-  PanelSizes,
-  TimelineViewport,
-} from '../types/ui';
+import type { AppMode, PanelSizes, TimelineViewport } from '../types/ui';
 import { computeFrameAtTime } from '../core/engine/playbackSingleton';
 import { usePlaybackStore } from './playbackStore';
+import { readPreference, storePreference } from '../services/analytics/consent';
+import { OPTIONAL_STORAGE_KEYS } from '../services/privacy/dataInventory';
 
 export type Theme = 'light' | 'dark';
 
 function getInitialTheme(): Theme {
-  const stored = localStorage.getItem('excalimate-theme');
+  const stored = readPreference(OPTIONAL_STORAGE_KEYS.theme);
   if (stored === 'light' || stored === 'dark') return stored;
   return 'light';
 }
@@ -92,14 +90,14 @@ export const useUIStore = create<UIState>()((set, get) => ({
   },
 
   setTheme: (theme: Theme): void => {
-    localStorage.setItem('excalimate-theme', theme);
+    storePreference(OPTIONAL_STORAGE_KEYS.theme, theme);
     set({ theme });
   },
 
   toggleTheme: (): void => {
     set((state) => {
       const next = state.theme === 'dark' ? 'light' : 'dark';
-      localStorage.setItem('excalimate-theme', next);
+      storePreference(OPTIONAL_STORAGE_KEYS.theme, next);
       return { theme: next };
     });
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2025-09-27",
   "pages_build_output_dir": "./dist",
   "observability": {
-    "enabled": true,
+    "enabled": false,
   },
   "assets": {
     "not_found_handling": "single-page-application",


### PR DESCRIPTION
## Summary
- keep PostHog product analytics disabled until affirmative, versioned consent and constrain it to a public event/property allowlist
- add a shared processing, event, storage, retention, recipient, and exclusion inventory to the app privacy controls and landing-page privacy notice
- gate optional preference persistence, remove optional storage on withdrawal, and clean up legacy PostHog identifiers
- disclose required Cloudflare edge processing, feedback-portal processing, and the retained GitHub/unpkg requests; add resource-integrity protections and disable request-level Workers observability
- preserve the Cloudflare-adapted landing deployment through its generated `dist/server/wrangler.json` configuration
- document production privacy and deployment settings and add consent, revocation, and payload-filtering coverage

## Compliance notes
- consentless measurement is limited to existing aggregate Cloudflare edge reports; IP-derived visitor metrics are not treated as anonymous analytics
- PostHog data is described as pseudonymous and remains consent-gated
- public feedback fields, its signed identity cookie, GitHub storage, Turnstile, and rate limiting are included in the exact processing inventory
- release still requires counsel review of the documented legitimate-interest/ePrivacy assessments and verification of production vendor settings

## Testing
- `npm run lint`
- `npm test` — 288 tests
- `npm run build`
- `npm run check` in `landing-page/`
- `npm test` in `landing-page/` — 40 tests
- `npm run build` in `landing-page/`
- `npx wrangler deploy --dry-run --config dist/server/wrangler.json` in `landing-page/`
- generated-output assertions for pre-consent PostHog loading, public inventories, feedback processing, and pinned unpkg resource safeguards